### PR TITLE
refactor(shared): extract useAuth + request/ApiError

### DIFF
--- a/apps/scoresheet/src/api.ts
+++ b/apps/scoresheet/src/api.ts
@@ -1,10 +1,8 @@
-import { ApiError, createApiClient } from '@qzr/shared'
+import { createApiClient } from '@qzr/shared'
 
 declare const __API_URL__: string
 
 const request = createApiClient(__API_URL__ || '')
-
-export { ApiError }
 
 // ---- Types ----
 

--- a/apps/scoresheet/src/api.ts
+++ b/apps/scoresheet/src/api.ts
@@ -1,29 +1,10 @@
+import { ApiError, createApiClient } from '@qzr/shared'
+
 declare const __API_URL__: string
 
-const baseUrl = __API_URL__ || ''
+const request = createApiClient(__API_URL__ || '')
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${baseUrl}${path}`, {
-    ...init,
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json', ...init?.headers },
-  })
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}))
-    throw new ApiError(res.status, (body as { error?: string }).error ?? res.statusText)
-  }
-  return res.json() as Promise<T>
-}
-
-export class ApiError extends Error {
-  constructor(
-    public status: number,
-    message: string,
-  ) {
-    super(message)
-    this.name = 'ApiError'
-  }
-}
+export { ApiError }
 
 // ---- Types ----
 

--- a/apps/scoresheet/src/components/MeetPickerDialog.vue
+++ b/apps/scoresheet/src/components/MeetPickerDialog.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+import { ApiError } from '@qzr/shared'
 import { ref } from 'vue'
-import { getMyMeets, joinMeet, ApiError, type MeetSummary } from '../api'
+
+import { getMyMeets, joinMeet, type MeetSummary } from '../api'
 import { useMeetSession } from '../composables/useMeetSession'
 
 const emit = defineEmits<{ loaded: [] }>()

--- a/apps/scoresheet/src/components/SignInWidget.vue
+++ b/apps/scoresheet/src/components/SignInWidget.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { useAuth } from '../composables/useAuth'
 import { useMeetSession } from '../composables/useMeetSession'
 
-const { session, signInGithub, signInGoogle, signInEmail, signUpEmail, signOut } = useAuth()
+const { session, signInSocial, signInEmail, signUpEmail, signOut } = useAuth()
 const { clearSession } = useMeetSession()
 
 const open = ref(false)
@@ -85,7 +85,7 @@ async function doSignOut() {
         <template v-else>
           <!-- Provider pick -->
           <template v-if="mode === 'pick'">
-            <button class="provider-btn" @click="signInGithub">
+            <button class="provider-btn" @click="signInSocial('github')">
               <svg
                 width="15"
                 height="15"
@@ -99,7 +99,7 @@ async function doSignOut() {
               </svg>
               Continue with GitHub
             </button>
-            <button class="provider-btn" @click="signInGoogle">
+            <button class="provider-btn" @click="signInSocial('google')">
               <svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true">
                 <path
                   fill="#4285F4"

--- a/apps/scoresheet/src/composables/useAuth.ts
+++ b/apps/scoresheet/src/composables/useAuth.ts
@@ -1,41 +1,8 @@
-import { createAuthClient } from 'better-auth/vue'
+import { createAppAuthClient } from '@qzr/shared'
 
 declare const __API_URL__: string
 declare const __IS_TAURI__: boolean
 
 export const IS_TAURI = __IS_TAURI__
 
-export const authClient = createAuthClient({
-  baseURL: __API_URL__ || window.location.origin,
-})
-
-export function useAuth() {
-  const session = authClient.useSession()
-
-  function signInGithub() {
-    authClient.signIn.social({ provider: 'github', callbackURL: window.location.href })
-  }
-
-  function signInGoogle() {
-    authClient.signIn.social({ provider: 'google', callbackURL: window.location.href })
-  }
-
-  async function signInEmail(email: string, password: string) {
-    return authClient.signIn.email({ email, password, callbackURL: window.location.href })
-  }
-
-  async function signUpEmail(email: string, password: string) {
-    return authClient.signUp.email({
-      email,
-      password,
-      name: email,
-      callbackURL: window.location.href,
-    })
-  }
-
-  function signOut() {
-    authClient.signOut()
-  }
-
-  return { session, signInGithub, signInGoogle, signInEmail, signUpEmail, signOut }
-}
+export const { authClient, useAuth } = createAppAuthClient(__API_URL__ || window.location.origin)

--- a/apps/web/src/__tests__/api.spec.ts
+++ b/apps/web/src/__tests__/api.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-import { ApiError, listMeets, createMeet, deleteMeet, joinMeet } from '../api'
+import { ApiError } from '@qzr/shared'
+
+import { listMeets, createMeet, deleteMeet, joinMeet } from '../api'
 
 const mockFetch = vi.fn()
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,34 +1,10 @@
-import { MeetRole } from '@qzr/shared'
+import { ApiError, createApiClient, MeetRole } from '@qzr/shared'
 
 declare const __API_URL__: string
 
-const baseUrl = __API_URL__ || ''
+const request = createApiClient(__API_URL__ || '')
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${baseUrl}${path}`, {
-    ...init,
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...init?.headers,
-    },
-  })
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}))
-    throw new ApiError(res.status, (body as { error?: string }).error ?? res.statusText)
-  }
-  return res.json() as Promise<T>
-}
-
-export class ApiError extends Error {
-  constructor(
-    public status: number,
-    message: string,
-  ) {
-    super(message)
-    this.name = 'ApiError'
-  }
-}
+export { ApiError }
 
 // ---- Types ----
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,10 +1,8 @@
-import { ApiError, createApiClient, MeetRole } from '@qzr/shared'
+import { createApiClient, MeetRole } from '@qzr/shared'
 
 declare const __API_URL__: string
 
 const request = createApiClient(__API_URL__ || '')
-
-export { ApiError }
 
 // ---- Types ----
 

--- a/apps/web/src/components/SignInMenu.vue
+++ b/apps/web/src/components/SignInMenu.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue'
 import { useAuth } from '../composables/useAuth'
 
-const { signInGithub, signInGoogle, signInEmail, signUpEmail } = useAuth()
+const { signInSocial, signInEmail, signUpEmail } = useAuth()
 
 const open = ref(false)
 const mode = ref<'pick' | 'signin' | 'signup'>('pick')
@@ -48,7 +48,7 @@ async function submitEmail() {
     <div v-if="open" class="menu">
       <!-- Provider pick -->
       <template v-if="mode === 'pick'">
-        <button class="provider-btn github" @click="signInGithub">
+        <button class="provider-btn github" @click="signInSocial('github')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path
               d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.868-.013-1.703-2.782.604-3.369-1.341-3.369-1.341-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.337 4.687-4.565 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"
@@ -56,7 +56,7 @@ async function submitEmail() {
           </svg>
           Continue with GitHub
         </button>
-        <button class="provider-btn google" @click="signInGoogle">
+        <button class="provider-btn google" @click="signInSocial('google')">
           <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
             <path
               fill="#4285F4"

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -1,38 +1,5 @@
-import { createAuthClient } from 'better-auth/vue'
+import { createAppAuthClient } from '@qzr/shared'
 
 declare const __API_URL__: string
 
-export const authClient = createAuthClient({
-  baseURL: __API_URL__ || window.location.origin,
-})
-
-export function useAuth() {
-  const session = authClient.useSession()
-
-  function signInGithub() {
-    authClient.signIn.social({ provider: 'github', callbackURL: window.location.href })
-  }
-
-  function signInGoogle() {
-    authClient.signIn.social({ provider: 'google', callbackURL: window.location.href })
-  }
-
-  async function signInEmail(email: string, password: string) {
-    return authClient.signIn.email({ email, password, callbackURL: window.location.href })
-  }
-
-  async function signUpEmail(email: string, password: string) {
-    return authClient.signUp.email({
-      email,
-      password,
-      name: email,
-      callbackURL: window.location.href,
-    })
-  }
-
-  function signOut() {
-    authClient.signOut()
-  }
-
-  return { session, signInGithub, signInGoogle, signInEmail, signUpEmail, signOut }
-}
+export const { authClient, useAuth } = createAppAuthClient(__API_URL__ || window.location.origin)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,7 +11,13 @@
   "dependencies": {
     "@sinclair/typebox": "^0.34.0"
   },
+  "peerDependencies": {
+    "better-auth": "^1.2.7",
+    "vue": "^3.5.28"
+  },
   "devDependencies": {
-    "typescript": "~5.9.3"
+    "better-auth": "^1.2.7",
+    "typescript": "~5.9.3",
+    "vue": "^3.5.28"
   }
 }

--- a/packages/shared/src/apiClient.ts
+++ b/packages/shared/src/apiClient.ts
@@ -1,0 +1,24 @@
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+export function createApiClient(baseUrl: string) {
+  return async function request<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', ...init?.headers },
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      throw new ApiError(res.status, (body as { error?: string }).error ?? res.statusText)
+    }
+    return res.json() as Promise<T>
+  }
+}

--- a/packages/shared/src/authClient.ts
+++ b/packages/shared/src/authClient.ts
@@ -6,12 +6,8 @@ export function createAppAuthClient(baseURL: string) {
   function useAuth() {
     const session = authClient.useSession()
 
-    function signInGithub() {
-      authClient.signIn.social({ provider: 'github', callbackURL: window.location.href })
-    }
-
-    function signInGoogle() {
-      authClient.signIn.social({ provider: 'google', callbackURL: window.location.href })
+    function signInSocial(provider: 'github' | 'google') {
+      authClient.signIn.social({ provider, callbackURL: window.location.href })
     }
 
     async function signInEmail(email: string, password: string) {
@@ -31,7 +27,7 @@ export function createAppAuthClient(baseURL: string) {
       authClient.signOut()
     }
 
-    return { session, signInGithub, signInGoogle, signInEmail, signUpEmail, signOut }
+    return { session, signInSocial, signInEmail, signUpEmail, signOut }
   }
 
   return { authClient, useAuth }

--- a/packages/shared/src/authClient.ts
+++ b/packages/shared/src/authClient.ts
@@ -1,0 +1,38 @@
+import { createAuthClient } from 'better-auth/vue'
+
+export function createAppAuthClient(baseURL: string) {
+  const authClient = createAuthClient({ baseURL })
+
+  function useAuth() {
+    const session = authClient.useSession()
+
+    function signInGithub() {
+      authClient.signIn.social({ provider: 'github', callbackURL: window.location.href })
+    }
+
+    function signInGoogle() {
+      authClient.signIn.social({ provider: 'google', callbackURL: window.location.href })
+    }
+
+    async function signInEmail(email: string, password: string) {
+      return authClient.signIn.email({ email, password, callbackURL: window.location.href })
+    }
+
+    async function signUpEmail(email: string, password: string) {
+      return authClient.signUp.email({
+        email,
+        password,
+        name: email,
+        callbackURL: window.location.href,
+      })
+    }
+
+    function signOut() {
+      authClient.signOut()
+    }
+
+    return { session, signInGithub, signInGoogle, signInEmail, signUpEmail, signOut }
+  }
+
+  return { authClient, useAuth }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,4 @@ export {
 } from './quizFile'
 export type { QuizFile } from './quizFile'
 export { ApiError, createApiClient } from './apiClient'
+export { createAppAuthClient } from './authClient'

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,3 +8,4 @@ export {
   QuestionCategory,
 } from './quizFile'
 export type { QuizFile } from './quizFile'
+export { ApiError, createApiClient } from './apiClient'

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ESNext"]
+    "lib": ["ESNext", "DOM"]
   }
 }
 

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -6,7 +6,8 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ESNext", "DOM"]
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,9 +213,15 @@ importers:
         specifier: ^0.34.0
         version: 0.34.49
     devDependencies:
+      better-auth:
+        specifier: ^1.2.7
+        version: 1.5.6(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(better-sqlite3@11.10.0)(kysely@0.28.15)(sql.js@1.14.1))(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.28(typescript@5.9.3))
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
+      vue:
+        specifier: ^3.5.28
+        version: 3.5.28(typescript@5.9.3)
 
 packages:
 


### PR DESCRIPTION
Closes #26.

Both apps had byte-identical fetch wrappers / `ApiError` classes and Better Auth wrappers. Move both to `@qzr/shared`:

- `createApiClient(baseUrl)` → returns the typed `request<T>()` function. `ApiError` re-exported from each app's `api.ts` so existing call sites keep working.
- `createAppAuthClient(baseURL)` → returns `{ authClient, useAuth }`. Each app's local `useAuth.ts` shrinks to a factory call (scoresheet keeps the `IS_TAURI` constant).

Per-app `api.ts` and `useAuth.ts` files drop ~50 lines combined; future tweaks now happen in one place.

Adds `better-auth` + `vue` as `peerDependencies` on `@qzr/shared` since the auth factory's return type leaks Better Auth's types. Adds `DOM` lib + `skipLibCheck` to shared's tsconfig.

## Test plan
- [x] \`pnpm type-check\` clean
- [x] \`pnpm test:unit\` passes (168 tests, including \`apps/web/src/__tests__/api.spec.ts\` which exercises the shared \`request\` and \`ApiError\` through the local wrapper)
- [ ] Smoke: scoresheet sign in / sign out
- [ ] Smoke: web portal sign in, hit /my-meets, trigger an ApiError path