### PR TITLE
docs: add scheduling design doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,5 +115,6 @@ When working on scoring logic, rules, or architecture, read the relevant file fi
 * `docs/scoring-rules-explained.md` — cell types, point values,
   toss-up/bonus/A-B/foul/overtime/placement
 * `docs/rules.md` — full rules from official pdf
+* `docs/scheduling.md` — meet scheduling design: prelims, stats break, elims, data model, builder UX
 * `docs/architecture.md` — data flow, layer responsibilities, key design decisions
 * `docs/auth-proposal.md` — Phase 4 architecture, API stack, security, data model

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ docs/
   scoring-rules-explained.md     # Cell types, point values, all scoring rules
   architecture.md                # Monorepo structure, API stack, scoresheet internals
   rules.md                       # Full rules from the official rulebook PDF
+  scheduling.md                  # Meet scheduling: prelims, stats break, elims, data model
   auth.md                        # Auth implementation, OAuth, Tauri, security
   roles-and-access.md            # Meet roles, codes, join flow, rotation policy
   data-model.md                  # Full schema, memberships, quizzer identity

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,12 +10,17 @@ pointer in suggested build order. See `CHANGELOG.md` for what has shipped, and t
 1. [#7 Results submission](https://github.com/TommyAmberson/qzr-sheet/issues/7) — officials submit
    completed scoresheets to the server; standalone, foundational for stats and schedule linkage
 2. [#9 Schedule — generation, management, and views](https://github.com/TommyAmberson/qzr-sheet/issues/9)
-   — round-robin scheduling, broken into sub-issues:
-   * [#12 Schedule generation + schema](https://github.com/TommyAmberson/qzr-sheet/issues/12)
+   — admin-driven schedule builder per [docs/scheduling.md](./docs/scheduling.md), broken into
+   sub-issues:
+   * [#12 Schedule schema + rooms/slots CRUD](https://github.com/TommyAmberson/qzr-sheet/issues/12)
      (foundational)
-   * [#13 Schedule view + publish](https://github.com/TommyAmberson/qzr-sheet/issues/13)
-   * [#14 Schedule manual editing](https://github.com/TommyAmberson/qzr-sheet/issues/14)
-   * [#15 Schedule re-generation](https://github.com/TommyAmberson/qzr-sheet/issues/15)
+   * [#13 Schedule view (read-only)](https://github.com/TommyAmberson/qzr-sheet/issues/13)
+   * [#14 Schedule editor (direct manipulation)](https://github.com/TommyAmberson/qzr-sheet/issues/14)
+   * Prelim draw utility (new issue, coming)
+   * Schedule rule engine (new issue, coming)
+   * [#15 Late-team handling](https://github.com/TommyAmberson/qzr-sheet/issues/15)
+   * Post-stats-break consolation marking (new issue, coming) — blocked by #8
+   * Elim bracket epic (new issue, coming) — blocked by #12, #14
    * [#16 Schedule result linkage](https://github.com/TommyAmberson/qzr-sheet/issues/16) — blocked
      by #7, #12
 3. [#6 Load teams from schedule](https://github.com/TommyAmberson/qzr-sheet/issues/6) — blocked by

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,0 +1,349 @@
+# Schedule design
+
+This document defines the domain model for meet scheduling. A qzr meet has two materially different
+scheduling phases (prelims and elims) with a pivot step in between. The official rules
+(`docs/rules.md` §"Rules for Tournament" and §"Tournament Brackets") already specify the preliminary
+pairings, elimination brackets, and intermediate quiz structures, and this doc is the design layer
+that sits above those rules.
+
+**Source of truth for rules**: `docs/rules.md`. If `rules.md` is missing something from the official
+PDF, `rules.md` gets corrected first and this doc may need re-alignment.
+
+**Philosophy**: the schedule feature is an **admin-driven builder**, not a generator. The admin
+assembles the schedule in a grid editor, and the system offers assists — draw helpers, drag-and-drop
+swaps, conflict warnings, quick fills — that make building fast without taking the wheel. When the
+admin clicks "Generate prelims", the system produces a first draft that the admin is expected to
+tweak; rearranging rounds, swapping teams, and adding events all remain first-class actions. The
+admin should feel like they built the schedule with help, not like they approved a computed result.
+
+Planning and work tracking live in GitHub issues (see `#9` Schedule epic and its sub-issues). This
+doc is the stable design reference those issues link back to.
+
+## 1. Vocabulary
+
+| Term                           | Meaning                                                                                                                                                                                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Meet**                       | A named multi-day event. One `quiz_meets` row.                                                                                                                                                                                              |
+| **Division**                   | A competitive tier inside the meet. Set once at meet creation and never changes for a team. Today: Divisions 1, 2, 3. Stored as JSON on `quiz_meets.divisions`; teams carry a `division` string.                                            |
+| **Team**                       | A church-owned roster for one meet + division. `teams` row. Has `consolation: boolean` (already in schema) — always `false` during prelims; set post-stats-break to route a team into the consolation elim bracket. Division never changes. |
+| **Room**                       | A physical location where quizzes run in parallel. Named ("Room 1"–"Room 5"). New concept — not in schema today.                                                                                                                            |
+| **Round**                      | An ordinal grouping of quizzes that run simultaneously across rooms in the same time slot.                                                                                                                                                  |
+| **Slot**                       | A wall-clock time for a round. Not 1:1 with round — non-quiz events also occupy slots.                                                                                                                                                      |
+| **Quiz**                       | Three teams competing at one `(round, room)` pair. Labeled `Div 1 Quiz 1`, `Div 2 Quiz A`, `Div 2 Quiz X`, etc.                                                                                                                             |
+| **Prelim** (qualifier)         | Round-robin within a division. Every team plays exactly 3 prelim quizzes. Pairings are lookup tables (`rules.md` §"Preliminary Round Brackets", 4–21 teams).                                                                                |
+| **Stats break**                | Transition. Admin reviews standings and picks an elim structure based on team count.                                                                                                                                                        |
+| **Elim** (elimination round)   | Bracketed post-prelim phase. Teams identified by seed (`1st Quiz A`), not name, until results resolve placements.                                                                                                                           |
+| **XYZ quizzes** (intermediate) | Three 3-team quizzes holding 9 teams ranked 7–15 after prelims. Top 3 join the championship bracket; bottom 6 go to consolation (positions 10–15). `rules.md` §2.a.i–iii.                                                                   |
+| **XXYYZZ quizzes**             | Three 3-team quizzes for teams 16–24 in meets with > 24 teams. `rules.md` §2.a.iv–vi.                                                                                                                                                       |
+| **Championship bracket**       | 9-team elim bracket for the top 9 teams (or top 6 + top 3 of XYZ). Three named templates: Bracket A, B, C. `rules.md` §"Elimination Round Brackets".                                                                                        |
+| **Consolation bracket**        | Secondary 9-team bracket for positions 10–18 in meets with > 24 teams. Uses the same templates.                                                                                                                                             |
+| **Championship quizzes**       | 3–5 end-of-bracket quizzes with "win twice" semantics. `rules.md` §3.                                                                                                                                                                       |
+| **Event**                      | Non-quiz item on the schedule — Breakfast, Stats Break, Worship, etc. Occupies a slot, no room/teams.                                                                                                                                       |
+
+## 2. How a meet actually runs
+
+Based on a sample Quiz Meet Finals 2023 schedule:
+
+```
+Friday
+  7:00  Registration (event)
+  7:30  Assembly (event)
+  8:00  PRELIMS ROUND 1 — Div 1 Quiz 1 in Room 1, Div 2 Quizzes 1–4 in Rooms 2–5
+  8:25  PRELIMS ROUND 2
+   …
+  9:40  PRELIMS ROUND 6 (Div 1 finishes; Div 2 continues)
+Saturday
+  8:00  Breakfast (event)
+  9:00  PRELIMS ROUND 7–8
+  9:50  Stats Break (event)
+ 10:30  ELIMS — Div 1 Quiz A/B, Div 2 Quiz X/Y (intermediates)
+ 11:20  ELIMS continue
+ 12:45  ELIMS — lettered quizzes (Div 1 Quiz C, Div 2 Quiz C, Div 2C Quiz N…)
+   …
+  3:15  Div 2C Finals
+  3:45  Div 2 Finals
+  4:15  Div 1 Finals
+  5:00+ non-quiz events (Supper, Worship, Awards)
+```
+
+Observations that shape the data model:
+
+1. Rooms persist across both phases. Room 1 runs Div 1 quizzes in prelims and Div 1 elims in finals.
+   The room pool is a meet-level resource.
+2. Multiple divisions run in parallel in the same slot. Each division owns a subset of rooms per
+   round.
+3. Slot durations vary. Most prelim slots are 25 min; events take variable time. Admin controls slot
+   duration per row.
+4. Different divisions have different prelim round counts. Division 1 finishes earlier than Division
+   2 because it has fewer teams.
+5. Seeds become meaningful at the stats break. Prelim points → standings → bracket assignments.
+6. Elim quizzes reference _other_ quizzes, not teams. `Div 2 Quiz D` = "2nd Quiz A, 3rd Quiz A, 1st
+   Quiz B". Teams substitute in as prior quizzes finish.
+7. XYZ intermediates take their seeds from prelim standings (`rules.md` §2.a.i–iii).
+8. Consolation is a separate elim bracket _inside the same division_, not a separate division. Team
+   division never changes. `consolation: boolean` on a team is the bracket-lane marker.
+9. Consolation and XYZ are both conditional on team count per `rules.md` §2.a.
+
+## 3. Rules and invariants
+
+Hard rules are enforced by the builder; soft rules produce warnings only.
+
+**Prelim hard rules**:
+
+1. 3 teams per quiz. Always.
+2. 3 quizzes per team. A division with `q` teams has exactly `q` prelim quizzes.
+3. No team in two quizzes in the same round.
+4. No room hosts two quizzes in the same round.
+5. Divisions are fixed — no moving teams between divisions.
+
+**Prelim soft rules** (warn, don't block):
+
+1. Opponent variety (may be unavoidable for 4–6 team divisions — `rules.md` §"Preliminary Round
+   Brackets" notes same-opponent repeats in small fields).
+2. Room variety — a team shouldn't be stuck in the same room for all 3 of its quizzes.
+3. Round variety — a team shouldn't always open or always close.
+4. Balanced division-room allocation per round.
+
+**Prelim count invariant**:
+
+With 3 teams per quiz and 3 quizzes per team, `# quizzes == # teams`. The builder surfaces this when
+the admin picks room count and round count.
+
+**Elim rules**: deferred to the elim epic; `rules.md` §"Elimination Round Brackets" is the source of
+truth.
+
+**Event rules**:
+
+* Events occupy a slot but no rooms or quizzes.
+* Events can be inserted between quiz rounds.
+* Events don't enforce the default slot duration.
+
+## 4. The prelim draw (utility, not the main UX)
+
+**The draw is a lookup, not a search.** `rules.md` §"Preliminary Round Brackets" spells out pairings
+for 4–21 teams as a fixed table. Example for 9 teams:
+
+```
+Quizzes: 1. ABC  2. DEF  3. GHI  4. ADG  5. BEH  6. CDH  7. AEI  8. BFG  9. CFI
+```
+
+The helper substitutes teams A–U into the slots. Team counts > 21 are out of scope for the built-in
+helper; the admin builds those manually in the editor.
+
+**Inputs**: ordered team list for the division, target rooms/rounds.
+
+**Output**: `q` quizzes each with `teamIds`, plus suggested `(round, room)` assignments from a
+second `autoSlot` step.
+
+**Sub-utilities** (each individually invocable):
+
+1. **Composition** — `rules.md` lookup, returning `[team, team, team][]`.
+2. **Slot** — fit any list of quizzes into `(round, room)` without hard-rule conflicts.
+
+Divisions are independent draws. Admin allocates rooms to divisions per round. Late teams are
+handled via the editor: add team to division, then place manually or with a "Suggest placement"
+helper. Regenerate stays available as a destructive button.
+
+## 5. Stats break — the pivot
+
+Per `rules.md` §2.a, the transition is deterministic once team count is known. Per division, the
+admin:
+
+1. Reviews prelim standings (sum of 3 prelim quiz scores per team, per `rules.md` §1.a).
+   Tiebreakers: quiz score at end of question 20 (§1.a.iv).
+2. Looks up the tournament shape for team count:
+
+   | Team count | Structure                                                                                                |
+   | ---------- | -------------------------------------------------------------------------------------------------------- |
+   | ≤ 9        | Single championship bracket, no XYZ, no consolation.                                                     |
+   | 10–14      | Top 9 → championship bracket. Teams 10+ dropped.                                                         |
+   | 15–20      | Top 6 → championship (auto-qualify). Teams 7–15 → XYZ. Teams 16+ dropped.                                |
+   | 21–24      | Same as 15–20.                                                                                           |
+   | > 24       | Top 6 → championship. Teams 7–15 → XYZ. Teams 16–24 → XXYYZZ. Consolation final-9 holds positions 10–18. |
+
+3. Flips `teams.consolation=true` for teams headed to consolation. For the "> 24 teams" shape,
+   consolation membership is finalised _after_ XYZ and XXYYZZ resolve, not at the break itself.
+4. Generates the elim schedule using the selected bracket template (A / B / C).
+
+`teams.consolation` is the authoritative lane marker, written at stats break and updated by the elim
+result pipeline. A team's `division` is never rewritten.
+
+## 6. Elims (elimination round)
+
+Elim quizzes hold three **seed references** rather than teams. The structure is not a search —
+`rules.md` spells out every bracket template.
+
+**Intermediate quizzes**: XYZ (`rules.md` §2.a.i–iii) and XXYYZZ (§2.a.iv–vi) with their hard-coded
+compositions.
+
+**Championship brackets**: A (winner-move-up, quizzes A–I), B (double-elim, quizzes A–L), C
+(combination, quizzes A–M). Admin picks one per division at stats break.
+
+**Championship quizzes**: 3–5 quiz series with "win twice" termination (`rules.md` §3). Championship
+quizzes after Quiz H/I/etc. are added on demand as results come in.
+
+**Consolation bracket**: 9-team bracket using one of A/B/C, populated from positions 10–18. Only
+present in meets > 24 teams.
+
+**Seed-reference formats**:
+
+| Format                                     | Meaning                                      |
+| ------------------------------------------ | -------------------------------------------- |
+| `prelimSeed(n)`                            | Team ranked `n` from prelim standings        |
+| `place(quizId, p)`                         | Team that placed `p` in a given bracket quiz |
+| `xyzTop3(rank)` / `xyzBottom6(rank)`       | XYZ advancers / fall-throughs                |
+| `xxyyzzTop3(rank)` / `xxyyzzBottom6(rank)` | XXYYZZ equivalents                           |
+| `winner(quizId)` / `loser(quizId)`         | Convenience for championship series          |
+| `tiebreaker(candidates)`                   | Unresolved tied teams (`rules.md` §2.b)      |
+
+## 7. Data model
+
+```ts
+// A named physical location within a meet.
+export const meetRooms = sqliteTable('meet_rooms', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  meetId: integer('meet_id')
+    .notNull()
+    .references(() => quizMeets.id, { onDelete: 'cascade' }),
+  name: text('name').notNull(),
+  sortOrder: integer('sort_order').notNull(),
+})
+
+// A row in the left-hand time column. May hold quizzes or a non-quiz event.
+export const meetSlots = sqliteTable('meet_slots', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  meetId: integer('meet_id')
+    .notNull()
+    .references(() => quizMeets.id, { onDelete: 'cascade' }),
+  startAt: integer('start_at', { mode: 'timestamp' }).notNull(),
+  durationMinutes: integer('duration_minutes').notNull(),
+  kind: text('kind', { enum: ['quiz', 'event'] }).notNull(),
+  eventLabel: text('event_label'),
+  sortOrder: integer('sort_order').notNull(),
+})
+
+// One 3-team quiz at (slot, room). Prelim or elim.
+export const scheduledQuizzes = sqliteTable('scheduled_quizzes', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  meetId: integer('meet_id')
+    .notNull()
+    .references(() => quizMeets.id, { onDelete: 'cascade' }),
+  slotId: integer('slot_id')
+    .notNull()
+    .references(() => meetSlots.id, { onDelete: 'cascade' }),
+  roomId: integer('room_id')
+    .notNull()
+    .references(() => meetRooms.id, { onDelete: 'cascade' }),
+  division: text('division').notNull(),
+  phase: text('phase', { enum: ['prelim', 'elim'] }).notNull(),
+  lane: text('lane', { enum: ['main', 'consolation', 'intermediate'] }),
+  label: text('label').notNull(),
+  bracketLabel: text('bracket_label'),
+  publishedAt: integer('published_at', { mode: 'timestamp' }),
+})
+
+// Three seats per quiz. Either teamId (prelim, or elim once resolved) or seedRef (elim, unresolved).
+export const scheduledQuizSeats = sqliteTable('scheduled_quiz_seats', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  quizId: integer('quiz_id')
+    .notNull()
+    .references(() => scheduledQuizzes.id, { onDelete: 'cascade' }),
+  seatNumber: integer('seat_number').notNull(),
+  teamId: integer('team_id').references(() => teams.id, { onDelete: 'set null' }),
+  seedRef: text('seed_ref'),
+})
+```
+
+**Notes**:
+
+* `scheduled_quizzes` is a single table for both phases; `phase` discriminates. `lane` is only
+  meaningful when `phase='elim'`.
+* Prelim seats fill `teamId` at creation; `seedRef` stays null.
+* Elim seats start with `seedRef`; `teamId` fills in as prior quizzes resolve (issue `#16`).
+* Events live on `meet_slots` with `kind='event'`, no child `scheduled_quizzes`.
+* `teams.division` is immutable. `teams.consolation` starts false, set post-stats-break or post-XYZ.
+
+**First-delivery scope cut**: the initial schema PR ships these tables, but only writes
+`phase='prelim'` rows. The `lane`, `bracketLabel`, and `seedRef` columns exist from day one but stay
+unused until the elim epic.
+
+## 8. UX — the builder (primary experience)
+
+The Schedule tab is a grid editor: y-axis = slots, x-axis = rooms, plus division filter. Each cell
+is a quiz card with three team chips.
+
+**Direct manipulation**:
+
+* Click a team chip → dropdown to pick a different team in the same division.
+* Drag a team chip between quizzes → swap or move.
+* Drag a quiz card between `(round, room)` cells → move the whole quiz.
+* Drag a row header to reorder rounds.
+* Right-click / ellipsis on quiz card → delete, duplicate seats, move to…, convert to event row.
+* Click an empty cell → "Add quiz" popup.
+* Click "+" between rows → "Add event" popup.
+
+**Toolbar assists (not automation)**:
+
+* Draw Prelims (division picker) — first-draft.
+* Auto-slot — assigns `(round, room)` without changing compositions.
+* Balance Rooms/Rounds — reshuffles slot assignments for variety.
+* Fill Empty Seats — suggest a team per-quiz; admin confirms.
+* Find Conflicts — jump to next hard-rule violation.
+* Regenerate (destructive) — wipes and restarts.
+
+**Rule surfacing**:
+
+* Hard violations: red border, blocks save/publish.
+* Soft warnings: yellow dot, hover tooltip.
+* Division status panel: per-division progress summary.
+
+**Publish**: draft (admin-only) vs published (coaches/viewers see it). Published schedules remain
+editable; edits show a "draft changes" marker and don't affect public view until re-published.
+
+## 9. UX flow (end-to-end)
+
+```
+Meet setup
+  1. Admin creates meet, adds divisions, adds rooms.
+  2. Coaches register churches / teams / quizzers.
+
+Prelim build
+  3. Admin opens Schedule tab (empty grid).
+  4. (Optional) clicks "Draw Prelims" for a division → first draft.
+  5. Admin edits: swaps, drags, adds event rows, tweaks slot times.
+  6. Publishes.
+
+Prelim running
+  7. Scoresheet auto-populates teams.
+  8. Officials submit results.
+
+Stats break (per division)
+  9.  Admin reviews Standings.
+  10. Picks elim shape (looks up team count in §5 table).
+  11. Flips `consolation=true` on bottom-M teams.
+
+Elim build
+  12. Admin opens Schedule tab, switches to Elim mode.
+  13. (Optional) clicks "Draw Elims" per division → bracket draft.
+  14. Admin edits seed refs, reorders rounds, adds events.
+  15. Publishes.
+
+Elim running
+  16. XYZ/XXYYZZ resolve → `consolation=true` propagates to remaining teams.
+  17. Results flow in; seed refs resolve to teams.
+  18. Final placements displayed.
+```
+
+## 10. Open questions
+
+1. Is `docs/rules.md` complete vs the official PDF? Flagged as uncertain.
+2. Sample schedules show "Quiz X" and "Quiz Y" only (6 teams), but `rules.md` §2.a specifies XYZ (9
+   teams). Is X+Y (no Z) a variant used for smaller fields?
+3. `new 11` / `new 15` placeholders in sample schedules — confirm naming convention for
+   XYZ-to-consolation transitions.
+4. Championship-series termination: auto-generate Quiz H/I/etc. or admin-added on demand?
+5. Tie-breaker quizzes for positions 6/15/24 (`rules.md` §2.b) — on-demand rows or pre-scheduled?
+6. Late teams during elims — current assumption: prelims only. Confirm.
+7. Bracket auto-advance vs manual confirm when Quiz A's result lands.
+8. Keep both `teams.consolation` and `scheduled_quizzes.lane`, or collapse one into the other?
+   Proposal keeps both.


### PR DESCRIPTION
## Summary

- Adds `docs/scheduling.md` — domain design for meet scheduling: vocabulary, how
  a meet runs, rules/invariants, prelim draw (lookup-table utility), stats
  break, elim structure (XYZ/XXYYZZ + Bracket A/B/C per `rules.md`), data
  model (`meet_rooms`, `meet_slots`, `scheduled_quizzes`, `scheduled_quiz_seats`),
  builder-first UX, and 8 open questions.
- Cross-links added from `README.md` docs index, `CLAUDE.md` Reference Docs,
  and `ROADMAP.md` item 2.
- Refreshed sub-issue list under `#9` in `ROADMAP.md` with renamed
  titles matching the decomposition in the design doc. Four new sub-issues
  (prelim draw utility, rule engine, consolation marking, elim epic) will be
  opened as follow-ups once this lands so they can link the merged doc URL.

Follow-up work (not part of this PR):

- Update bodies of `#9`, `#12`, `#13`, `#14`, `#15`, `#16` to link
  `docs/scheduling.md`.
- Open the four new sub-issues referenced above with `claude-created` +
  `roadmap` labels.
- Backfill `ROADMAP.md` with the new issue numbers.

## Test plan

- [ ] `docs/scheduling.md` renders cleanly on GitHub
- [ ] Cross-links from `README.md` / `CLAUDE.md` / `ROADMAP.md` resolve
- [ ] `rules.md` references (§1.a, §2.a.i–vi, §3, §"Preliminary Round Brackets",
      §"Elimination Round Brackets") all point at real sections
- [ ] No code/tests changed; CI should only run format/lint

_Created by Claude Code_