### PR TITLE
refactor(scoresheet): brand GreyedOut + ValidationErrors keys (closes #21)

### DIFF
--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -263,8 +263,10 @@ const allValidationMessages = computed(() => {
   if (tooManyTimeoutsTeams.value.size > 0) {
     msgs.add(validationMessage(ValidationCode.TooManyTimeouts))
   }
-  for (const codes of validationErrors.value.values()) {
-    for (const code of codes) msgs.add(validationMessage(code))
+  for (const col of validationErrors.value.values()) {
+    for (const codes of col.values()) {
+      for (const code of codes) msgs.add(validationMessage(code))
+    }
   }
   return [...msgs]
 })

--- a/apps/scoresheet/src/composables/useScoresheet.ts
+++ b/apps/scoresheet/src/composables/useScoresheet.ts
@@ -28,7 +28,7 @@ import {
   quizJumpedComplete,
 } from '../scoring/overtime'
 import { computePlacements, computePlacementPoints } from '../scoring/placement'
-import { toSeatIdx } from '../types/indices'
+import { teamSeatKey, toSeatIdx, toTeamIdx } from '../types/indices'
 import type { DeserializeResult } from '../persistence/quizFile'
 import { saveToStorage, loadFromStorage, clearStorage } from '../persistence/autoSave'
 
@@ -256,8 +256,11 @@ export function useScoresheet() {
   }
 
   function isGreyedOut(teamIdx: number, seatIdx: number, colIdx: number): boolean {
-    const d = greyedOutResult.value.disabled
-    return d.has(`${teamIdx}:${colIdx}`) || d.has(`${teamIdx}:${seatIdx}:${colIdx}`)
+    const g = greyedOutResult.value
+    return (
+      (g.disabledTeams[colIdx]?.has(toTeamIdx(teamIdx)) ?? false) ||
+      (g.disabledSeats[colIdx]?.has(teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx))) ?? false)
+    )
   }
 
   function isInvalid(teamIdx: number, seatIdx: number, colIdx: number): boolean {
@@ -342,7 +345,11 @@ export function useScoresheet() {
   }
 
   function isFouledOnQuestion(teamIdx: number, seatIdx: number, colIdx: number): boolean {
-    return greyedOutResult.value.fouledQuizzers.has(`${teamIdx}:${seatIdx}:${colIdx}`)
+    return (
+      greyedOutResult.value.fouledQuizzers[colIdx]?.has(
+        teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx)),
+      ) ?? false
+    )
   }
 
   function teamHasErrors(teamIdx: number): boolean {

--- a/apps/scoresheet/src/composables/useScoresheet.ts
+++ b/apps/scoresheet/src/composables/useScoresheet.ts
@@ -264,12 +264,18 @@ export function useScoresheet() {
   }
 
   function isInvalid(teamIdx: number, seatIdx: number, colIdx: number): boolean {
-    return validationErrors.value.has(`${teamIdx}:${seatIdx}:${colIdx}`)
+    return (
+      validationErrors.value
+        .get(colIdx)
+        ?.has(teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx))) ?? false
+    )
   }
 
   /** Get human-readable validation messages for a cell (deduplicated) */
   function cellValidationMessages(teamIdx: number, seatIdx: number, colIdx: number): string[] {
-    const codes = validationErrors.value.get(`${teamIdx}:${seatIdx}:${colIdx}`)
+    const codes = validationErrors.value
+      .get(colIdx)
+      ?.get(teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx)))
     if (!codes) return []
     return [...new Set(codes.map(validationMessage))]
   }
@@ -277,10 +283,7 @@ export function useScoresheet() {
   /** Whether any cell in a column has a validation error */
   function columnHasErrors(colIdx: number): boolean {
     if (timeoutValidationErrors.value.has(colIdx)) return true
-    for (const key of validationErrors.value.keys()) {
-      if (key.endsWith(`:${colIdx}`)) return true
-    }
-    return false
+    return (validationErrors.value.get(colIdx)?.size ?? 0) > 0
   }
 
   /** Get deduplicated validation messages for all cells in a column */
@@ -289,8 +292,9 @@ export function useScoresheet() {
     if (timeoutValidationErrors.value.has(colIdx)) {
       msgs.add(validationMessage(ValidationCode.TimeoutAfterQ16))
     }
-    for (const [key, codes] of validationErrors.value) {
-      if (key.endsWith(`:${colIdx}`)) {
+    const col = validationErrors.value.get(colIdx)
+    if (col) {
+      for (const codes of col.values()) {
         for (const code of codes) msgs.add(validationMessage(code))
       }
     }
@@ -299,17 +303,20 @@ export function useScoresheet() {
 
   /** Whether any cell for a specific quizzer has a validation error */
   function quizzerHasErrors(teamIdx: number, seatIdx: number): boolean {
-    for (const key of validationErrors.value.keys()) {
-      if (key.startsWith(`${teamIdx}:${seatIdx}:`)) return true
+    const key = teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx))
+    for (const col of validationErrors.value.values()) {
+      if (col.has(key)) return true
     }
     return false
   }
 
   /** Get deduplicated validation messages for a specific quizzer */
   function quizzerValidationMessages(teamIdx: number, seatIdx: number): string[] {
+    const key = teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx))
     const msgs = new Set<string>()
-    for (const [key, codes] of validationErrors.value) {
-      if (key.startsWith(`${teamIdx}:${seatIdx}:`)) {
+    for (const col of validationErrors.value.values()) {
+      const codes = col.get(key)
+      if (codes) {
         for (const code of codes) msgs.add(validationMessage(code))
       }
     }
@@ -325,9 +332,12 @@ export function useScoresheet() {
     if (tooManyTimeoutsTeams.value.has(teamIdx)) {
       msgs.add(validationMessage(ValidationCode.TooManyTimeouts))
     }
-    for (const [key, codes] of validationErrors.value) {
-      if (key.startsWith(`${teamIdx}:`)) {
-        for (const code of codes) msgs.add(validationMessage(code))
+    const teamPrefix = `${teamIdx}:`
+    for (const col of validationErrors.value.values()) {
+      for (const [key, codes] of col) {
+        if ((key as string).startsWith(teamPrefix)) {
+          for (const code of codes) msgs.add(validationMessage(code))
+        }
       }
     }
     return [...msgs]
@@ -355,8 +365,11 @@ export function useScoresheet() {
   function teamHasErrors(teamIdx: number): boolean {
     if (timeoutErrorsByTeam.value.has(teamIdx)) return true
     if (tooManyTimeoutsTeams.value.has(teamIdx)) return true
-    for (const key of validationErrors.value.keys()) {
-      if (key.startsWith(`${teamIdx}:`)) return true
+    const teamPrefix = `${teamIdx}:`
+    for (const col of validationErrors.value.values()) {
+      for (const key of col.keys()) {
+        if ((key as string).startsWith(teamPrefix)) return true
+      }
     }
     return false
   }
@@ -392,11 +405,10 @@ export function useScoresheet() {
     if (!noJumps.value[colIdx]) return false
     // No-jump on an orphaned column is itself invalid
     if (orphanedColumns.value.has(colIdx)) return true
-    for (const key of validationErrors.value.keys()) {
-      if (key.endsWith(`:${colIdx}`)) {
-        const codes = validationErrors.value.get(key)
-        if (codes?.includes(ValidationCode.NoJump)) return true
-      }
+    const col = validationErrors.value.get(colIdx)
+    if (!col) return false
+    for (const codes of col.values()) {
+      if (codes.includes(ValidationCode.NoJump)) return true
     }
     return false
   }

--- a/apps/scoresheet/src/composables/useScoresheet.ts
+++ b/apps/scoresheet/src/composables/useScoresheet.ts
@@ -332,10 +332,13 @@ export function useScoresheet() {
     if (tooManyTimeoutsTeams.value.has(teamIdx)) {
       msgs.add(validationMessage(ValidationCode.TooManyTimeouts))
     }
-    const teamPrefix = `${teamIdx}:`
-    for (const col of validationErrors.value.values()) {
-      for (const [key, codes] of col) {
-        if ((key as string).startsWith(teamPrefix)) {
+    const seatCount = teamQuizzers.value[teamIdx]?.length ?? 0
+    const team = toTeamIdx(teamIdx)
+    for (let s = 0; s < seatCount; s++) {
+      const key = teamSeatKey(team, toSeatIdx(s))
+      for (const col of validationErrors.value.values()) {
+        const codes = col.get(key)
+        if (codes) {
           for (const code of codes) msgs.add(validationMessage(code))
         }
       }
@@ -365,10 +368,12 @@ export function useScoresheet() {
   function teamHasErrors(teamIdx: number): boolean {
     if (timeoutErrorsByTeam.value.has(teamIdx)) return true
     if (tooManyTimeoutsTeams.value.has(teamIdx)) return true
-    const teamPrefix = `${teamIdx}:`
-    for (const col of validationErrors.value.values()) {
-      for (const key of col.keys()) {
-        if ((key as string).startsWith(teamPrefix)) return true
+    const seatCount = teamQuizzers.value[teamIdx]?.length ?? 0
+    const team = toTeamIdx(teamIdx)
+    for (let s = 0; s < seatCount; s++) {
+      const key = teamSeatKey(team, toSeatIdx(s))
+      for (const col of validationErrors.value.values()) {
+        if (col.has(key)) return true
       }
     }
     return false

--- a/apps/scoresheet/src/scoring/__tests__/greyedOut.spec.ts
+++ b/apps/scoresheet/src/scoring/__tests__/greyedOut.spec.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { BonusRule, CellValue, buildColumns } from '../../types/scoresheet'
-import { computeGreyedOut } from '../greyedOut'
+import { computeGreyedOut, type GreyedOutResult } from '../greyedOut'
 import { ColStatus } from '../helpers'
 import { computeOtIneligibility } from '../overtime'
+import { teamSeatKey, toSeatIdx, toTeamIdx } from '../../types/indices'
 
 const columns = buildColumns()
 const C = CellValue.Correct
@@ -19,21 +20,23 @@ function colIdxOf(key: string): number {
   return idx
 }
 
-/** Helper: check if a team is greyed at a column */
-function isGreyed(result: { disabled: Set<string> }, teamIdx: number, colIdx: number): boolean {
-  return result.disabled.has(`${teamIdx}:${colIdx}`)
+/** Helper: check if a team is greyed at the team level on a column. */
+function isGreyed(result: GreyedOutResult, teamIdx: number, colIdx: number): boolean {
+  return result.disabledTeams[colIdx]?.has(toTeamIdx(teamIdx)) ?? false
 }
 
 /** Helper: check if a column is a bonus for a team (other 2 teams tossed-up) */
 function isBonusFor(
-  result: { tossedUp: Set<string> },
+  result: GreyedOutResult,
   teamIdx: number,
   colIdx: number,
   teamCount = 3,
 ): boolean {
+  const col = result.tossedUp[colIdx]
+  if (!col) return false
   let tossedTeams = 0
   for (let t = 0; t < teamCount; t++) {
-    if (t !== teamIdx && result.tossedUp.has(`${t}:${colIdx}`)) tossedTeams++
+    if (t !== teamIdx && col.has(toTeamIdx(t))) tossedTeams++
   }
   return tossedTeams === teamCount - 1
 }
@@ -287,25 +290,29 @@ describe('greyed-out logic', () => {
 
   // --- Quizzer foul on A/B question greys subsequent sub-parts ---
 
+  function fouled(result: GreyedOutResult, t: number, s: number, c: number): boolean {
+    return result.fouledQuizzers[c]?.has(teamSeatKey(toTeamIdx(t), toSeatIdx(s))) ?? false
+  }
+
   it('quizzer foul on base A/B question greys that quizzer on A and B', () => {
     const cells = blankCells()
     cells[0]![0]![colIdxOf('17')] = F // team 0, quizzer 0 fouls on Q17
     const result = computeGreyedOut(cells, columns)
-    expect(result.fouledQuizzers.has(`0:0:${colIdxOf('17A')}`)).toBe(true)
-    expect(result.fouledQuizzers.has(`0:0:${colIdxOf('17B')}`)).toBe(true)
+    expect(fouled(result, 0, 0, colIdxOf('17A'))).toBe(true)
+    expect(fouled(result, 0, 0, colIdxOf('17B'))).toBe(true)
     // Other quizzers on the same team are NOT affected
-    expect(result.fouledQuizzers.has(`0:1:${colIdxOf('17A')}`)).toBe(false)
+    expect(fouled(result, 0, 1, colIdxOf('17A'))).toBe(false)
     // Other teams are NOT affected
-    expect(result.fouledQuizzers.has(`1:0:${colIdxOf('17A')}`)).toBe(false)
+    expect(fouled(result, 1, 0, colIdxOf('17A'))).toBe(false)
   })
 
   it('quizzer foul on A question greys that quizzer on B', () => {
     const cells = blankCells()
     cells[1]![2]![colIdxOf('18A')] = F // team 1, quizzer 2 fouls on Q18A
     const result = computeGreyedOut(cells, columns)
-    expect(result.fouledQuizzers.has(`1:2:${colIdxOf('18B')}`)).toBe(true)
+    expect(fouled(result, 1, 2, colIdxOf('18B'))).toBe(true)
     // NOT greyed on 18A itself (that's where the foul happened)
-    expect(result.fouledQuizzers.has(`1:2:${colIdxOf('18A')}`)).toBe(false)
+    expect(fouled(result, 1, 2, colIdxOf('18A'))).toBe(false)
   })
 
   it('quizzer foul on B question does not propagate further', () => {
@@ -313,22 +320,22 @@ describe('greyed-out logic', () => {
     cells[0]![0]![colIdxOf('17B')] = F // foul on B — nowhere to propagate
     const result = computeGreyedOut(cells, columns)
     // No fouledQuizzers entries for Q18 or beyond from this
-    expect(result.fouledQuizzers.has(`0:0:${colIdxOf('18')}`)).toBe(false)
+    expect(fouled(result, 0, 0, colIdxOf('18'))).toBe(false)
   })
 
   it('foul on normal (non-AB) question does not create fouledQuizzers entries', () => {
     const cells = blankCells()
     cells[0]![0]![colIdxOf('1')] = F // Q1 is not A/B
     const result = computeGreyedOut(cells, columns)
-    expect(result.fouledQuizzers.size).toBe(0)
+    expect(result.fouledQuizzers.every((s) => s.size === 0)).toBe(true)
   })
 
   it('foul on Q16 (AB but not error-points) still greys quizzer on 16A and 16B', () => {
     const cells = blankCells()
     cells[2]![1]![colIdxOf('16')] = F // team 2, quizzer 1 fouls on Q16
     const result = computeGreyedOut(cells, columns)
-    expect(result.fouledQuizzers.has(`2:1:${colIdxOf('16A')}`)).toBe(true)
-    expect(result.fouledQuizzers.has(`2:1:${colIdxOf('16B')}`)).toBe(true)
+    expect(fouled(result, 2, 1, colIdxOf('16A'))).toBe(true)
+    expect(fouled(result, 2, 1, colIdxOf('16B'))).toBe(true)
   })
 
   // --- colStatuses ---
@@ -541,26 +548,28 @@ describe('greyed-out logic', () => {
     const result = computeGreyedOut(otCells, otCols, ineligibility)
     // Team 0 was eligible in round 1 — NOT greyed on round 1 columns
     expect(isGreyed(result, 0, otCi('21'))).toBe(true) // greyed because answered
-    expect(result.tossedUp.has(`0:${otCi('21')}`)).toBe(false)
-    expect(result.tossedUp.has(`0:${otCi('22')}`)).toBe(false)
-    expect(result.tossedUp.has(`0:${otCi('23')}`)).toBe(false)
+    expect(result.tossedUp[otCi('21')]?.has(toTeamIdx(0)) ?? false).toBe(false)
+    expect(result.tossedUp[otCi('22')]?.has(toTeamIdx(0)) ?? false).toBe(false)
+    expect(result.tossedUp[otCi('23')]?.has(toTeamIdx(0)) ?? false).toBe(false)
     // Team 0 IS greyed/tossed on round 2 columns
     expect(isGreyed(result, 0, otCi('24'))).toBe(true)
-    expect(result.tossedUp.has(`0:${otCi('24')}`)).toBe(true)
+    expect(result.tossedUp[otCi('24')]?.has(toTeamIdx(0)) ?? false).toBe(true)
     // Teams 1 & 2 still competing in round 2
     expect(isGreyed(result, 1, otCi('24'))).toBe(false)
     expect(isGreyed(result, 2, otCi('24'))).toBe(false)
   })
 })
 
-/** Helper: check if a specific seat is greyed (3-part key) */
+/** Helper: check if a specific seat is greyed at the seat level. */
 function isSeatGreyed(
-  result: { disabled: Set<string> },
+  result: GreyedOutResult,
   teamIdx: number,
   seatIdx: number,
   colIdx: number,
 ): boolean {
-  return result.disabled.has(`${teamIdx}:${seatIdx}:${colIdx}`)
+  return (
+    result.disabledSeats[colIdx]?.has(teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx))) ?? false
+  )
 }
 
 describe('seat bonus greying', () => {

--- a/apps/scoresheet/src/scoring/__tests__/helpers.spec.ts
+++ b/apps/scoresheet/src/scoring/__tests__/helpers.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { CellValue } from '../../types/scoresheet'
+import { toTeamIdx } from '../../types/indices'
 import {
   isAnswer,
   isResolved,
@@ -203,42 +204,45 @@ describe('colHasAnyContent', () => {
 })
 
 describe('isBonusSituation', () => {
+  // tossedUp is now per-column: tossedUp[colIdx] is the set of teams tossed up on that column.
+  const teams = (...ts: number[]) => new Set(ts.map(toTeamIdx))
+
   // 3-team quiz: team X is in bonus if the other 2 teams are tossed up on that column.
   it('returns true when all other teams are tossed up', () => {
-    const tossedUp = new Set(['1:0', '2:0'])
+    const tossedUp = [teams(1, 2)]
     expect(isBonusSituation(tossedUp, 0, 0, 3)).toBe(true)
   })
 
   it('returns false when only one other team is tossed up', () => {
-    const tossedUp = new Set(['1:0'])
+    const tossedUp = [teams(1)]
     expect(isBonusSituation(tossedUp, 0, 0, 3)).toBe(false)
   })
 
   it('returns false when no other team is tossed up', () => {
-    expect(isBonusSituation(new Set(), 0, 0, 3)).toBe(false)
+    expect(isBonusSituation([teams()], 0, 0, 3)).toBe(false)
   })
 
   it('does not count the checked team itself as tossed up', () => {
     // Team 0 tossed up — but we are checking if team 0 is in a bonus situation
-    const tossedUp = new Set(['0:0', '1:0'])
+    const tossedUp = [teams(0, 1)]
     // Team 2 needs to be tossed up for team 0 to be in bonus; only 1 other team is
     expect(isBonusSituation(tossedUp, 0, 0, 3)).toBe(false)
   })
 
   it('checks the correct column index', () => {
     // Teams 1 and 2 tossed up on col 1, not col 0
-    const tossedUp = new Set(['1:1', '2:1'])
+    const tossedUp = [teams(), teams(1, 2)]
     expect(isBonusSituation(tossedUp, 0, 0, 3)).toBe(false)
     expect(isBonusSituation(tossedUp, 0, 1, 3)).toBe(true)
   })
 
   it('works correctly for team 1 as the bonus team', () => {
-    const tossedUp = new Set(['0:0', '2:0'])
+    const tossedUp = [teams(0, 2)]
     expect(isBonusSituation(tossedUp, 1, 0, 3)).toBe(true)
   })
 
   it('works correctly for a 2-team quiz', () => {
-    const tossedUp = new Set(['1:0'])
+    const tossedUp = [teams(1)]
     expect(isBonusSituation(tossedUp, 0, 0, 2)).toBe(true)
   })
 })

--- a/apps/scoresheet/src/scoring/__tests__/validation.spec.ts
+++ b/apps/scoresheet/src/scoring/__tests__/validation.spec.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from 'vitest'
 import { CellValue, buildColumns } from '../../types/scoresheet'
 import { computeGreyedOut } from '../greyedOut'
-import { validateCells, ValidationCode, validationMessage } from '../validation'
+import {
+  validateCells,
+  ValidationCode,
+  validationMessage,
+  type ValidationErrors,
+} from '../validation'
 import { getOvertimeEligibleTeams } from '../overtime'
 import { computeOrphanedColumns } from '../columnVisibility'
+import { teamSeatKey, toSeatIdx, toTeamIdx } from '../../types/indices'
 
 const columns = buildColumns()
 const C = CellValue.Correct
@@ -32,24 +38,24 @@ function blankCells(): CellValue[][][] {
 
 /** Check if a specific cell has a specific validation code */
 function hasCode(
-  errors: Map<string, ValidationCode[]>,
+  errors: ValidationErrors,
   teamIdx: number,
   seatIdx: number,
   colIdx: number,
   code: ValidationCode,
 ): boolean {
-  const codes = errors.get(`${teamIdx}:${seatIdx}:${colIdx}`)
+  const codes = errors.get(colIdx)?.get(teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx)))
   return codes ? codes.includes(code) : false
 }
 
 /** Check if a specific cell has any validation error */
 function hasAny(
-  errors: Map<string, ValidationCode[]>,
+  errors: ValidationErrors,
   teamIdx: number,
   seatIdx: number,
   colIdx: number,
 ): boolean {
-  return errors.has(`${teamIdx}:${seatIdx}:${colIdx}`)
+  return errors.get(colIdx)?.has(teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx))) ?? false
 }
 
 describe('validationMessage', () => {
@@ -634,13 +640,13 @@ describe('cell validation', () => {
     }
 
     function otHasCode(
-      errors: Map<string, ValidationCode[]>,
+      errors: ValidationErrors,
       teamIdx: number,
       seatIdx: number,
       colIdx: number,
       code: ValidationCode,
     ): boolean {
-      const codes = errors.get(`${teamIdx}:${seatIdx}:${colIdx}`)
+      const codes = errors.get(colIdx)?.get(teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx)))
       return codes ? codes.includes(code) : false
     }
 

--- a/apps/scoresheet/src/scoring/greyedOut.ts
+++ b/apps/scoresheet/src/scoring/greyedOut.ts
@@ -7,13 +7,10 @@ import {
   isResolved,
   findErrorSeat,
 } from './helpers'
+import { type TeamIdx, type TeamSeat, toTeamIdx, toSeatIdx, teamSeatKey } from '../types/indices'
 
 /**
  * Compute which cells are greyed out (disabled).
- *
- * `disabled` contains two key formats:
- * - "teamIdx:colIdx" — team-level greying (question done, toss-up, OT ineligibility)
- * - "teamIdx:seatIdx:colIdx" — seat-level greying (seat bonus mode)
  *
  * Three kinds of greying:
  * - "Question done": when a question has an answer (C/E/B/MB), all teams
@@ -25,13 +22,19 @@ import {
  *   are greyed out (only the seat matching the last error can answer).
  *
  * Fouls don't end a question — it's re-asked.
+ *
+ * Output is per-column nested: `disabledTeams[col]`, `tossedUp[col]`, etc.
+ * Lookups by colIdx are O(1) without scanning a flat composite-key set.
  */
 export interface GreyedOutResult {
-  disabled: Set<string>
-  /** Teams that can't jump on a column due to toss-up/error chain: Set of "teamIdx:colIdx" */
-  tossedUp: Set<string>
-  /** Quizzers who fouled on a question and can't answer sub-parts: Set of "teamIdx:seatIdx:colIdx" */
-  fouledQuizzers: Set<string>
+  /** Per column: teams disabled at the team level (question done, toss-up, OT-ineligible). */
+  disabledTeams: Set<TeamIdx>[]
+  /** Per column: (team, seat) pairs disabled at the seat level (seat-bonus mode). */
+  disabledSeats: Set<TeamSeat>[]
+  /** Per column: teams currently tossed up on this column (carry-forward chain). */
+  tossedUp: Set<TeamIdx>[]
+  /** Per column: (team, seat) pairs that fouled and can't answer this sub-part. */
+  fouledQuizzers: Set<TeamSeat>[]
   /** Per-column game-logic status: Pending, Errored, Resolved, or Skipped */
   colStatuses: ColStatus[]
 }
@@ -42,7 +45,8 @@ export function computeGreyedOut(
   otIneligibility?: Map<number, Set<number>>,
   bonusRule: BonusRule = BonusRule.Seat,
 ): GreyedOutResult {
-  const disabled = new Set<string>()
+  const disabledTeams: Set<TeamIdx>[] = cols.map(() => new Set<TeamIdx>())
+  const disabledSeats: Set<TeamSeat>[] = cols.map(() => new Set<TeamSeat>())
   const colStatuses: ColStatus[] = cols.map(() => ColStatus.Pending)
   const teamCount = cellData.length
   const keyToIdx = buildKeyToIdx(cols)
@@ -56,7 +60,7 @@ export function computeGreyedOut(
 
   function greyAllTeams(colIdx: number) {
     for (let teamIdx = 0; teamIdx < teamCount; teamIdx++) {
-      disabled.add(`${teamIdx}:${colIdx}`)
+      disabledTeams[colIdx]!.add(toTeamIdx(teamIdx))
     }
   }
 
@@ -73,7 +77,7 @@ export function computeGreyedOut(
   // Track which teams are tossed-up (can't jump) per column due to error chain.
   // This is separate from "question is done" greying — only toss-up greying
   // carries forward.
-  const tossedUp: Set<string>[] = cols.map(() => new Set<string>())
+  const tossedUp: Set<TeamIdx>[] = cols.map(() => new Set<TeamIdx>())
   // For seat bonus: the seat of the most recent error feeding into each column
   const lastErrorSeat: (number | undefined)[] = cols.map(() => undefined)
 
@@ -86,7 +90,7 @@ export function computeGreyedOut(
   if (otIneligibility) {
     for (const [colIdx, ineligible] of otIneligibility) {
       for (const teamIdx of ineligible) {
-        tossedUp[colIdx]!.add(`${teamIdx}`)
+        tossedUp[colIdx]!.add(toTeamIdx(teamIdx))
       }
     }
   }
@@ -133,21 +137,22 @@ export function computeGreyedOut(
     }
 
     // 4. Toss-up greying: teams in tossedUp set are greyed on this column
-    for (const teamIdxStr of tossedUp[colIdx]!) {
-      disabled.add(`${teamIdxStr}:${colIdx}`)
+    for (const teamIdx of tossedUp[colIdx]!) {
+      disabledTeams[colIdx]!.add(teamIdx)
     }
 
     // 4b. Seat bonus greying: on bonus columns, grey non-matching seats on the bonus team
     if (bonusRule === BonusRule.Seat && lastErrorSeat[colIdx] !== undefined) {
       const tossedHere = tossedUp[colIdx]!
       for (let teamIdx = 0; teamIdx < teamCount; teamIdx++) {
-        if (tossedHere.has(`${teamIdx}`)) continue
+        const branded = toTeamIdx(teamIdx)
+        if (tossedHere.has(branded)) continue
         // Check if every OTHER team is tossed (= bonus for this team)
         if (tossedHere.size === teamCount - 1) {
           const seatCount = cellData[teamIdx]!.length
           for (let seatIdx = 0; seatIdx < seatCount; seatIdx++) {
             if (seatIdx !== lastErrorSeat[colIdx]) {
-              disabled.add(`${teamIdx}:${seatIdx}:${colIdx}`)
+              disabledSeats[colIdx]!.add(teamSeatKey(branded, toSeatIdx(seatIdx)))
             }
           }
         }
@@ -158,16 +163,17 @@ export function computeGreyedOut(
     // Only errors cause toss-ups — not B/MB
     if (colStatuses[colIdx] === ColStatus.Errored) {
       // Determine which teams would be tossed on the next column
-      const wouldBeTossed: number[] = []
+      const wouldBeTossed: TeamIdx[] = []
       let newErrorSeat: number | undefined
       for (let teamIdx = 0; teamIdx < teamCount; teamIdx++) {
+        const branded = toTeamIdx(teamIdx)
         if (hasValue(teamIdx, colIdx, CellValue.Error)) {
-          wouldBeTossed.push(teamIdx)
+          wouldBeTossed.push(branded)
           // Track the seat that caused this error (for seat bonus)
           const seat = findErrorSeat(cellData, teamIdx, colIdx)
           if (seat !== undefined) newErrorSeat = seat
-        } else if (tossedUp[colIdx]!.has(`${teamIdx}`) && !hasAnswer(teamIdx, colIdx)) {
-          wouldBeTossed.push(teamIdx)
+        } else if (tossedUp[colIdx]!.has(branded) && !hasAnswer(teamIdx, colIdx)) {
+          wouldBeTossed.push(branded)
         }
       }
 
@@ -188,7 +194,7 @@ export function computeGreyedOut(
 
       if (nq !== undefined) {
         for (const teamIdx of wouldBeTossed) {
-          tossedUp[nq]!.add(`${teamIdx}`)
+          tossedUp[nq]!.add(teamIdx)
         }
         // Propagate error seat: new error replaces, otherwise carry existing
         lastErrorSeat[nq] = newErrorSeat ?? lastErrorSeat[colIdx]
@@ -196,20 +202,9 @@ export function computeGreyedOut(
     }
   }
 
-  // Two views of the same data: the per-column `tossedUp` array drives the
-  // forward propagation above, while this flat Set lets downstream callers
-  // (validation, isBonusForTeam, the composable) check arbitrary (team, col)
-  // pairs in O(1) without needing the colIdx-indexed structure.
-  const tossedUpSet = new Set<string>()
-  for (let colIdx = 0; colIdx < cols.length; colIdx++) {
-    for (const teamIdxStr of tossedUp[colIdx]!) {
-      tossedUpSet.add(`${teamIdxStr}:${colIdx}`)
-    }
-  }
-
   // Build fouledQuizzers: quizzers who fouled on a numbered question
   // can't answer subsequent sub-parts (A/B) of the same question
-  const fouledQuizzers = new Set<string>()
+  const fouledQuizzers: Set<TeamSeat>[] = cols.map(() => new Set<TeamSeat>())
   for (let colIdx = 0; colIdx < cols.length; colIdx++) {
     const col = cols[colIdx]!
     if (!col.isAB) continue
@@ -219,17 +214,18 @@ export function computeGreyedOut(
       for (let seatIdx = 0; seatIdx < team.length; seatIdx++) {
         if (team[seatIdx]![colIdx] !== CellValue.Foul) continue
 
+        const key = teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx))
         // Foul on Normal → grey this quizzer on A and B
         if (col.type === QuestionType.Normal) {
           const aColIdx = keyToIdx.get(`${col.number}A`)
           const bColIdx = keyToIdx.get(`${col.number}B`)
-          if (aColIdx !== undefined) fouledQuizzers.add(`${teamIdx}:${seatIdx}:${aColIdx}`)
-          if (bColIdx !== undefined) fouledQuizzers.add(`${teamIdx}:${seatIdx}:${bColIdx}`)
+          if (aColIdx !== undefined) fouledQuizzers[aColIdx]!.add(key)
+          if (bColIdx !== undefined) fouledQuizzers[bColIdx]!.add(key)
         }
         // Foul on A → grey this quizzer on B
         if (col.type === QuestionType.A) {
           const bColIdx = keyToIdx.get(`${col.number}B`)
-          if (bColIdx !== undefined) fouledQuizzers.add(`${teamIdx}:${seatIdx}:${bColIdx}`)
+          if (bColIdx !== undefined) fouledQuizzers[bColIdx]!.add(key)
         }
         // Foul on B → nothing further
       }
@@ -240,10 +236,10 @@ export function computeGreyedOut(
   if (otIneligibility) {
     for (const [colIdx, ineligible] of otIneligibility) {
       for (const teamIdx of ineligible) {
-        disabled.add(`${teamIdx}:${colIdx}`)
+        disabledTeams[colIdx]!.add(toTeamIdx(teamIdx))
       }
     }
   }
 
-  return { disabled, tossedUp: tossedUpSet, fouledQuizzers, colStatuses }
+  return { disabledTeams, disabledSeats, tossedUp, fouledQuizzers, colStatuses }
 }

--- a/apps/scoresheet/src/scoring/helpers.ts
+++ b/apps/scoresheet/src/scoring/helpers.ts
@@ -1,5 +1,5 @@
 import { CellValue } from '../types/scoresheet'
-import type { TeamIdx } from '../types/indices'
+import { toTeamIdx, type TeamIdx } from '../types/indices'
 
 /**
  * Shared helper functions for querying the positional cell grid.
@@ -108,7 +108,7 @@ export function isBonusSituation(
   if (!col) return false
   let tossedTeams = 0
   for (let otherIdx = 0; otherIdx < teamCount; otherIdx++) {
-    if (otherIdx !== teamIdx && col.has(otherIdx as TeamIdx)) tossedTeams++
+    if (otherIdx !== teamIdx && col.has(toTeamIdx(otherIdx))) tossedTeams++
   }
   return tossedTeams === teamCount - 1
 }

--- a/apps/scoresheet/src/scoring/helpers.ts
+++ b/apps/scoresheet/src/scoring/helpers.ts
@@ -1,4 +1,5 @@
 import { CellValue } from '../types/scoresheet'
+import type { TeamIdx } from '../types/indices'
 
 /**
  * Shared helper functions for querying the positional cell grid.
@@ -94,16 +95,20 @@ export function colHasAnyContent(cellData: CellValue[][][], colIdx: number): boo
 /**
  * Whether a column is a bonus situation for a given team.
  * A bonus situation means every *other* team is tossed up on that column.
+ *
+ * Takes the per-column nested array from `GreyedOutResult.tossedUp`.
  */
 export function isBonusSituation(
-  tossedUp: Set<string>,
+  tossedUp: Set<TeamIdx>[],
   teamIdx: number,
   colIdx: number,
   teamCount: number,
 ): boolean {
+  const col = tossedUp[colIdx]
+  if (!col) return false
   let tossedTeams = 0
   for (let otherIdx = 0; otherIdx < teamCount; otherIdx++) {
-    if (otherIdx !== teamIdx && tossedUp.has(`${otherIdx}:${colIdx}`)) tossedTeams++
+    if (otherIdx !== teamIdx && col.has(otherIdx as TeamIdx)) tossedTeams++
   }
   return tossedTeams === teamCount - 1
 }

--- a/apps/scoresheet/src/scoring/validation.ts
+++ b/apps/scoresheet/src/scoring/validation.ts
@@ -1,7 +1,7 @@
 import { CellValue, QuestionType, type Column } from '../types/scoresheet'
 import type { GreyedOutResult } from './greyedOut'
 import { ColStatus, isAnswer, isBonusSituation } from './helpers'
-import { toSeatIdx, toTeamIdx, teamSeatKey } from '../types/indices'
+import { toSeatIdx, toTeamIdx, teamSeatKey, type TeamSeat } from '../types/indices'
 
 export enum ValidationCode {
   /** Answer by a quizzer with no name (empty seat) */
@@ -57,8 +57,15 @@ export function validationMessage(code: ValidationCode): string {
 }
 
 /**
- * Validate all cells and return a map of "teamIdx:seatIdx:colIdx" → ValidationCode[].
- * Only cells with problems appear in the map.
+ * Per-column nested map of validation errors. Outer key is `colIdx`, inner is the
+ * branded (team, seat) composite. Only cells with problems appear in the map —
+ * a column with no errors has no entry in the outer map.
+ */
+export type ValidationErrors = Map<number, Map<TeamSeat, ValidationCode[]>>
+
+/**
+ * Validate all cells and return a per-column map of (team, seat) → codes.
+ * Only cells with problems appear in the result.
  */
 export function validateCells(
   cellData: CellValue[][][],
@@ -68,17 +75,22 @@ export function validateCells(
   otEligibleTeams?: Set<number>,
   orphanedColumns?: Set<number>,
   emptySeats?: Set<string>,
-): Map<string, ValidationCode[]> {
-  const errors = new Map<string, ValidationCode[]>()
+): ValidationErrors {
+  const errors: ValidationErrors = new Map()
   const teamCount = cellData.length
 
   function addError(teamIdx: number, seatIdx: number, colIdx: number, code: ValidationCode) {
-    const key = `${teamIdx}:${seatIdx}:${colIdx}`
-    const existing = errors.get(key)
+    let col = errors.get(colIdx)
+    if (!col) {
+      col = new Map()
+      errors.set(colIdx, col)
+    }
+    const key = teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx))
+    const existing = col.get(key)
     if (existing) {
       existing.push(code)
     } else {
-      errors.set(key, [code])
+      col.set(key, [code])
     }
   }
 

--- a/apps/scoresheet/src/scoring/validation.ts
+++ b/apps/scoresheet/src/scoring/validation.ts
@@ -1,6 +1,7 @@
 import { CellValue, QuestionType, type Column } from '../types/scoresheet'
 import type { GreyedOutResult } from './greyedOut'
 import { ColStatus, isAnswer, isBonusSituation } from './helpers'
+import { toSeatIdx, toTeamIdx, teamSeatKey } from '../types/indices'
 
 export enum ValidationCode {
   /** Answer by a quizzer with no name (empty seat) */
@@ -174,12 +175,16 @@ export function validateCells(
         }
 
         // --- Fouled on question (can't answer sub-parts) ---
-        if (greyResult.fouledQuizzers.has(`${teamIdx}:${seatIdx}:${colIdx}`)) {
+        if (
+          greyResult.fouledQuizzers[colIdx]?.has(
+            teamSeatKey(toTeamIdx(teamIdx), toSeatIdx(seatIdx)),
+          )
+        ) {
           addError(teamIdx, seatIdx, colIdx, ValidationCode.FouledOnQuestion)
         }
 
         // --- Tossed up / wrong team bonus ---
-        if (isAnswer(v) && greyResult.tossedUp.has(`${teamIdx}:${colIdx}`)) {
+        if (isAnswer(v) && greyResult.tossedUp[colIdx]?.has(toTeamIdx(teamIdx))) {
           // Check if some other team has a bonus situation on this column
           let isBonusForOther = false
           for (let otherTeamIdx = 0; otherTeamIdx < teamCount; otherTeamIdx++) {

--- a/apps/scoresheet/src/types/indices.ts
+++ b/apps/scoresheet/src/types/indices.ts
@@ -35,6 +35,7 @@ declare const TeamIdxBrand: unique symbol
 declare const SeatIdxBrand: unique symbol
 declare const ColIdxBrand: unique symbol
 declare const QuizzerIdBrand: unique symbol
+declare const TeamSeatBrand: unique symbol
 
 /** 0-based index into the teams array. Immutable for the life of a quiz. */
 export type TeamIdx = number & { readonly [TeamIdxBrand]: void }
@@ -44,6 +45,11 @@ export type SeatIdx = number & { readonly [SeatIdxBrand]: void }
 export type ColIdx = number & { readonly [ColIdxBrand]: void }
 /** Stable numeric identity of a quizzer. Immutable — survives seat changes. */
 export type QuizzerId = number & { readonly [QuizzerIdBrand]: void }
+/**
+ * Composite key for the (team, seat) pair, used as a Set/Map key where a single
+ * scalar is required. Built only via `teamSeatKey()` so the brand stays honest.
+ */
+export type TeamSeat = string & { readonly [TeamSeatBrand]: void }
 
 /** Cast a plain number to a TeamIdx. Use at boundaries where 0-based semantics are known. */
 export const toTeamIdx = (n: number): TeamIdx => n as TeamIdx
@@ -53,3 +59,5 @@ export const toSeatIdx = (n: number): SeatIdx => n as SeatIdx
 export const toColIdx = (n: number): ColIdx => n as ColIdx
 /** Cast a plain number to a QuizzerId. Use when reading an id from the store or a quiz file. */
 export const toQuizzerId = (n: number): QuizzerId => n as QuizzerId
+/** Build the composite key for a (team, seat) pair. */
+export const teamSeatKey = (t: TeamIdx, s: SeatIdx): TeamSeat => `${t}:${s}` as TeamSeat


### PR DESCRIPTION
## Summary

Replaces the flat string-keyed sets/maps in `apps/scoresheet/src/scoring/greyedOut.ts` and `apps/scoresheet/src/scoring/validation.ts` with per-column nested structures using branded keys.

### Before

`GreyedOutResult` exposed three `Set<string>` collections with mixed key formats (`"team:col"` vs `"team:seat:col"`), and `validateCells` returned `Map<string, ValidationCode[]>` keyed by `"team:seat:col"`. Two costs:

1. **Brand erasure** — the codebase has `TeamIdx` / `SeatIdx` / `ColIdx` brands but template-literal keys threw them away at the seam.
2. **Hot-path scans** — `useScoresheet.ts` consumers fell back to `key.endsWith(\`:${colIdx}\`)` and `key.startsWith(\`${teamIdx}:\`)` because flat maps can't be queried by one index. Worst: `columnHasErrors` × 21 columns per render iterating the whole error set.

### After

```ts
// GreyedOutResult — was 3 Set<string>, now 4 per-column branded arrays
disabledTeams: Set<TeamIdx>[]      // [colIdx] — team-level greying
disabledSeats: Set<TeamSeat>[]     // [colIdx] — seat-bonus greying
tossedUp:      Set<TeamIdx>[]      // [colIdx] — was already this shape internally
fouledQuizzers: Set<TeamSeat>[]    // [colIdx]

// ValidationErrors — was Map<string, code[]>, now nested
type ValidationErrors = Map<number, Map<TeamSeat, ValidationCode[]>>
```

New `TeamSeat` brand + `teamSeatKey(t, s)` helper in `apps/scoresheet/src/types/indices.ts` for the unavoidable composite case.

### Hot-path wins (`useScoresheet.ts`)

| Function | Before | After |
|---|---|---|
| `columnHasErrors(c)` | full keys-scan with `endsWith` | `errs.get(c)?.size > 0` — O(1) |
| `columnValidationMessages(c)` | full scan + filter | iterate one column's values |
| `noJumpHasConflict(c)` | full keys-scan with `endsWith` | iterate one column's values |
| `isInvalid(t,s,c)` / `cellValidationMessages` | flat key lookup | nested key lookup |
| `quizzerHasErrors` / `quizzerValidationMessages` | `startsWith` scan | iterate columns × `Map.has(teamSeatKey)` |
| `teamHasErrors` / `teamValidationMessages` | `startsWith` scan | iterate seats × columns × `Map.has(teamSeatKey)` |

The brand stays honest end-to-end — no `\`${t}:${s}:${c}\`” template literals at any consumer.

## Commits

1. **`add TeamSeat brand`** — scaffolding-only commit (new branded type + helper).
2. **`per-column GreyedOutResult`** — restructure greyedOut + helpers.isBonusSituation + validation.ts call sites + useScoresheet's isGreyedOut/isFouledOnQuestion + greyedOut/helpers tests.
3. **`per-column ValidationErrors`** — restructure validateCells return type + 7 useScoresheet consumers + Scoresheet.vue's allValidationMessages aggregation + validation tests.
4. **`keep TeamSeat brand honest`** — simplify-pass follow-up: replaces a brand-defeating `(key as string).startsWith()` workaround in `teamHasErrors`/`teamValidationMessages` with explicit seat iteration. Caught by all three review agents.

## Test plan

- [x] `pnpm type-check` clean across all packages
- [x] `pnpm test:unit` — all 673 tests pass on every commit (40+ greyedOut, 40+ validation, 20+ helpers, plus full integration tests)
- [x] Three-agent simplify-pass review (reuse / quality / efficiency) — caught the brand-violation in commit 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>— If this PR was useful, react with 👍. Otherwise 👎.</sub>