### PR TITLE
ci: grant Claude review action the tools it needs to post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,6 +44,12 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # Tools the /code-review:code-review skill needs to inspect the PR + post results.
-          # Without this the SDK denied the gh calls and no review was posted.
-          claude_args: '--allowed-tools "Read,Grep,Glob,Bash(gh:*),Bash(git:*)"'
+          # Narrow allowlist: read-only gh subcommands + the comment/review POSTs we want,
+          # plus history-only git subcommands. Avoids granting blanket Bash(gh:*) / Bash(git:*).
+          claude_args: >-
+            --allowed-tools
+            "Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh
+            pr checks:*),Bash(gh api repos/*/pulls/*:*),Bash(gh api repos/*/issues/*:*),Bash(gh
+            issue view:*),Bash(gh issue list:*),Bash(gh label list:*),Bash(git log:*),Bash(git
+            blame:*),Bash(git diff:*),Bash(git show:*)"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,15 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # write so the action can post review comments + check runs
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0 # need full history for git blame / log lookups during review
 
       - name: Run Claude Code Review
         id: claude-review
@@ -42,6 +43,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          # Tools the /code-review:code-review skill needs to inspect the PR + post results.
+          # Without this the SDK denied the gh calls and no review was posted.
+          claude_args: '--allowed-tools "Read,Grep,Glob,Bash(gh:*),Bash(git:*)"'
 


### PR DESCRIPTION
## Summary

The auto-review action ran on PRs #27 and #28 but posted zero comments. Workflow log showed \`permission_denials_count: 9\` and "No buffered inline comments" — the SDK denied the gh/git calls the \`/code-review:code-review\` skill makes, so it had nothing to post.

Three fixes to \`.github/workflows/claude-code-review.yml\`:

1. **\`pull-requests: write\` + \`issues: write\`** (was \`read\`) — without this the action can't post review comments or check runs even if the SDK lets it
2. **\`fetch-depth: 0\`** (was \`1\`) — the skill's "git blame / history" check needs full history; depth-1 only has the latest commit
3. **\`claude_args: '--allowed-tools "Read,Grep,Glob,Bash(gh:*),Bash(git:*)"'\`** — explicit allowlist for the tools the skill actually uses

This PR is itself a self-test: when CI runs on this branch, it'll use the **new** workflow file (since \`pull_request\` events read the workflow from the PR's HEAD), so a successful review post here proves the fix.

## Test plan

- [ ] CI run on this PR posts a real \`### Code review\` comment (success path)
- [ ] If it still fails, log will show whether the remaining issue is permissions or auth

---
_Created by Claude Code_