### PR TITLE
refactor: codebase simplification (post-0.7.1 cleanup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ packages/
   obvious should be extremely brief or omitted. Prefer comments that explain "why" or complex logic.
 * Commits should be atomic and self-contained, with conventional commit messages. Commits should not
   be too large or too small. Use branches for larger features or refactors.
+* Work on feature branches, not directly on master. Merge when ready.
 * Always run pnpm commands from the repo root using root-level aliases (e.g. `pnpm test:unit`, not
   `pnpm --filter scoresheet test:unit`) — keeps commands predictable for auto-approval.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,8 @@ packages/
 * Column keys: `"1"`–`"15"`, `"16"`/`"16A"`/`"16B"` through `"20B"`, `"21"`+ for overtime.
 * Tests live in `__tests__/` subdirectories next to the code they test.
 * Slight preference for writing tests before features.
-* Redundant comments are not helpful. Only comment to explain "why" or complex logic.
+* Redundant comments are not helpful. Comments that simply say "what" is happening when the code is
+  obvious should be extremely brief or omitted. Prefer comments that explain "why" or complex logic.
 * Commits should be atomic and self-contained, with conventional commit messages. Commits should not
   be too large or too small. Use branches for larger features or refactors.
 * Always run pnpm commands from the repo root using root-level aliases (e.g. `pnpm test:unit`, not

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -675,30 +675,40 @@ function headerClass(colIdx: number): string {
   return classes.join(' ')
 }
 
-function colGroupClass(colIdx: number): string {
-  const col = columns.value[colIdx]
-  if (!col) return ''
-
-  const classes: string[] = []
+// Class string per column, called from 7 template sections per render.
+// Memoize once per column-list change instead of recomputing for each section.
+const colGroupClassMap = computed<Map<number, string>>(() => {
+  const map = new Map<number, string>()
   const dc = displayColumns.value
-  if (dc[dc.length - 1]?.idx === colIdx) classes.push('col--last')
-  if (!col.isOvertime && roundEndIndices.value.has(colIdx)) classes.push('col--reg-last')
-
-  if (col.isOvertime) {
-    if (col.type === QuestionType.Normal && (col.number - 21) % 3 === 0) {
-      classes.push(
-        col.number === 21 ? 'col--overtime col--ot-start' : 'col--overtime col--ot-round-start',
-      )
-    } else if (roundEndIndices.value.has(colIdx)) {
-      classes.push('col--overtime col--ot-round-end')
-    } else {
-      classes.push('col--overtime')
+  const cols = columns.value
+  const roundEnds = roundEndIndices.value
+  const lastIdx = dc[dc.length - 1]?.idx
+  for (const { idx } of dc) {
+    const col = cols[idx]
+    if (!col) continue
+    const classes: string[] = []
+    if (idx === lastIdx) classes.push('col--last')
+    if (!col.isOvertime && roundEnds.has(idx)) classes.push('col--reg-last')
+    if (col.isOvertime) {
+      if (col.type === QuestionType.Normal && (col.number - 21) % 3 === 0) {
+        classes.push(
+          col.number === 21 ? 'col--overtime col--ot-start' : 'col--overtime col--ot-round-start',
+        )
+      } else if (roundEnds.has(idx)) {
+        classes.push('col--overtime col--ot-round-end')
+      } else {
+        classes.push('col--overtime')
+      }
+    } else if (col.isAB && col.isErrorPoints) {
+      classes.push('col--ab')
     }
-  } else if (col.isAB && col.isErrorPoints) {
-    classes.push('col--ab')
+    map.set(idx, classes.join(' '))
   }
+  return map
+})
 
-  return classes.join(' ')
+function colGroupClass(colIdx: number): string {
+  return colGroupClassMap.value.get(colIdx) ?? ''
 }
 
 declare const __APP_VERSION__: string

--- a/apps/scoresheet/src/composables/useScoresheet.ts
+++ b/apps/scoresheet/src/composables/useScoresheet.ts
@@ -65,6 +65,28 @@ export function useScoresheet() {
   /** Timeouts per team — 0 to MAX_TIMEOUTS_PER_TEAM entries per team */
   const timeoutMap = ref(new Map<number, Timeout[]>())
 
+  /**
+   * Recover the OT-rounds count from a freshly loaded quiz: with regulation-only
+   * columns we ask the scorer how many OT rounds the saved answers actually need.
+   */
+  function computeInitialOtRounds(
+    overtime: boolean,
+    loadedTeams: { onTime: boolean }[],
+    loadedNoJumps: Map<string, boolean>,
+  ): number {
+    if (!overtime) return 1
+    const cols = buildColumns(20)
+    return Math.max(
+      1,
+      computeOvertimeRounds(
+        store.cellGrid(cols),
+        cols,
+        loadedTeams.map((t) => t.onTime),
+        cols.map((c) => loadedNoJumps.get(c.key) ?? false),
+      ),
+    )
+  }
+
   // --- Restore persisted state from localStorage ---
   const restored = loadFromStorage()
   if (restored) {
@@ -72,17 +94,11 @@ export function useScoresheet() {
     quiz.value = store.quiz
     noJumpMap.value = restored.noJumps
     timeoutMap.value = restored.timeouts
-    internalOtRounds.value = restored.quiz.overtime
-      ? Math.max(
-          1,
-          computeOvertimeRounds(
-            store.cellGrid(buildColumns(20)),
-            buildColumns(20),
-            restored.teams.map((t) => t.onTime),
-            buildColumns(20).map((c) => restored.noJumps.get(c.key) ?? false),
-          ),
-        )
-      : 1
+    internalOtRounds.value = computeInitialOtRounds(
+      restored.quiz.overtime,
+      restored.teams,
+      restored.noJumps,
+    )
     if (restored.answers.length > 0 || restored.quizzers.some((q) => q.name.trim())) {
       history.push({ undo: () => {}, redo: () => {} })
     }
@@ -661,17 +677,7 @@ export function useScoresheet() {
     quiz.value = store.quiz
     noJumpMap.value = data.noJumps
     timeoutMap.value = data.timeouts
-    internalOtRounds.value = data.quiz.overtime
-      ? Math.max(
-          1,
-          computeOvertimeRounds(
-            store.cellGrid(buildColumns(20)),
-            buildColumns(20),
-            data.teams.map((t) => t.onTime),
-            buildColumns(20).map((c) => data.noJumps.get(c.key) ?? false),
-          ),
-        )
-      : 1
+    internalOtRounds.value = computeInitialOtRounds(data.quiz.overtime, data.teams, data.noJumps)
     answerVersion.value++
     teamVersion.value++
     history.clear()

--- a/apps/scoresheet/src/composables/useScoresheet.ts
+++ b/apps/scoresheet/src/composables/useScoresheet.ts
@@ -431,7 +431,11 @@ export function useScoresheet() {
     )
   })
 
-  /** Grow internal allocation when more rounds are needed */
+  /**
+   * Grow-only: once we've allocated columns for round N we keep them. Shrinking
+   * would silently drop user-entered answers in later rounds when the visible
+   * window contracts (e.g. after deleting a tie-breaking answer).
+   */
   watch(visibleOtRounds, (needed) => {
     if (needed > internalOtRounds.value) {
       internalOtRounds.value = needed
@@ -524,7 +528,15 @@ export function useScoresheet() {
     teamVersion.value++
   }
 
-  /** Toggle no-jump for a column by key */
+  /**
+   * Toggle no-jump for a column by key.
+   *
+   * The `noJumpMap.value = new Map(noJumpMap.value)` reassignment after each
+   * `.set()` is intentional: Vue's `ref(Map)` only tracks ref reassignment, not
+   * in-place Map mutation, so consumers (`noJumps` computed → `otIneligibility`
+   * → `greyedOutResult`) won't recompute without it. Same pattern repeats in
+   * the timeout helpers below.
+   */
   function toggleNoJump(colIdx: ColIdx) {
     const key = columns.value[colIdx]?.key
     if (!key) return
@@ -636,7 +648,6 @@ export function useScoresheet() {
     const current = teamTimeouts(teamId)
     const existingIdx = current.findIndex((t) => t.afterColumnKey === columnKey)
     if (existingIdx >= 0) {
-      // Remove it
       const snapshot = snapshotTimeouts()
       const next = current.filter((_, i) => i !== existingIdx)
       timeoutMap.value.set(teamId, next)

--- a/apps/scoresheet/src/scoring/greyedOut.ts
+++ b/apps/scoresheet/src/scoring/greyedOut.ts
@@ -196,7 +196,10 @@ export function computeGreyedOut(
     }
   }
 
-  // Flatten tossedUp array into a single Set of "teamIdx:colIdx" for easy lookup
+  // Two views of the same data: the per-column `tossedUp` array drives the
+  // forward propagation above, while this flat Set lets downstream callers
+  // (validation, isBonusForTeam, the composable) check arbitrary (team, col)
+  // pairs in O(1) without needing the colIdx-indexed structure.
   const tossedUpSet = new Set<string>()
   for (let colIdx = 0; colIdx < cols.length; colIdx++) {
     for (const teamIdxStr of tossedUp[colIdx]!) {

--- a/apps/scoresheet/src/scoring/scoreTeam.ts
+++ b/apps/scoresheet/src/scoring/scoreTeam.ts
@@ -159,7 +159,6 @@ export function scoreTeam(
         if (col.isErrorPoints) {
           deduct = true
         } else if (qError[seatIdx]! >= 2) {
-          // 2nd+ individual error
           deduct = true
         } else if (teamErrors >= 3 && qError[seatIdx] === 1) {
           // 3rd+ team error, but this is the quizzer's 1st error

--- a/apps/scoresheet/src/types/scoresheet.ts
+++ b/apps/scoresheet/src/types/scoresheet.ts
@@ -1,25 +1,12 @@
-export enum CellValue {
-  Correct = 'c',
-  Error = 'e',
-  Foul = 'f',
-  Bonus = 'b',
-  MissedBonus = 'mb',
-  Empty = '',
-}
+import { BonusRule, CellValue, PlacementFormula, QuestionCategory } from '@qzr/shared'
 
+export { BonusRule, CellValue, PlacementFormula, QuestionCategory }
+
+/** Sub-column kind within a question (Normal / A / B). Distinct from `QuestionCategory`. */
 export enum QuestionType {
   Normal = '',
   A = 'A',
   B = 'B',
-}
-
-export enum QuestionCategory {
-  INT = 'INT',
-  FTV = 'FTV',
-  REF = 'REF',
-  MA = 'MA',
-  Q = 'Q',
-  SIT = 'SIT',
 }
 
 /**
@@ -28,18 +15,6 @@ export enum QuestionCategory {
  * 2 = solo 2nd, 2.2 = two-way tie for 2nd, 3 = solo 3rd.
  */
 export type PlaceKey = 1 | 1.2 | 1.3 | 2 | 2.2 | 3
-
-export enum PlacementFormula {
-  /** Official rulebook: 1st=score/10, 2nd=score/10−1, 3rd=score/10−2; friendly ties */
-  Rules = 'rules',
-  /** Pre-2023 spreadsheet formula: 1st=score/10+2, 2nd=score/10, 3rd=score/10−1 */
-  Legacy = 'legacy',
-}
-
-export enum BonusRule {
-  Team = 'team',
-  Seat = 'seat',
-}
 
 export interface Quiz {
   id: number

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
+    "@qzr/shared": "workspace:*",
     "better-auth": "^1.2.7",
     "vue": "^3.5.28",
     "vue-router": "^4.5.1"

--- a/apps/web/src/__tests__/meetAccess.spec.ts
+++ b/apps/web/src/__tests__/meetAccess.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { AccountRole, MeetRole } from '@qzr/shared'
 import type { MeetMembership } from '../api'
 import { coachChurchIds, isAdminOrSuperuser, canAccessChurchRoster } from '../meetAccess'
 
@@ -11,9 +12,9 @@ function m(
 describe('coachChurchIds', () => {
   it('returns church IDs where the user is head_coach for the meet', () => {
     const memberships: MeetMembership[] = [
-      m({ meetId: 1, role: 'head_coach', churchId: 10 }),
-      m({ meetId: 1, role: 'head_coach', churchId: 20 }),
-      m({ meetId: 2, role: 'head_coach', churchId: 30 }),
+      m({ meetId: 1, role: MeetRole.HeadCoach, churchId: 10 }),
+      m({ meetId: 1, role: MeetRole.HeadCoach, churchId: 20 }),
+      m({ meetId: 2, role: MeetRole.HeadCoach, churchId: 30 }),
     ]
     const ids = coachChurchIds(memberships, 1)
     expect(ids).toEqual(new Set([10, 20]))
@@ -21,43 +22,45 @@ describe('coachChurchIds', () => {
 
   it('ignores non-coach roles', () => {
     const memberships: MeetMembership[] = [
-      m({ meetId: 1, role: 'admin' }),
-      m({ meetId: 1, role: 'viewer' }),
-      m({ meetId: 1, role: 'official' }),
+      m({ meetId: 1, role: MeetRole.Admin }),
+      m({ meetId: 1, role: MeetRole.Viewer }),
+      m({ meetId: 1, role: MeetRole.Official }),
     ]
     expect(coachChurchIds(memberships, 1)).toEqual(new Set())
   })
 
   it('ignores coach memberships without a churchId', () => {
-    const memberships: MeetMembership[] = [m({ meetId: 1, role: 'head_coach' })]
+    const memberships: MeetMembership[] = [m({ meetId: 1, role: MeetRole.HeadCoach })]
     expect(coachChurchIds(memberships, 1)).toEqual(new Set())
   })
 
   it('returns empty set when no memberships match the meet', () => {
-    const memberships: MeetMembership[] = [m({ meetId: 99, role: 'head_coach', churchId: 10 })]
+    const memberships: MeetMembership[] = [
+      m({ meetId: 99, role: MeetRole.HeadCoach, churchId: 10 }),
+    ]
     expect(coachChurchIds(memberships, 1)).toEqual(new Set())
   })
 })
 
 describe('isAdminOrSuperuser', () => {
   it('returns true when accountRole is superuser regardless of memberships', () => {
-    expect(isAdminOrSuperuser([], 1, 'superuser')).toBe(true)
+    expect(isAdminOrSuperuser([], 1, AccountRole.Superuser)).toBe(true)
   })
 
   it('returns true when any membership for the meet has admin role', () => {
-    const memberships: MeetMembership[] = [m({ meetId: 1, role: 'admin' })]
+    const memberships: MeetMembership[] = [m({ meetId: 1, role: MeetRole.Admin })]
     expect(isAdminOrSuperuser(memberships, 1, undefined)).toBe(true)
   })
 
   it('returns false for admin membership on a different meet', () => {
-    const memberships: MeetMembership[] = [m({ meetId: 2, role: 'admin' })]
+    const memberships: MeetMembership[] = [m({ meetId: 2, role: MeetRole.Admin })]
     expect(isAdminOrSuperuser(memberships, 1, undefined)).toBe(false)
   })
 
   it('returns false for non-admin, non-superuser', () => {
     const memberships: MeetMembership[] = [
-      m({ meetId: 1, role: 'head_coach', churchId: 10 }),
-      m({ meetId: 1, role: 'viewer' }),
+      m({ meetId: 1, role: MeetRole.HeadCoach, churchId: 10 }),
+      m({ meetId: 1, role: MeetRole.Viewer }),
     ]
     expect(isAdminOrSuperuser(memberships, 1, undefined)).toBe(false)
   })
@@ -69,37 +72,37 @@ describe('isAdminOrSuperuser', () => {
 
 describe('canAccessChurchRoster', () => {
   it('admin can access any church roster', () => {
-    const memberships: MeetMembership[] = [m({ meetId: 1, role: 'admin' })]
+    const memberships: MeetMembership[] = [m({ meetId: 1, role: MeetRole.Admin })]
     expect(canAccessChurchRoster(memberships, 1, 10, undefined)).toBe(true)
     expect(canAccessChurchRoster(memberships, 1, 99, undefined)).toBe(true)
   })
 
   it('superuser can access any church roster', () => {
-    expect(canAccessChurchRoster([], 1, 10, 'superuser')).toBe(true)
+    expect(canAccessChurchRoster([], 1, 10, AccountRole.Superuser)).toBe(true)
   })
 
   it('coach can access their own church roster', () => {
-    const memberships: MeetMembership[] = [m({ meetId: 1, role: 'head_coach', churchId: 10 })]
+    const memberships: MeetMembership[] = [m({ meetId: 1, role: MeetRole.HeadCoach, churchId: 10 })]
     expect(canAccessChurchRoster(memberships, 1, 10, undefined)).toBe(true)
   })
 
   it('coach cannot access a different church roster', () => {
-    const memberships: MeetMembership[] = [m({ meetId: 1, role: 'head_coach', churchId: 10 })]
+    const memberships: MeetMembership[] = [m({ meetId: 1, role: MeetRole.HeadCoach, churchId: 10 })]
     expect(canAccessChurchRoster(memberships, 1, 20, undefined)).toBe(false)
   })
 
   it('viewer cannot access any church roster', () => {
-    const memberships: MeetMembership[] = [m({ meetId: 1, role: 'viewer' })]
+    const memberships: MeetMembership[] = [m({ meetId: 1, role: MeetRole.Viewer })]
     expect(canAccessChurchRoster(memberships, 1, 10, undefined)).toBe(false)
   })
 
   it('official cannot access any church roster', () => {
-    const memberships: MeetMembership[] = [m({ meetId: 1, role: 'official' })]
+    const memberships: MeetMembership[] = [m({ meetId: 1, role: MeetRole.Official })]
     expect(canAccessChurchRoster(memberships, 1, 10, undefined)).toBe(false)
   })
 
   it("coach on a different meet cannot access this meet's roster", () => {
-    const memberships: MeetMembership[] = [m({ meetId: 2, role: 'head_coach', churchId: 10 })]
+    const memberships: MeetMembership[] = [m({ meetId: 2, role: MeetRole.HeadCoach, churchId: 10 })]
     expect(canAccessChurchRoster(memberships, 1, 10, undefined)).toBe(false)
   })
 })

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,3 +1,5 @@
+import { MeetRole } from '@qzr/shared'
+
 declare const __API_URL__: string
 
 const baseUrl = __API_URL__ || ''
@@ -54,7 +56,7 @@ export interface MeetMembership {
   meetId: number
   meetName: string
   viewerCode: string
-  role: 'admin' | 'head_coach' | 'official' | 'viewer' | 'superuser'
+  role: MeetRole
   label?: string
   churchId?: number
 }
@@ -141,7 +143,7 @@ export function rotateOfficialCode(
 
 export function joinMeet(
   code: string,
-): Promise<{ meet: { id: number; name: string }; role: string; label?: string }> {
+): Promise<{ meet: { id: number; name: string }; role: MeetRole; label?: string }> {
   return request('/api/join', {
     method: 'POST',
     body: JSON.stringify({ code }),
@@ -150,7 +152,7 @@ export function joinMeet(
 
 export function joinMeetGuest(
   code: string,
-): Promise<{ token: string; meet: { id: number; name: string }; role: string; label?: string }> {
+): Promise<{ token: string; meet: { id: number; name: string }; role: MeetRole; label?: string }> {
   return request('/api/join/guest', {
     method: 'POST',
     body: JSON.stringify({ code }),
@@ -167,7 +169,7 @@ export interface MeetMember {
   userId: string
   name: string
   email: string
-  role: 'admin' | 'head_coach' | 'official' | 'viewer'
+  role: MeetRole
   churchId?: number
   officialCodeId?: number
 }
@@ -179,7 +181,7 @@ export function listMembers(meetId: number): Promise<{ members: MeetMember[] }> 
 export function revokeMember(
   meetId: number,
   userId: string,
-  scope: { role: string; churchId?: number; officialCodeId?: number },
+  scope: { role: MeetRole; churchId?: number; officialCodeId?: number },
 ): Promise<{ deleted: true }> {
   return request(`/api/meets/${meetId}/members/${userId}`, {
     method: 'DELETE',

--- a/apps/web/src/meetAccess.ts
+++ b/apps/web/src/meetAccess.ts
@@ -1,10 +1,11 @@
+import { AccountRole, MeetRole } from '@qzr/shared'
 import type { MeetMembership } from './api'
 
 /** Church IDs the current user coaches in a given meet. */
 export function coachChurchIds(memberships: MeetMembership[], meetId: number): Set<number> {
   return new Set(
     memberships
-      .filter((m) => m.meetId === meetId && m.role === 'head_coach' && m.churchId != null)
+      .filter((m) => m.meetId === meetId && m.role === MeetRole.HeadCoach && m.churchId != null)
       .map((m) => m.churchId!),
   )
 }
@@ -12,8 +13,8 @@ export function coachChurchIds(memberships: MeetMembership[], meetId: number): S
 /**
  * Whether the user has admin-level access for a meet.
  *
- * True when the account-level role is `'superuser'` OR any membership
- * for the meet has the `'admin'` role.
+ * True when the account-level role is superuser OR any membership
+ * for the meet has the admin role.
  */
 export function isAdminOrSuperuser(
   memberships: MeetMembership[],
@@ -21,8 +22,8 @@ export function isAdminOrSuperuser(
   accountRole: string | undefined,
 ): boolean {
   return (
-    accountRole === 'superuser' ||
-    memberships.some((m) => m.meetId === meetId && m.role === 'admin')
+    accountRole === AccountRole.Superuser ||
+    memberships.some((m) => m.meetId === meetId && m.role === MeetRole.Admin)
   )
 }
 

--- a/apps/web/src/views/HomeView.vue
+++ b/apps/web/src/views/HomeView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
+import { AccountRole } from '@qzr/shared'
 import { useAuth } from '../composables/useAuth'
 import { getMyMeets, joinMeet, joinMeetGuest, createMeet, type MeetMembership } from '../api'
 
@@ -17,7 +18,9 @@ const submitting = ref(false)
 const codeError = ref('')
 
 const isSuperuser = computed(
-  () => (session.value?.data?.user as Record<string, unknown> | undefined)?.role === 'superuser',
+  () =>
+    (session.value?.data?.user as Record<string, unknown> | undefined)?.role ===
+    AccountRole.Superuser,
 )
 
 const showCreateMeet = ref(false)

--- a/apps/web/src/views/QuizMeetView.vue
+++ b/apps/web/src/views/QuizMeetView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
+import { MeetRole } from '@qzr/shared'
 import {
   getMeet,
   getMyMeets,
@@ -38,8 +39,8 @@ const loading = ref(true)
 const error = ref('')
 
 const role = computed(() => membership.value?.role ?? null)
-const isSuperuser = computed(() => role.value === 'superuser')
-const isAdmin = computed(() => role.value === 'admin' || role.value === 'superuser')
+const isSuperuser = computed(() => role.value === MeetRole.Superuser)
+const isAdmin = computed(() => role.value === MeetRole.Admin || role.value === MeetRole.Superuser)
 
 const myCoachChurchIds = ref<Set<number>>(new Set())
 
@@ -293,9 +294,9 @@ async function loadDialogMembers() {
   const res = await listMembers(meetId.value!).catch(() => null)
   if (res) {
     d.members = res.members.filter((m) => {
-      if (d.kind === 'admin') return m.role === 'admin'
-      if (d.kind === 'church') return m.role === 'head_coach' && m.churchId === d.id
-      if (d.kind === 'official') return m.role === 'official' && m.officialCodeId === d.id
+      if (d.kind === 'admin') return m.role === MeetRole.Admin
+      if (d.kind === 'church') return m.role === MeetRole.HeadCoach && m.churchId === d.id
+      if (d.kind === 'official') return m.role === MeetRole.Official && m.officialCodeId === d.id
       return false
     })
   }

--- a/packages/api/src/routes/meets.ts
+++ b/packages/api/src/routes/meets.ts
@@ -6,7 +6,7 @@ import { requireAuth, requireSuperuser, getUser } from '../middleware/session'
 import { createDb, type Db } from '../lib/db'
 import { generateCode, hashCode } from '../lib/codes'
 import * as schema from '../db/schema'
-import { AccountRole } from '@qzr/shared'
+import { AccountRole, MeetRole } from '@qzr/shared'
 
 export interface MeetsVariables extends SessionVariables {
   db: Db
@@ -329,7 +329,7 @@ interface MeetMember {
   userId: string
   name: string
   email: string
-  role: 'admin' | 'head_coach' | 'official' | 'viewer'
+  role: MeetRole
   churchId?: number
   officialCodeId?: number
 }
@@ -357,7 +357,7 @@ meets.get('/:id/members', async (c) => {
     .where(eq(schema.adminMemberships.meetId, meetId))
 
   for (const r of admins) {
-    members.push({ ...r, role: 'admin' })
+    members.push({ ...r, role: MeetRole.Admin })
   }
 
   const coaches = await db
@@ -372,7 +372,7 @@ meets.get('/:id/members', async (c) => {
     .where(eq(schema.coachMemberships.meetId, meetId))
 
   for (const r of coaches) {
-    members.push({ ...r, role: 'head_coach' })
+    members.push({ ...r, role: MeetRole.HeadCoach })
   }
 
   const officials = await db
@@ -387,7 +387,7 @@ meets.get('/:id/members', async (c) => {
     .where(eq(schema.officialMemberships.meetId, meetId))
 
   for (const r of officials) {
-    members.push({ ...r, role: 'official' })
+    members.push({ ...r, role: MeetRole.Official })
   }
 
   const viewers = await db
@@ -401,7 +401,7 @@ meets.get('/:id/members', async (c) => {
     .where(eq(schema.viewerMemberships.meetId, meetId))
 
   for (const r of viewers) {
-    members.push({ ...r, role: 'viewer' })
+    members.push({ ...r, role: MeetRole.Viewer })
   }
 
   return c.json({ members })
@@ -419,14 +419,14 @@ meets.delete('/:id/members/:userId', async (c) => {
   }
 
   const body = await c.req.json<{
-    role: string
+    role: MeetRole
     churchId?: number
     officialCodeId?: number
   }>()
 
   let deleted = 0
 
-  if (body.role === 'admin') {
+  if (body.role === MeetRole.Admin) {
     if (user.role !== AccountRole.Superuser) {
       return c.json({ error: 'Only superusers can revoke admin memberships' }, 403)
     }
@@ -440,7 +440,7 @@ meets.delete('/:id/members/:userId', async (c) => {
       )
       .returning()
     deleted = rows.length
-  } else if (body.role === 'head_coach' && body.churchId) {
+  } else if (body.role === MeetRole.HeadCoach && body.churchId) {
     const rows = await db
       .delete(schema.coachMemberships)
       .where(
@@ -451,7 +451,7 @@ meets.delete('/:id/members/:userId', async (c) => {
       )
       .returning()
     deleted = rows.length
-  } else if (body.role === 'official' && body.officialCodeId) {
+  } else if (body.role === MeetRole.Official && body.officialCodeId) {
     const rows = await db
       .delete(schema.officialMemberships)
       .where(
@@ -463,7 +463,7 @@ meets.delete('/:id/members/:userId', async (c) => {
       )
       .returning()
     deleted = rows.length
-  } else if (body.role === 'viewer') {
+  } else if (body.role === MeetRole.Viewer) {
     const rows = await db
       .delete(schema.viewerMemberships)
       .where(

--- a/packages/api/src/routes/meets.ts
+++ b/packages/api/src/routes/meets.ts
@@ -344,65 +344,53 @@ meets.get('/:id/members', async (c) => {
     return c.json({ error: 'Admin or superuser access required' }, 403)
   }
 
-  const members: MeetMember[] = []
+  const [admins, coaches, officials, viewers] = await Promise.all([
+    db
+      .select({
+        userId: schema.adminMemberships.accountId,
+        name: schema.user.name,
+        email: schema.user.email,
+      })
+      .from(schema.adminMemberships)
+      .innerJoin(schema.user, eq(schema.adminMemberships.accountId, schema.user.id))
+      .where(eq(schema.adminMemberships.meetId, meetId)),
+    db
+      .select({
+        userId: schema.coachMemberships.accountId,
+        name: schema.user.name,
+        email: schema.user.email,
+        churchId: schema.coachMemberships.churchId,
+      })
+      .from(schema.coachMemberships)
+      .innerJoin(schema.user, eq(schema.coachMemberships.accountId, schema.user.id))
+      .where(eq(schema.coachMemberships.meetId, meetId)),
+    db
+      .select({
+        userId: schema.officialMemberships.accountId,
+        name: schema.user.name,
+        email: schema.user.email,
+        officialCodeId: schema.officialMemberships.officialCodeId,
+      })
+      .from(schema.officialMemberships)
+      .innerJoin(schema.user, eq(schema.officialMemberships.accountId, schema.user.id))
+      .where(eq(schema.officialMemberships.meetId, meetId)),
+    db
+      .select({
+        userId: schema.viewerMemberships.accountId,
+        name: schema.user.name,
+        email: schema.user.email,
+      })
+      .from(schema.viewerMemberships)
+      .innerJoin(schema.user, eq(schema.viewerMemberships.accountId, schema.user.id))
+      .where(eq(schema.viewerMemberships.meetId, meetId)),
+  ])
 
-  const admins = await db
-    .select({
-      userId: schema.adminMemberships.accountId,
-      name: schema.user.name,
-      email: schema.user.email,
-    })
-    .from(schema.adminMemberships)
-    .innerJoin(schema.user, eq(schema.adminMemberships.accountId, schema.user.id))
-    .where(eq(schema.adminMemberships.meetId, meetId))
-
-  for (const r of admins) {
-    members.push({ ...r, role: MeetRole.Admin })
-  }
-
-  const coaches = await db
-    .select({
-      userId: schema.coachMemberships.accountId,
-      name: schema.user.name,
-      email: schema.user.email,
-      churchId: schema.coachMemberships.churchId,
-    })
-    .from(schema.coachMemberships)
-    .innerJoin(schema.user, eq(schema.coachMemberships.accountId, schema.user.id))
-    .where(eq(schema.coachMemberships.meetId, meetId))
-
-  for (const r of coaches) {
-    members.push({ ...r, role: MeetRole.HeadCoach })
-  }
-
-  const officials = await db
-    .select({
-      userId: schema.officialMemberships.accountId,
-      name: schema.user.name,
-      email: schema.user.email,
-      officialCodeId: schema.officialMemberships.officialCodeId,
-    })
-    .from(schema.officialMemberships)
-    .innerJoin(schema.user, eq(schema.officialMemberships.accountId, schema.user.id))
-    .where(eq(schema.officialMemberships.meetId, meetId))
-
-  for (const r of officials) {
-    members.push({ ...r, role: MeetRole.Official })
-  }
-
-  const viewers = await db
-    .select({
-      userId: schema.viewerMemberships.accountId,
-      name: schema.user.name,
-      email: schema.user.email,
-    })
-    .from(schema.viewerMemberships)
-    .innerJoin(schema.user, eq(schema.viewerMemberships.accountId, schema.user.id))
-    .where(eq(schema.viewerMemberships.meetId, meetId))
-
-  for (const r of viewers) {
-    members.push({ ...r, role: MeetRole.Viewer })
-  }
+  const members: MeetMember[] = [
+    ...admins.map((r) => ({ ...r, role: MeetRole.Admin })),
+    ...coaches.map((r) => ({ ...r, role: MeetRole.HeadCoach })),
+    ...officials.map((r) => ({ ...r, role: MeetRole.Official })),
+    ...viewers.map((r) => ({ ...r, role: MeetRole.Viewer })),
+  ]
 
   return c.json({ members })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@qzr/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       better-auth:
         specifier: ^1.2.7
         version: 1.5.6(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(better-sqlite3@11.10.0)(kysely@0.28.15)(sql.js@1.14.1))(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.28(typescript@5.9.3))


### PR DESCRIPTION
## Summary

Eight atomic commits from a code-reuse / quality / efficiency audit of the codebase. No behavior changes; \`pnpm type-check && pnpm test:unit\` clean at every commit.

### Refactor / dedup

- **Re-export shared enums in scoresheet** (\`f01b52f\`) — \`CellValue\` / \`QuestionCategory\` / \`PlacementFormula\` / \`BonusRule\` were declared twice with identical members. Now re-export from \`@qzr/shared\` (-25 lines)
- **Use shared \`MeetRole\` / \`AccountRole\` enums in web + API** (\`eb55836\`) — replaces hand-typed string-literal unions and \`=== 'superuser'\` checks; web app gains \`@qzr/shared\` workspace dep
- **Extract \`computeInitialOtRounds\` helper** (\`46279dc\`) — kills a duplicate 11-line block (with \`buildColumns(20)\` called 3×) shared between localStorage restore and \`loadFile\`

### Performance

- **Parallelize 4 member queries** (\`ef1eddf\`) — \`GET /api/meets/:id/members\` ran 4 D1 queries serially with no data dependencies; now in \`Promise.all\` (~3-4× faster admin landing)
- **Memoize \`colGroupClass\` via computed Map** (\`40a92b2\`) — was called 7× per column per render; one Map per column-list change instead

### Docs

- **Tighten comments per CLAUDE.md** (\`356fed6\`) — strip 2 narrative \`// what\` comments, add WHY comments for the \`noJumpMap\` reactivity-reassignment pattern, the \`visibleOtRounds\` grow-only invariant, and the dual-view \`tossedUp\` data structure
- **Clarify CLAUDE.md comment guidance** (\`f8c859a\`) — distinguishes redundant "what" narration from useful "why" comments
- **Require feature branches** (\`6c23f6d\`) — adds the convention to CLAUDE.md

## Deferred work (filed as separate issues)

The audit also surfaced larger refactors that need their own focused PRs — filed as issues #20–#26 with \`claude-created\` and (in some cases) \`enhancement\`:

- #20 Replace version-ref reactivity bumps with native Vue store reactivity
- #21 Brand the \`tossedUp\` / \`disabled\` collection keys
- #22 Deduplicate \`SignInWidget\` and \`SignInMenu\`
- #23 Batch roster import/sync N+1 DB round-trips
- #24 Pre-group validation errors to avoid per-cell map iteration
- #25 Eliminate template-wrapper boilerplate around branded indices
- #26 Extract \`useAuth\` and \`request()\`/\`ApiError\` to \`@qzr/shared\`

## Test plan

- [x] \`pnpm type-check\` clean
- [x] \`pnpm test:unit\` — 168 passed
- [ ] Smoke-test scoresheet UI (open, enter cells, save, reload — confirm no visual regression)
- [ ] Smoke-test admin meet view (member listing should still work; load should be faster)

---
_Created by Claude Code_