### PR TITLE
refactor(api): batch roster/import + /sync writes (closes #23)

### DIFF
--- a/packages/api/src/routes/__tests__/churches.spec.ts
+++ b/packages/api/src/routes/__tests__/churches.spec.ts
@@ -1574,6 +1574,41 @@ describe('POST /api/meets/:meetId/roster/import', () => {
     expect(teams).toHaveLength(2)
     expect(teams.map((t) => t.number).sort()).toEqual([1, 2])
   })
+
+  // Guards the batched-insert rewrite (issue #23): every roster row must point
+  // at a real identity row and the name-to-identity mapping must be 1:1. A
+  // silent index-pairing off-by-one in the batched path would cross-link
+  // quizzers and slip past the counter-only assertions above.
+  it('pairs every inserted quizzer with its own identity row', async () => {
+    const app = createApp(testSuperuser, db)
+    const meet = await seedMeet(db)
+
+    const rows = [
+      { church: 'Grace', division: 'Open', teamName: 'Eagles', quizzerName: 'Alice' },
+      { church: 'Grace', division: 'Open', teamName: 'Eagles', quizzerName: 'Bob' },
+      { church: 'Grace', division: 'Teen', teamName: 'Doves', quizzerName: 'Carol' },
+      { church: 'First Baptist', division: 'Open', teamName: 'Hawks', quizzerName: 'Dan' },
+      { church: 'First Baptist', division: 'Open', teamName: 'Hawks', quizzerName: 'Eve' },
+      { church: 'First Baptist', division: 'Teen', teamName: 'Sparrows', quizzerName: 'Frank' },
+    ]
+    const res = await app.request(`/api/meets/${meet.id}/roster/import`, importBody(rows), env)
+    expect(res.status).toBe(201)
+
+    const rosters = await db.select().from(schema.teamRosters)
+    const identities = await db.select().from(schema.quizzerIdentities)
+    const identityIds = new Set(identities.map((r) => r.id))
+
+    expect(rosters).toHaveLength(rows.length)
+    expect(identities).toHaveLength(rows.length)
+    for (const r of rosters) expect(identityIds.has(r.quizzerId)).toBe(true)
+
+    // 1:1 mapping — no identity reused across rosters
+    const usedIdentities = new Set(rosters.map((r) => r.quizzerId))
+    expect(usedIdentities.size).toBe(rosters.length)
+
+    // Every expected name lands in the roster exactly once
+    expect(rosters.map((r) => r.name).sort()).toEqual(rows.map((r) => r.quizzerName).sort())
+  })
 })
 
 // ---- Roster export ----

--- a/packages/api/src/routes/__tests__/churches.spec.ts
+++ b/packages/api/src/routes/__tests__/churches.spec.ts
@@ -1575,10 +1575,9 @@ describe('POST /api/meets/:meetId/roster/import', () => {
     expect(teams.map((t) => t.number).sort()).toEqual([1, 2])
   })
 
-  // Guards the batched-insert rewrite (issue #23): every roster row must point
-  // at a real identity row and the name-to-identity mapping must be 1:1. A
-  // silent index-pairing off-by-one in the batched path would cross-link
-  // quizzers and slip past the counter-only assertions above.
+  // Guards batchCreateQuizzers' slot-to-identity pairing (issue #23): an
+  // off-by-one in the batched path would cross-link quizzers and slip past the
+  // counter-only assertions above.
   it('pairs every inserted quizzer with its own identity row', async () => {
     const app = createApp(testSuperuser, db)
     const meet = await seedMeet(db)

--- a/packages/api/src/routes/churches.ts
+++ b/packages/api/src/routes/churches.ts
@@ -650,24 +650,31 @@ churches.post('/churches/:churchId/roster/sync', async (c) => {
 
   const teamIdMap = new Map<number, number>() // tempId → realId
 
+  // Batch-insert all new teams, then map input slot → real id by returning order.
+  const newTeamSlots = body.teams.map((t, i) => ({ t, number: i + 1 })).filter(({ t }) => t.id < 0)
+  const newTeamRows = newTeamSlots.map(({ t, number }) => ({
+    meetId: church.meetId,
+    churchId,
+    division: t.division,
+    number,
+  }))
+  const insertedTeams =
+    newTeamRows.length > 0 ? await db.insert(schema.teams).values(newTeamRows).returning() : []
+  insertedTeams.forEach((team, idx) => {
+    teamIdMap.set(newTeamSlots[idx]!.t.id, team.id)
+  })
+
+  // Existing team updates stay serial — typically 0–few edits per sync.
   for (let i = 0; i < body.teams.length; i++) {
     const t = body.teams[i]!
+    if (t.id < 0) continue
+    const current = currentTeamMap.get(t.id)
     const number = i + 1
-    if (t.id < 0) {
-      const [created] = await db
-        .insert(schema.teams)
-        .values({ meetId: church.meetId, churchId, division: t.division, number })
-        .returning()
-      teamIdMap.set(t.id, created!.id)
-    } else {
-      // Update division and/or number on existing team if changed
-      const current = currentTeamMap.get(t.id)
-      if (current && (current.division !== t.division || current.number !== number)) {
-        await db
-          .update(schema.teams)
-          .set({ division: t.division, number })
-          .where(eq(schema.teams.id, t.id))
-      }
+    if (current && (current.division !== t.division || current.number !== number)) {
+      await db
+        .update(schema.teams)
+        .set({ division: t.division, number })
+        .where(eq(schema.teams.id, t.id))
     }
   }
 
@@ -675,46 +682,64 @@ churches.post('/churches/:churchId/roster/sync', async (c) => {
 
   const quizzerIdMap = new Map<number, number>() // tempId → realId
 
+  // Collect all new-quizzer slots across teams first, then batch both the
+  // identity rows and the roster rows, pairing identity ids to names by
+  // input-array index.
+  const newQuizzerSlots: Array<{ tempId: number; teamId: number; name: string }> = []
   for (const t of body.teams) {
     const realTeamId = t.id > 0 ? t.id : teamIdMap.get(t.id)!
-
     for (const q of t.quizzers) {
       if (q.id < 0) {
-        // New quizzer: create identity + roster entry
-        const [identity] = await db.insert(schema.quizzerIdentities).values({}).returning()
-        await db
-          .insert(schema.teamRosters)
-          .values({ teamId: realTeamId, quizzerId: identity!.id, name: q.name.trim() })
-        quizzerIdMap.set(q.id, identity!.id)
-      } else {
-        // Existing quizzer: check for move or rename
-        const current = currentRosterMap.get(q.id)
-        if (current) {
-          const nameChanged = current.name !== q.name.trim()
-          const movedTeam = current.teamId !== realTeamId
+        newQuizzerSlots.push({ tempId: q.id, teamId: realTeamId, name: q.name.trim() })
+      }
+    }
+  }
+  const newIdentities =
+    newQuizzerSlots.length > 0
+      ? await db
+          .insert(schema.quizzerIdentities)
+          .values(Array.from({ length: newQuizzerSlots.length }, () => ({})))
+          .returning()
+      : []
+  const newRosterRows = newQuizzerSlots.map((slot, idx) => ({
+    teamId: slot.teamId,
+    quizzerId: newIdentities[idx]!.id,
+    name: slot.name,
+  }))
+  if (newRosterRows.length > 0) await db.insert(schema.teamRosters).values(newRosterRows)
+  newQuizzerSlots.forEach((slot, idx) => {
+    quizzerIdMap.set(slot.tempId, newIdentities[idx]!.id)
+  })
 
-          if (movedTeam) {
-            await db
-              .update(schema.teamRosters)
-              .set({ teamId: realTeamId, name: q.name.trim() })
-              .where(
-                and(
-                  eq(schema.teamRosters.quizzerId, q.id),
-                  eq(schema.teamRosters.teamId, current.teamId),
-                ),
-              )
-          } else if (nameChanged) {
-            await db
-              .update(schema.teamRosters)
-              .set({ name: q.name.trim() })
-              .where(
-                and(
-                  eq(schema.teamRosters.quizzerId, q.id),
-                  eq(schema.teamRosters.teamId, realTeamId),
-                ),
-              )
-          }
-        }
+  // Moves and renames stay serial — bounded by the number of actual changes,
+  // not the total roster size, and batching UPDATE would need CASE WHEN SQL
+  // that's harder to audit than this per-row form.
+  for (const t of body.teams) {
+    const realTeamId = t.id > 0 ? t.id : teamIdMap.get(t.id)!
+    for (const q of t.quizzers) {
+      if (q.id < 0) continue
+      const current = currentRosterMap.get(q.id)
+      if (!current) continue
+      const nameChanged = current.name !== q.name.trim()
+      const movedTeam = current.teamId !== realTeamId
+
+      if (movedTeam) {
+        await db
+          .update(schema.teamRosters)
+          .set({ teamId: realTeamId, name: q.name.trim() })
+          .where(
+            and(
+              eq(schema.teamRosters.quizzerId, q.id),
+              eq(schema.teamRosters.teamId, current.teamId),
+            ),
+          )
+      } else if (nameChanged) {
+        await db
+          .update(schema.teamRosters)
+          .set({ name: q.name.trim() })
+          .where(
+            and(eq(schema.teamRosters.quizzerId, q.id), eq(schema.teamRosters.teamId, realTeamId)),
+          )
       }
     }
   }

--- a/packages/api/src/routes/churches.ts
+++ b/packages/api/src/routes/churches.ts
@@ -1005,11 +1005,8 @@ churches.post('/meets/:meetId/roster/import', async (c) => {
 
 /**
  * Create N new quizzers in two batched writes: allocate identities, then insert
- * rosters pairing each identity id to its slot by input-array index.
- *
- * The pairing is the invariant: `slots[i]` receives `identities[i].id`. Drizzle
- * preserves input order in `.returning()` so this holds as long as both calls
- * complete successfully. The roster/import pairing test exercises this end-to-end.
+ * rosters pairing `slots[i]` with `identities[i].id`. Relies on Drizzle
+ * preserving input order in `.returning()`.
  */
 async function batchCreateQuizzers(
   db: Db,

--- a/packages/api/src/routes/churches.ts
+++ b/packages/api/src/routes/churches.ts
@@ -909,51 +909,58 @@ churches.post('/meets/:meetId/roster/import', async (c) => {
     }
   }
 
-  // Load existing teams + rosters for all involved churches, for deduplication
-  // existingTeamRosters: churchId → Array<{ teamId, division, quizzerNames: Set<string> }>
+  // Load existing teams + rosters across all involved churches in two queries.
   const allChurchIds = [...new Set([...teamGroupMap.values()].map((g) => g.key.churchId))]
-  const nextNumberByChurch = new Map<number, number>()
+  const existingTeams =
+    allChurchIds.length > 0
+      ? await db.select().from(schema.teams).where(inArray(schema.teams.churchId, allChurchIds))
+      : []
+  const existingRosterRows =
+    existingTeams.length > 0
+      ? await db
+          .select()
+          .from(schema.teamRosters)
+          .where(
+            inArray(
+              schema.teamRosters.teamId,
+              existingTeams.map((t) => t.id),
+            ),
+          )
+      : []
+
+  const rosterByTeam = new Map<number, string[]>()
+  for (const row of existingRosterRows) {
+    if (!rosterByTeam.has(row.teamId)) rosterByTeam.set(row.teamId, [])
+    rosterByTeam.get(row.teamId)!.push(row.name)
+  }
+  const nextNumberByChurch = new Map<number, number>(allChurchIds.map((cid) => [cid, 1]))
   const existingTeamRosters = new Map<
     number,
     Array<{ teamId: number; division: string; quizzerNames: Set<string> }>
-  >()
-  for (const cid of allChurchIds) {
-    const existingTeams = await db.select().from(schema.teams).where(eq(schema.teams.churchId, cid))
-    const max = existingTeams.length === 0 ? 0 : Math.max(...existingTeams.map((r) => r.number))
-    nextNumberByChurch.set(cid, max + 1)
-
-    const teamRosterRows =
-      existingTeams.length > 0
-        ? await db
-            .select()
-            .from(schema.teamRosters)
-            .where(
-              inArray(
-                schema.teamRosters.teamId,
-                existingTeams.map((t) => t.id),
-              ),
-            )
-        : []
-    const rosterByTeam = new Map<number, string[]>()
-    for (const row of teamRosterRows) {
-      if (!rosterByTeam.has(row.teamId)) rosterByTeam.set(row.teamId, [])
-      rosterByTeam.get(row.teamId)!.push(row.name)
+  >(allChurchIds.map((cid) => [cid, []]))
+  for (const t of existingTeams) {
+    existingTeamRosters.get(t.churchId)!.push({
+      teamId: t.id,
+      division: t.division,
+      quizzerNames: new Set(rosterByTeam.get(t.id) ?? []),
+    })
+    const nextNum = t.number + 1
+    if (nextNum > nextNumberByChurch.get(t.churchId)!) {
+      nextNumberByChurch.set(t.churchId, nextNum)
     }
-    existingTeamRosters.set(
-      cid,
-      existingTeams.map((t) => ({
-        teamId: t.id,
-        division: t.division,
-        quizzerNames: new Set(rosterByTeam.get(t.id) ?? []),
-      })),
-    )
   }
 
-  let teamsCreated = 0
-  let quizzersAdded = 0
-
+  // Decide new teams + names up front, then write in three batched phases:
+  // (1) insert all teams, (2) allocate all identities, (3) insert all rosters
+  // pairing identity ids to names by input-array index.
+  const teamInserts: Array<{
+    meetId: number
+    churchId: number
+    division: string
+    number: number
+  }> = []
+  const namesPerTeamSlot: string[][] = []
   for (const { key, quizzerNames } of teamGroupMap.values()) {
-    // Skip if an existing team in this church+division already has exactly this quizzer set
     const existing = existingTeamRosters.get(key.churchId) ?? []
     const isDuplicate = existing.some(
       (t) =>
@@ -965,23 +972,35 @@ churches.post('/meets/:meetId/roster/import', async (c) => {
 
     const number = nextNumberByChurch.get(key.churchId)!
     nextNumberByChurch.set(key.churchId, number + 1)
-
-    const [team] = await db
-      .insert(schema.teams)
-      .values({ meetId, churchId: key.churchId, division: key.division, number })
-      .returning()
-    teamsCreated++
-
-    for (const name of quizzerNames) {
-      const [identity] = await db.insert(schema.quizzerIdentities).values({}).returning()
-      await db
-        .insert(schema.teamRosters)
-        .values({ teamId: team!.id, quizzerId: identity!.id, name })
-      quizzersAdded++
-    }
+    teamInserts.push({ meetId, churchId: key.churchId, division: key.division, number })
+    namesPerTeamSlot.push(quizzerNames)
   }
 
-  return c.json({ churchesCreated, teamsCreated, quizzersAdded }, 201)
+  const insertedTeams =
+    teamInserts.length > 0 ? await db.insert(schema.teams).values(teamInserts).returning() : []
+
+  const totalQuizzers = namesPerTeamSlot.reduce((sum, ns) => sum + ns.length, 0)
+  const identities =
+    totalQuizzers > 0
+      ? await db
+          .insert(schema.quizzerIdentities)
+          .values(Array.from({ length: totalQuizzers }, () => ({})))
+          .returning()
+      : []
+
+  const rosterRows: Array<{ teamId: number; quizzerId: number; name: string }> = []
+  let idCursor = 0
+  insertedTeams.forEach((team, slot) => {
+    for (const name of namesPerTeamSlot[slot]!) {
+      rosterRows.push({ teamId: team.id, quizzerId: identities[idCursor++]!.id, name })
+    }
+  })
+  if (rosterRows.length > 0) await db.insert(schema.teamRosters).values(rosterRows)
+
+  return c.json(
+    { churchesCreated, teamsCreated: insertedTeams.length, quizzersAdded: rosterRows.length },
+    201,
+  )
 })
 
 // ---- Helpers ----

--- a/packages/api/src/routes/churches.ts
+++ b/packages/api/src/routes/churches.ts
@@ -664,7 +664,6 @@ churches.post('/churches/:churchId/roster/sync', async (c) => {
     teamIdMap.set(newTeamSlots[idx]!.t.id, team.id)
   })
 
-  // Existing team updates stay serial — typically 0–few edits per sync.
   for (let i = 0; i < body.teams.length; i++) {
     const t = body.teams[i]!
     if (t.id < 0) continue
@@ -682,9 +681,6 @@ churches.post('/churches/:churchId/roster/sync', async (c) => {
 
   const quizzerIdMap = new Map<number, number>() // tempId → realId
 
-  // Collect all new-quizzer slots across teams first, then batch both the
-  // identity rows and the roster rows, pairing identity ids to names by
-  // input-array index.
   const newQuizzerSlots: Array<{ tempId: number; teamId: number; name: string }> = []
   for (const t of body.teams) {
     const realTeamId = t.id > 0 ? t.id : teamIdMap.get(t.id)!
@@ -694,26 +690,10 @@ churches.post('/churches/:churchId/roster/sync', async (c) => {
       }
     }
   }
-  const newIdentities =
-    newQuizzerSlots.length > 0
-      ? await db
-          .insert(schema.quizzerIdentities)
-          .values(Array.from({ length: newQuizzerSlots.length }, () => ({})))
-          .returning()
-      : []
-  const newRosterRows = newQuizzerSlots.map((slot, idx) => ({
-    teamId: slot.teamId,
-    quizzerId: newIdentities[idx]!.id,
-    name: slot.name,
-  }))
-  if (newRosterRows.length > 0) await db.insert(schema.teamRosters).values(newRosterRows)
-  newQuizzerSlots.forEach((slot, idx) => {
-    quizzerIdMap.set(slot.tempId, newIdentities[idx]!.id)
-  })
+  const newIdentityIds = await batchCreateQuizzers(db, newQuizzerSlots)
+  newQuizzerSlots.forEach((slot, idx) => quizzerIdMap.set(slot.tempId, newIdentityIds[idx]!))
 
-  // Moves and renames stay serial — bounded by the number of actual changes,
-  // not the total roster size, and batching UPDATE would need CASE WHEN SQL
-  // that's harder to audit than this per-row form.
+  // Serial updates: bounded by actual changes; batching would need CASE WHEN SQL.
   for (const t of body.teams) {
     const realTeamId = t.id > 0 ? t.id : teamIdMap.get(t.id)!
     for (const q of t.quizzers) {
@@ -975,16 +955,12 @@ churches.post('/meets/:meetId/roster/import', async (c) => {
     }
   }
 
-  // Decide new teams + names up front, then write in three batched phases:
-  // (1) insert all teams, (2) allocate all identities, (3) insert all rosters
-  // pairing identity ids to names by input-array index.
-  const teamInserts: Array<{
-    meetId: number
-    churchId: number
-    division: string
-    number: number
+  // Decide new teams + their quizzer lists up front, then write in two phases:
+  // (1) batch-insert teams, (2) batch-create quizzers pairing identity ids by slot.
+  const teamPlans: Array<{
+    insert: { meetId: number; churchId: number; division: string; number: number }
+    names: string[]
   }> = []
-  const namesPerTeamSlot: string[][] = []
   for (const { key, quizzerNames } of teamGroupMap.values()) {
     const existing = existingTeamRosters.get(key.churchId) ?? []
     const isDuplicate = existing.some(
@@ -997,38 +973,61 @@ churches.post('/meets/:meetId/roster/import', async (c) => {
 
     const number = nextNumberByChurch.get(key.churchId)!
     nextNumberByChurch.set(key.churchId, number + 1)
-    teamInserts.push({ meetId, churchId: key.churchId, division: key.division, number })
-    namesPerTeamSlot.push(quizzerNames)
+    teamPlans.push({
+      insert: { meetId, churchId: key.churchId, division: key.division, number },
+      names: quizzerNames,
+    })
   }
 
   const insertedTeams =
-    teamInserts.length > 0 ? await db.insert(schema.teams).values(teamInserts).returning() : []
-
-  const totalQuizzers = namesPerTeamSlot.reduce((sum, ns) => sum + ns.length, 0)
-  const identities =
-    totalQuizzers > 0
+    teamPlans.length > 0
       ? await db
-          .insert(schema.quizzerIdentities)
-          .values(Array.from({ length: totalQuizzers }, () => ({})))
+          .insert(schema.teams)
+          .values(teamPlans.map((p) => p.insert))
           .returning()
       : []
 
-  const rosterRows: Array<{ teamId: number; quizzerId: number; name: string }> = []
-  let idCursor = 0
-  insertedTeams.forEach((team, slot) => {
-    for (const name of namesPerTeamSlot[slot]!) {
-      rosterRows.push({ teamId: team.id, quizzerId: identities[idCursor++]!.id, name })
+  const quizzerSlots: Array<{ teamId: number; name: string }> = []
+  insertedTeams.forEach((team, idx) => {
+    for (const name of teamPlans[idx]!.names) {
+      quizzerSlots.push({ teamId: team.id, name })
     }
   })
-  if (rosterRows.length > 0) await db.insert(schema.teamRosters).values(rosterRows)
+  await batchCreateQuizzers(db, quizzerSlots)
 
   return c.json(
-    { churchesCreated, teamsCreated: insertedTeams.length, quizzersAdded: rosterRows.length },
+    { churchesCreated, teamsCreated: insertedTeams.length, quizzersAdded: quizzerSlots.length },
     201,
   )
 })
 
 // ---- Helpers ----
+
+/**
+ * Create N new quizzers in two batched writes: allocate identities, then insert
+ * rosters pairing each identity id to its slot by input-array index.
+ *
+ * The pairing is the invariant: `slots[i]` receives `identities[i].id`. Drizzle
+ * preserves input order in `.returning()` so this holds as long as both calls
+ * complete successfully. The roster/import pairing test exercises this end-to-end.
+ */
+async function batchCreateQuizzers(
+  db: Db,
+  slots: Array<{ teamId: number; name: string }>,
+): Promise<number[]> {
+  if (slots.length === 0) return []
+  const identities = await db
+    .insert(schema.quizzerIdentities)
+    .values(Array.from({ length: slots.length }, () => ({})))
+    .returning()
+  const rosterRows = slots.map((slot, idx) => ({
+    teamId: slot.teamId,
+    quizzerId: identities[idx]!.id,
+    name: slot.name,
+  }))
+  await db.insert(schema.teamRosters).values(rosterRows)
+  return identities.map((i) => i.id)
+}
 
 async function getTeamWithChurch(
   db: Db,


### PR DESCRIPTION
## Summary

Replaces the N+1 write loops in the two roster admin endpoints with batched inserts. A 15-church / 60-quizzer import drops from ~150 serial D1 round-trips to ~5.

### Before

Both `POST /api/meets/:meetId/roster/import` and `POST /api/churches/:churchId/roster/sync` looped over the payload and fired sequential `INSERT`s:

- `import`: per-church `SELECT teams` + `SELECT rosters`, then per-team `INSERT team`, then per-quizzer `INSERT identity` + `INSERT roster`.
- `sync`: reads were already batched via `inArray()`, but writes fired one-team-at-a-time + per-quizzer identity+roster pairs.

### After

Both handlers now collect all new rows into arrays up front, then emit one `.insert(table).values([...]).returning()` per table. The quizzer identity/roster pairing (each roster row's `quizzerId` must point at the matching identity) lives in a single shared helper `batchCreateQuizzers(db, slots)` that drives both endpoints.

- Updates (moves, renames, team number/division edits) stay serial — they're bounded by the number of actual changes, not by roster size, and batching `UPDATE` would need `CASE WHEN` SQL that's harder to audit.
- Deletes were already batched via `inArray()`.

### Deferred follow-ups (not in this PR)

- Church-creation loop in `roster/import` still runs serial (case-insensitive name lookup + async `hashCode`). Could batch with a dedup-then-insert pass; deferred to avoid expanding scope.
- `Promise.all(teams, identities)` to run the two independent inserts concurrently — marginal win, not in this PR.

## Commits

1. **`test(api): assert roster/import pairing`** — safety-net test that verifies every roster row points at a unique, real `quizzer_identities` row after a multi-church import. Guards the pairing invariant the batched rewrite depends on.
2. **`refactor(api): batch roster/import writes`** — three-phase batched rewrite of the import endpoint.
3. **`refactor(api): batch roster/sync writes`** — same pattern applied to the smaller sync endpoint.
4. **`refactor(api): extract batchCreateQuizzers helper`** — follow-up from the simplify-pass review: pulls the "allocate identities + insert rosters paired by index" pattern into one helper used by both endpoints; collapses parallel arrays in `roster/import` into `teamPlans: Array<{insert, names}>`.

## Test plan

- [x] `pnpm type-check` clean across all packages
- [x] `pnpm test:unit` — 169 tests pass (168 existing + 1 new pairing-invariant test). The 32 existing roster tests continue to pass, including:
  - All 17 `roster/import` scenarios (happy path, case-insensitive church match, shortName match, quizzer dedup, team grouping, admin auth, empty rejection, exact-match skip, subset-doesn't-skip, division-varies, auto-number, church counters)
  - All 15 `roster/sync` scenarios (team create/update/delete with cascade, quizzer create/rename/move/unassign/delete, order preservation, 404)
- [x] Three-agent simplify-pass review (reuse / quality / efficiency) — caught the `batchCreateQuizzers` extraction and parallel-arrays collapse that landed as commit 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>— If this PR was useful, react with 👍. Otherwise 👎.</sub>