### PR TITLE
refactor(ui): extract SignInForm to @qzr/ui

### DIFF
--- a/apps/scoresheet/package.json
+++ b/apps/scoresheet/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@sinclair/typebox": "^0.34.0",
     "@qzr/shared": "workspace:*",
+    "@qzr/ui": "workspace:*",
     "better-auth": "^1.2.7",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-fs": "^2",

--- a/apps/scoresheet/src/components/SignInWidget.vue
+++ b/apps/scoresheet/src/components/SignInWidget.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
+import { SignInForm } from '@qzr/ui'
 import { useAuth } from '../composables/useAuth'
 import { useMeetSession } from '../composables/useMeetSession'
 
@@ -8,11 +9,7 @@ const { clearSession } = useMeetSession()
 
 const open = ref(false)
 const menuPos = ref({ top: 0, right: 0 })
-const mode = ref<'pick' | 'signin' | 'signup'>('pick')
-const email = ref('')
-const password = ref('')
-const error = ref('')
-const pending = ref(false)
+const form = useTemplateRef<{ reset: () => void }>('form')
 
 function toggle(event: MouseEvent) {
   if (open.value) {
@@ -27,28 +24,7 @@ function toggle(event: MouseEvent) {
 
 function close() {
   open.value = false
-  reset()
-}
-
-function reset() {
-  mode.value = 'pick'
-  email.value = ''
-  password.value = ''
-  error.value = ''
-  pending.value = false
-}
-
-async function submitEmail() {
-  error.value = ''
-  pending.value = true
-  const fn = mode.value === 'signup' ? signUpEmail : signInEmail
-  const result = await fn(email.value, password.value)
-  pending.value = false
-  if (result?.error) {
-    error.value = result.error.message ?? 'Something went wrong'
-  } else {
-    close()
-  }
+  form.value?.reset()
 }
 
 async function doSignOut() {
@@ -82,77 +58,14 @@ async function doSignOut() {
         </template>
 
         <!-- Signed out -->
-        <template v-else>
-          <!-- Provider pick -->
-          <template v-if="mode === 'pick'">
-            <button class="provider-btn" @click="signInSocial('github')">
-              <svg
-                width="15"
-                height="15"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.868-.013-1.703-2.782.604-3.369-1.341-3.369-1.341-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.337 4.687-4.565 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"
-                />
-              </svg>
-              Continue with GitHub
-            </button>
-            <button class="provider-btn" @click="signInSocial('google')">
-              <svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  fill="#4285F4"
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                />
-                <path
-                  fill="#34A853"
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                />
-                <path
-                  fill="#FBBC05"
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
-                />
-                <path
-                  fill="#EA4335"
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                />
-              </svg>
-              Continue with Google
-            </button>
-            <div class="divider"><span>or</span></div>
-            <button class="email-toggle" @click="mode = 'signin'">Sign in with email</button>
-            <button class="email-toggle" @click="mode = 'signup'">Create account</button>
-          </template>
-
-          <!-- Email form -->
-          <template v-else>
-            <button class="back-btn" @click="mode = 'pick'">← Back</button>
-            <p class="form-title">{{ mode === 'signup' ? 'Create account' : 'Sign in' }}</p>
-            <form @submit.prevent="submitEmail">
-              <input
-                v-model="email"
-                type="email"
-                placeholder="Email"
-                autocomplete="email"
-                required
-                class="field"
-              />
-              <input
-                v-model="password"
-                type="password"
-                placeholder="Password"
-                autocomplete="current-password"
-                required
-                class="field"
-              />
-              <p v-if="error" class="error-msg">{{ error }}</p>
-              <button type="submit" class="submit-btn" :disabled="pending">
-                {{ pending ? 'Please wait…' : mode === 'signup' ? 'Create account' : 'Sign in' }}
-              </button>
-            </form>
-          </template>
-        </template>
+        <SignInForm
+          v-else
+          ref="form"
+          :sign-in-social="signInSocial"
+          :sign-in-email="signInEmail"
+          :sign-up-email="signUpEmail"
+          @success="close"
+        />
       </div>
     </Teleport>
   </div>
@@ -238,121 +151,5 @@ async function doSignOut() {
 
 .sign-out-btn:hover {
   color: var(--color-text-muted);
-}
-
-.provider-btn {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  width: 100%;
-  padding: 0.45rem 0.75rem;
-  border-radius: 0.375rem;
-  border: 1px solid var(--color-border-alt);
-  background: var(--color-bg);
-  color: var(--color-text-muted);
-  font-size: 0.8rem;
-  font-family: inherit;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.provider-btn:hover {
-  background: var(--color-bg-alt);
-}
-
-.divider {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--color-text-faint);
-  font-size: 0.75rem;
-}
-
-.divider::before,
-.divider::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  background: var(--color-border-alt);
-}
-
-.email-toggle {
-  width: 100%;
-  padding: 0.4rem 0.75rem;
-  background: none;
-  border: 1px solid var(--color-border-alt);
-  border-radius: 0.375rem;
-  color: var(--color-text-faint);
-  font-size: 0.8rem;
-  font-family: inherit;
-  cursor: pointer;
-  transition: color 0.15s;
-}
-
-.email-toggle:hover {
-  color: var(--color-text-muted);
-}
-
-.back-btn {
-  background: none;
-  border: none;
-  padding: 0;
-  color: var(--color-text-faint);
-  font-size: 0.75rem;
-  font-family: inherit;
-  cursor: pointer;
-  text-align: left;
-}
-
-.back-btn:hover {
-  color: var(--color-text-muted);
-}
-
-.form-title {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  margin: 0;
-}
-
-.field {
-  width: 100%;
-  padding: 0.4rem 0.6rem;
-  background: var(--color-bg);
-  border: 1px solid var(--color-border-alt);
-  border-radius: 0.375rem;
-  color: var(--color-text);
-  font-size: 0.8rem;
-  font-family: inherit;
-  box-sizing: border-box;
-}
-
-.field:focus {
-  outline: none;
-  border-color: var(--color-accent);
-}
-
-.error-msg {
-  font-size: 0.75rem;
-  color: var(--color-error, #f87171);
-  margin: 0;
-}
-
-.submit-btn {
-  width: 100%;
-  padding: 0.45rem 0.75rem;
-  background: var(--color-accent);
-  border: none;
-  border-radius: 0.375rem;
-  color: #fff;
-  font-size: 0.8rem;
-  font-family: inherit;
-  cursor: pointer;
-  transition: opacity 0.15s;
-}
-
-.submit-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 </style>

--- a/apps/scoresheet/src/components/SignInWidget.vue
+++ b/apps/scoresheet/src/components/SignInWidget.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, useTemplateRef } from 'vue'
+import { ref } from 'vue'
 import { SignInForm } from '@qzr/ui'
 import { useAuth } from '../composables/useAuth'
 import { useMeetSession } from '../composables/useMeetSession'
@@ -9,11 +9,10 @@ const { clearSession } = useMeetSession()
 
 const open = ref(false)
 const menuPos = ref({ top: 0, right: 0 })
-const form = useTemplateRef<{ reset: () => void }>('form')
 
 function toggle(event: MouseEvent) {
   if (open.value) {
-    close()
+    open.value = false
     return
   }
   const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
@@ -22,49 +21,39 @@ function toggle(event: MouseEvent) {
   open.value = true
 }
 
-function close() {
-  open.value = false
-  form.value?.reset()
-}
-
 async function doSignOut() {
   clearSession()
   await signOut()
-  close()
+  open.value = false
 }
 </script>
 
 <template>
   <div class="widget-wrap">
-    <!-- Signed in: show email truncated -->
     <button v-if="session.data" class="meta-btn" @click="toggle">
       {{ session.data.user.email }}
     </button>
-    <!-- Signed out -->
     <button v-else class="meta-btn" @click="toggle">Sign in</button>
 
     <Teleport to="body">
-      <div v-if="open" class="sign-in-backdrop" @click="close" />
+      <div v-if="open" class="sign-in-backdrop" @click="open = false" />
 
       <div
         v-if="open"
         class="sign-in-menu"
         :style="{ top: menuPos.top + 'px', right: menuPos.right + 'px' }"
       >
-        <!-- Signed in: sign out -->
         <template v-if="session.data">
           <p class="menu-email">{{ session.data.user.email }}</p>
           <button class="sign-out-btn" @click="doSignOut">Sign out</button>
         </template>
 
-        <!-- Signed out -->
         <SignInForm
           v-else
-          ref="form"
           :sign-in-social="signInSocial"
           :sign-in-email="signInEmail"
           :sign-up-email="signUpEmail"
-          @success="close"
+          @success="open = false"
         />
       </div>
     </Teleport>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@qzr/shared": "workspace:*",
+    "@qzr/ui": "workspace:*",
     "better-auth": "^1.2.7",
     "vue": "^3.5.28",
     "vue-router": "^4.5.1"

--- a/apps/web/src/components/SignInMenu.vue
+++ b/apps/web/src/components/SignInMenu.vue
@@ -1,41 +1,21 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, useTemplateRef } from 'vue'
+import { SignInForm } from '@qzr/ui'
 import { useAuth } from '../composables/useAuth'
 
 const { signInSocial, signInEmail, signUpEmail } = useAuth()
 
 const open = ref(false)
-const mode = ref<'pick' | 'signin' | 'signup'>('pick')
-const email = ref('')
-const password = ref('')
-const error = ref('')
-const pending = ref(false)
+const form = useTemplateRef<{ reset: () => void }>('form')
 
 function toggle() {
   open.value = !open.value
-  if (!open.value) reset()
+  if (!open.value) form.value?.reset()
 }
 
-function reset() {
-  mode.value = 'pick'
-  email.value = ''
-  password.value = ''
-  error.value = ''
-  pending.value = false
-}
-
-async function submitEmail() {
-  error.value = ''
-  pending.value = true
-  const fn = mode.value === 'signup' ? signUpEmail : signInEmail
-  const result = await fn(email.value, password.value)
-  pending.value = false
-  if (result?.error) {
-    error.value = result.error.message ?? 'Something went wrong'
-  } else {
-    open.value = false
-    reset()
-  }
+function close() {
+  open.value = false
+  form.value?.reset()
 }
 </script>
 
@@ -46,69 +26,13 @@ async function submitEmail() {
     <div v-if="open" class="backdrop" @click="toggle" />
 
     <div v-if="open" class="menu">
-      <!-- Provider pick -->
-      <template v-if="mode === 'pick'">
-        <button class="provider-btn github" @click="signInSocial('github')">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path
-              d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.868-.013-1.703-2.782.604-3.369-1.341-3.369-1.341-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.337 4.687-4.565 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"
-            />
-          </svg>
-          Continue with GitHub
-        </button>
-        <button class="provider-btn google" @click="signInSocial('google')">
-          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
-            <path
-              fill="#4285F4"
-              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-            />
-            <path
-              fill="#34A853"
-              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-            />
-            <path
-              fill="#FBBC05"
-              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
-            />
-            <path
-              fill="#EA4335"
-              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-            />
-          </svg>
-          Continue with Google
-        </button>
-        <div class="divider"><span>or</span></div>
-        <button class="email-toggle" @click="mode = 'signin'">Sign in with email</button>
-        <button class="email-toggle signup" @click="mode = 'signup'">Create account</button>
-      </template>
-
-      <!-- Email form -->
-      <template v-else>
-        <button class="back-btn" @click="mode = 'pick'">← Back</button>
-        <p class="form-title">{{ mode === 'signup' ? 'Create account' : 'Sign in' }}</p>
-        <form @submit.prevent="submitEmail">
-          <input
-            v-model="email"
-            type="email"
-            placeholder="Email"
-            autocomplete="email"
-            required
-            class="field"
-          />
-          <input
-            v-model="password"
-            type="password"
-            placeholder="Password"
-            autocomplete="current-password"
-            required
-            class="field"
-          />
-          <p v-if="error" class="error-msg">{{ error }}</p>
-          <button type="submit" class="submit-btn" :disabled="pending">
-            {{ pending ? 'Please wait…' : mode === 'signup' ? 'Create account' : 'Sign in' }}
-          </button>
-        </form>
-      </template>
+      <SignInForm
+        ref="form"
+        :sign-in-social="signInSocial"
+        :sign-in-email="signInEmail"
+        :sign-up-email="signUpEmail"
+        @success="close"
+      />
     </div>
   </div>
 </template>
@@ -138,123 +62,6 @@ async function submitEmail() {
   gap: 0.5rem;
   min-width: 220px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
-}
-
-.provider-btn {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  width: 100%;
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.375rem;
-  border: 1px solid var(--color-border-alt);
-  background: var(--color-bg);
-  color: var(--color-text-muted);
-  font-size: 0.8rem;
-  font-family: inherit;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.provider-btn:hover {
-  background: var(--color-bg-hover, #222);
-}
-
-.divider {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--color-text-faint);
-  font-size: 0.75rem;
-}
-
-.divider::before,
-.divider::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  background: var(--color-border-alt);
-}
-
-.email-toggle {
-  width: 100%;
-  padding: 0.4rem 0.75rem;
-  background: none;
-  border: 1px solid var(--color-border-alt);
-  border-radius: 0.375rem;
-  color: var(--color-text-faint);
-  font-size: 0.8rem;
-  font-family: inherit;
-  cursor: pointer;
-  transition: color 0.15s;
-}
-
-.email-toggle:hover,
-.email-toggle.signup:hover {
-  color: var(--color-text-muted);
-}
-
-.back-btn {
-  background: none;
-  border: none;
-  padding: 0;
-  color: var(--color-text-faint);
-  font-size: 0.75rem;
-  font-family: inherit;
-  cursor: pointer;
-  text-align: left;
-}
-
-.back-btn:hover {
-  color: var(--color-text-muted);
-}
-
-.form-title {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  margin: 0;
-}
-
-.field {
-  width: 100%;
-  padding: 0.4rem 0.6rem;
-  background: var(--color-bg);
-  border: 1px solid var(--color-border-alt);
-  border-radius: 0.375rem;
-  color: var(--color-text);
-  font-size: 0.8rem;
-  font-family: inherit;
-  box-sizing: border-box;
-}
-
-.field:focus {
-  outline: none;
-  border-color: var(--color-accent);
-}
-
-.error-msg {
-  font-size: 0.75rem;
-  color: var(--color-error, #f87171);
-  margin: 0;
-}
-
-.submit-btn {
-  width: 100%;
-  padding: 0.45rem 0.75rem;
-  background: var(--color-accent);
-  border: none;
-  border-radius: 0.375rem;
-  color: #fff;
-  font-size: 0.8rem;
-  font-family: inherit;
-  cursor: pointer;
-  transition: opacity 0.15s;
-}
-
-.submit-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 .nav-link {

--- a/apps/web/src/components/SignInMenu.vue
+++ b/apps/web/src/components/SignInMenu.vue
@@ -1,37 +1,25 @@
 <script setup lang="ts">
-import { ref, useTemplateRef } from 'vue'
+import { ref } from 'vue'
 import { SignInForm } from '@qzr/ui'
 import { useAuth } from '../composables/useAuth'
 
 const { signInSocial, signInEmail, signUpEmail } = useAuth()
 
 const open = ref(false)
-const form = useTemplateRef<{ reset: () => void }>('form')
-
-function toggle() {
-  open.value = !open.value
-  if (!open.value) form.value?.reset()
-}
-
-function close() {
-  open.value = false
-  form.value?.reset()
-}
 </script>
 
 <template>
   <div class="menu-wrap">
-    <button class="nav-link nav-btn" @click="toggle">Sign in</button>
+    <button class="nav-link nav-btn" @click="open = !open">Sign in</button>
 
-    <div v-if="open" class="backdrop" @click="toggle" />
+    <div v-if="open" class="backdrop" @click="open = false" />
 
     <div v-if="open" class="menu">
       <SignInForm
-        ref="form"
         :sign-in-social="signInSocial"
         :sign-in-email="signInEmail"
         :sign-up-email="signUpEmail"
-        @success="close"
+        @success="open = false"
       />
     </div>
   </div>

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,7 +16,7 @@ export default {
     'scope-enum': [
       1,
       'always',
-      ['scoresheet', 'web', 'api', 'shared', 'tauri', 'ci', 'deps'],
+      ['scoresheet', 'web', 'api', 'shared', 'ui', 'tauri', 'ci', 'deps'],
     ],
   },
 }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -95,6 +95,30 @@ export default tseslint.config(
     },
   },
   {
+    files: ['packages/ui/src/**/*.{ts,vue}'],
+    languageOptions: {
+      parserOptions: {
+        parser: tseslint.parser,
+        project: './packages/ui/tsconfig.json',
+        extraFileExtensions: ['.vue'],
+      },
+    },
+    rules: {
+      'prefer-const': 'error',
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+      }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      'vue/component-api-style': ['error', ['script-setup']],
+      'vue/block-order': ['error', { order: ['script', 'template', 'style'] }],
+      'vue/multi-word-component-names': 'off',
+    },
+  },
+  {
     files: ['packages/api/src/**/*.ts'],
     ignores: ['packages/api/src/**/__tests__/**'],
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "dev:api": "pnpm --filter @qzr/api dev",
     "test:unit": "pnpm --filter scoresheet test:unit && pnpm --filter @qzr/web test:unit && pnpm --filter @qzr/api test:unit",
     "test:watch": "pnpm --parallel --filter scoresheet --filter @qzr/web --filter @qzr/api exec vitest",
-    "type-check": "pnpm --filter @qzr/shared type-check && pnpm --filter scoresheet type-check && pnpm --filter @qzr/web type-check && pnpm --filter @qzr/api type-check",
-    "format": "prettier --write --experimental-cli apps/scoresheet/src/ apps/web/src/ packages/shared/src/ packages/api/src/",
+    "type-check": "pnpm --filter @qzr/shared type-check && pnpm --filter @qzr/ui type-check && pnpm --filter scoresheet type-check && pnpm --filter @qzr/web type-check && pnpm --filter @qzr/api type-check",
+    "format": "prettier --write --experimental-cli apps/scoresheet/src/ apps/web/src/ packages/shared/src/ packages/ui/src/ packages/api/src/",
     "lint": "eslint",
     "tauri": "pnpm --filter scoresheet tauri",
     "android:dev": "pnpm --filter scoresheet tauri android dev",
@@ -37,6 +37,10 @@
     "apps/scoresheet/src/**/*.{ts,vue,css}": "prettier --write --experimental-cli",
     "apps/web/src/**/*.{ts,vue,css}": "prettier --write --experimental-cli",
     "packages/shared/src/**/*.ts": [
+      "eslint --fix",
+      "prettier --write --experimental-cli"
+    ],
+    "packages/ui/src/**/*.{ts,vue,css}": [
       "eslint --fix",
       "prettier --write --experimental-cli"
     ],

--- a/packages/shared/src/authClient.ts
+++ b/packages/shared/src/authClient.ts
@@ -1,12 +1,14 @@
 import { createAuthClient } from 'better-auth/vue'
 
+export type SocialProvider = 'github' | 'google'
+
 export function createAppAuthClient(baseURL: string) {
   const authClient = createAuthClient({ baseURL })
 
   function useAuth() {
     const session = authClient.useSession()
 
-    function signInSocial(provider: 'github' | 'google') {
+    function signInSocial(provider: SocialProvider) {
       authClient.signIn.social({ provider, callbackURL: window.location.href })
     }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,3 +10,4 @@ export {
 export type { QuizFile } from './quizFile'
 export { ApiError, createApiClient } from './apiClient'
 export { createAppAuthClient } from './authClient'
+export type { SocialProvider } from './authClient'

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@qzr/ui",
+  "version": "0.7.1",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "type-check": "vue-tsc --noEmit"
+  },
+  "peerDependencies": {
+    "vue": "^3.5.28"
+  },
+  "devDependencies": {
+    "@vue/tsconfig": "^0.8.1",
+    "typescript": "~5.9.3",
+    "vue": "^3.5.28",
+    "vue-tsc": "^3.2.4"
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,6 +8,9 @@
   "scripts": {
     "type-check": "vue-tsc --noEmit"
   },
+  "dependencies": {
+    "@qzr/shared": "workspace:*"
+  },
   "peerDependencies": {
     "vue": "^3.5.28"
   },

--- a/packages/ui/src/SignInForm.vue
+++ b/packages/ui/src/SignInForm.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+type SignInResult = { error?: { message?: string | null } | null } | undefined
+
+const props = defineProps<{
+  signInSocial: (provider: 'github' | 'google') => void
+  signInEmail: (email: string, password: string) => Promise<SignInResult>
+  signUpEmail: (email: string, password: string) => Promise<SignInResult>
+}>()
+
+const emit = defineEmits<{ (e: 'success'): void }>()
+
+const mode = ref<'pick' | 'signin' | 'signup'>('pick')
+const email = ref('')
+const password = ref('')
+const error = ref('')
+const pending = ref(false)
+
+function reset() {
+  mode.value = 'pick'
+  email.value = ''
+  password.value = ''
+  error.value = ''
+  pending.value = false
+}
+
+defineExpose({ reset })
+
+async function submitEmail() {
+  error.value = ''
+  pending.value = true
+  const fn = mode.value === 'signup' ? props.signUpEmail : props.signInEmail
+  const result = await fn(email.value, password.value)
+  pending.value = false
+  if (result?.error) {
+    error.value = result.error.message ?? 'Something went wrong'
+  } else {
+    emit('success')
+  }
+}
+</script>
+
+<template>
+  <!-- Provider pick -->
+  <template v-if="mode === 'pick'">
+    <button class="provider-btn" @click="signInSocial('github')">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path
+          d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.868-.013-1.703-2.782.604-3.369-1.341-3.369-1.341-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.337 4.687-4.565 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"
+        />
+      </svg>
+      Continue with GitHub
+    </button>
+    <button class="provider-btn" @click="signInSocial('google')">
+      <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          fill="#4285F4"
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+        />
+        <path
+          fill="#34A853"
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+        />
+        <path
+          fill="#EA4335"
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        />
+      </svg>
+      Continue with Google
+    </button>
+    <div class="divider"><span>or</span></div>
+    <button class="email-toggle" @click="mode = 'signin'">Sign in with email</button>
+    <button class="email-toggle" @click="mode = 'signup'">Create account</button>
+  </template>
+
+  <!-- Email form -->
+  <template v-else>
+    <button class="back-btn" @click="mode = 'pick'">← Back</button>
+    <p class="form-title">{{ mode === 'signup' ? 'Create account' : 'Sign in' }}</p>
+    <form @submit.prevent="submitEmail">
+      <input
+        v-model="email"
+        type="email"
+        placeholder="Email"
+        autocomplete="email"
+        required
+        class="field"
+      />
+      <input
+        v-model="password"
+        type="password"
+        placeholder="Password"
+        autocomplete="current-password"
+        required
+        class="field"
+      />
+      <p v-if="error" class="error-msg">{{ error }}</p>
+      <button type="submit" class="submit-btn" :disabled="pending">
+        {{ pending ? 'Please wait…' : mode === 'signup' ? 'Create account' : 'Sign in' }}
+      </button>
+    </form>
+  </template>
+</template>
+
+<style scoped>
+.provider-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-border-alt);
+  background: var(--color-bg);
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.provider-btn:hover {
+  background: var(--color-bg-alt);
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-text-faint);
+  font-size: 0.75rem;
+}
+
+.divider::before,
+.divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--color-border-alt);
+}
+
+.email-toggle {
+  width: 100%;
+  padding: 0.4rem 0.75rem;
+  background: none;
+  border: 1px solid var(--color-border-alt);
+  border-radius: 0.375rem;
+  color: var(--color-text-faint);
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.email-toggle:hover {
+  color: var(--color-text-muted);
+}
+
+.back-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-text-faint);
+  font-size: 0.75rem;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.back-btn:hover {
+  color: var(--color-text-muted);
+}
+
+.form-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.field {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-alt);
+  border-radius: 0.375rem;
+  color: var(--color-text);
+  font-size: 0.8rem;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.field:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.error-msg {
+  font-size: 0.75rem;
+  color: var(--color-error, #f87171);
+  margin: 0;
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 0.45rem 0.75rem;
+  background: var(--color-accent);
+  border: none;
+  border-radius: 0.375rem;
+  color: #fff;
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.submit-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/packages/ui/src/SignInForm.vue
+++ b/packages/ui/src/SignInForm.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import type { SocialProvider } from '@qzr/shared'
 
 type SignInResult = { error?: { message?: string | null } | null } | undefined
 
 const props = defineProps<{
-  signInSocial: (provider: 'github' | 'google') => void
+  signInSocial: (provider: SocialProvider) => void
   signInEmail: (email: string, password: string) => Promise<SignInResult>
   signUpEmail: (email: string, password: string) => Promise<SignInResult>
 }>()
@@ -16,16 +17,6 @@ const email = ref('')
 const password = ref('')
 const error = ref('')
 const pending = ref(false)
-
-function reset() {
-  mode.value = 'pick'
-  email.value = ''
-  password.value = ''
-  error.value = ''
-  pending.value = false
-}
-
-defineExpose({ reset })
 
 async function submitEmail() {
   error.value = ''
@@ -42,7 +33,6 @@ async function submitEmail() {
 </script>
 
 <template>
-  <!-- Provider pick -->
   <template v-if="mode === 'pick'">
     <button class="provider-btn" @click="signInSocial('github')">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -78,7 +68,6 @@ async function submitEmail() {
     <button class="email-toggle" @click="mode = 'signup'">Create account</button>
   </template>
 
-  <!-- Email form -->
   <template v-else>
     <button class="back-btn" @click="mode = 'pick'">← Back</button>
     <p class="form-title">{{ mode === 'signup' ? 'Create account' : 'Sign in' }}</p>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,1 @@
+export { default as SignInForm } from './SignInForm.vue'

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "include": ["src/**/*", "src/**/*.vue"],
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@qzr/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@qzr/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.49
@@ -123,6 +126,9 @@ importers:
       '@qzr/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@qzr/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       better-auth:
         specifier: ^1.2.7
         version: 1.5.6(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(better-sqlite3@11.10.0)(kysely@0.28.15)(sql.js@1.14.1))(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.28(typescript@5.9.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,21 @@ importers:
         specifier: ^3.5.28
         version: 3.5.28(typescript@5.9.3)
 
+  packages/ui:
+    devDependencies:
+      '@vue/tsconfig':
+        specifier: ^0.8.1
+        version: 0.8.1(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3))
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vue:
+        specifier: ^3.5.28
+        version: 3.5.28(typescript@5.9.3)
+      vue-tsc:
+        specifier: ^3.2.4
+        version: 3.2.4(typescript@5.9.3)
+
 packages:
 
   '@acemir/cssom@0.9.31':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,10 @@ importers:
         version: 3.5.28(typescript@5.9.3)
 
   packages/ui:
+    dependencies:
+      '@qzr/shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@vue/tsconfig':
         specifier: ^0.8.1


### PR DESCRIPTION
## Summary

- New `@qzr/ui` workspace package; first resident is `SignInForm.vue` — the inner provider picker + email form + state machine shared between scoresheet and web.
- `SignInWidget.vue` (scoresheet, −199 lines) and `SignInMenu.vue` (web, −220 lines) now render `<SignInForm>` inside their own menu chrome. 635 lines → ~330, and the two flows can no longer drift.
- `SignInForm` is auth-agnostic: callers pass `signInSocial` / `signInEmail` / `signUpEmail` as props (each app keeps using its `useAuth` from `@qzr/shared`) and it emits `success` when the caller should close its menu.

Closes #22.

## Why `@qzr/ui` instead of extending `@qzr/shared`

Separates pure type/schema/logic deps (`shared`) from Vue SFC deps, and sets up a home for future cross-app UI (e.g. the template-wrapper dedup in #25). Cost was tiny: one `package.json`, `tsconfig.json`, `index.ts`, and a small ESLint block.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm test:unit` — 168/168 pass
- [x] `pnpm lint` clean on touched files
- [ ] Manual: sign in / sign up / social sign-in / error rendering in both scoresheet and portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Created by claude-opus-4-7</sub>