### PR TITLE
feat(api): schedule data spine + phase control plane

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,7 @@ pointer in suggested build order. See `CHANGELOG.md` for what has shipped, and t
    * [#14 Schedule editor (direct manipulation)](https://github.com/TommyAmberson/qzr-sheet/issues/14)
    * [#39 Prelim draw utility](https://github.com/TommyAmberson/qzr-sheet/issues/39)
    * [#40 Schedule rule engine](https://github.com/TommyAmberson/qzr-sheet/issues/40)
+   * Phase state machine + transition API (new issue, coming) — blocked by #12
    * [#15 Late-team handling](https://github.com/TommyAmberson/qzr-sheet/issues/15)
    * [#41 Post-stats-break consolation marking](https://github.com/TommyAmberson/qzr-sheet/issues/41)
      — blocked by #8

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,14 +1,13 @@
 import { createApiClient, MeetRole } from '@qzr/shared'
+import type { MeetPhase, DivisionStateValue } from '@qzr/shared'
+
+export type { MeetPhase, DivisionStateValue }
 
 declare const __API_URL__: string
 
 const request = createApiClient(__API_URL__ || '')
 
 // ---- Types ----
-
-export type MeetPhase = 'registration' | 'build' | 'live' | 'done'
-
-export type DivisionStateValue = 'prelim_running' | 'stats_break' | 'elim_running' | 'division_done'
 
 export interface QuizMeet {
   id: number

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -6,6 +6,10 @@ const request = createApiClient(__API_URL__ || '')
 
 // ---- Types ----
 
+export type MeetPhase = 'registration' | 'build' | 'live' | 'done'
+
+export type DivisionStateValue = 'prelim_running' | 'stats_break' | 'elim_running' | 'division_done'
+
 export interface QuizMeet {
   id: number
   name: string
@@ -14,6 +18,15 @@ export interface QuizMeet {
   viewerCode: string
   divisions: string[]
   createdAt: string
+  phase?: MeetPhase
+  registrationClosesAt?: string | null
+  meetStartsAt?: string | null
+}
+
+export interface DivisionState {
+  division: string
+  state: DivisionStateValue
+  transitionedAt: string
 }
 
 export interface OfficialCode {
@@ -66,6 +79,8 @@ export function updateMeet(
     dateTo?: string | null
     viewerCode?: string
     divisions?: string[]
+    registrationClosesAt?: string | null
+    meetStartsAt?: string | null
   },
 ): Promise<{ meet: QuizMeet }> {
   return request(`/api/meets/${id}`, {
@@ -111,6 +126,33 @@ export function rotateOfficialCode(
   codeId: number,
 ): Promise<{ officialCode: OfficialCode; code: string }> {
   return request(`/api/meets/${meetId}/official-codes/${codeId}/rotate`, { method: 'POST' })
+}
+
+// ---- Phase / division state ----
+
+export function setMeetPhase(
+  meetId: number,
+  phase: MeetPhase,
+): Promise<{ phase: MeetPhase; reversed: boolean; unchanged?: boolean }> {
+  return request(`/api/meets/${meetId}/phase`, {
+    method: 'POST',
+    body: JSON.stringify({ phase }),
+  })
+}
+
+export function setDivisionState(
+  meetId: number,
+  division: string,
+  state: DivisionStateValue,
+): Promise<{ state: DivisionStateValue; reversed: boolean; unchanged?: boolean }> {
+  return request(`/api/meets/${meetId}/divisions/${encodeURIComponent(division)}/state`, {
+    method: 'POST',
+    body: JSON.stringify({ state }),
+  })
+}
+
+export function getDivisionStates(meetId: number): Promise<{ divisionStates: DivisionState[] }> {
+  return request(`/api/meets/${meetId}/divisions/state`)
 }
 
 // ---- Join / memberships ----

--- a/apps/web/src/views/QuizMeetView.vue
+++ b/apps/web/src/views/QuizMeetView.vue
@@ -17,11 +17,13 @@ import {
   rotateOfficialCode,
   importRoster,
   exportRoster,
+  setMeetPhase,
   type MeetDetail,
   type MeetMembership,
   type Church,
   type OfficialCode,
   type MeetMember,
+  type MeetPhase,
   listMembers,
   revokeMember,
 } from '../api'
@@ -78,6 +80,70 @@ const showAddRoom = ref(false)
 const newRoomLabel = ref('')
 const addingRoom = ref(false)
 const addRoomError = ref('')
+
+// Phase header
+const PHASES: readonly MeetPhase[] = ['registration', 'build', 'live', 'done']
+const phaseSaving = ref(false)
+const phaseError = ref('')
+
+const currentPhase = computed<MeetPhase>(() => detail.value?.meet.phase ?? 'registration')
+const phaseIdx = computed(() => PHASES.indexOf(currentPhase.value))
+const nextPhase = computed<MeetPhase | null>(() =>
+  phaseIdx.value < PHASES.length - 1 ? PHASES[phaseIdx.value + 1]! : null,
+)
+const prevPhase = computed<MeetPhase | null>(() =>
+  phaseIdx.value > 0 ? PHASES[phaseIdx.value - 1]! : null,
+)
+const canAdvancePhase = computed(() => nextPhase.value !== null)
+const canRevertPhase = computed(() => prevPhase.value !== null)
+const phaseAdvanceTitle = computed(() =>
+  nextPhase.value ? `Advance to ${phaseLabel(nextPhase.value)}` : 'Already in final phase',
+)
+const phaseRevertTitle = computed(() =>
+  prevPhase.value
+    ? `Revert to ${phaseLabel(prevPhase.value)} (flagged as unusual)`
+    : 'No earlier phase',
+)
+
+function phaseLabel(p: MeetPhase | undefined): string {
+  switch (p) {
+    case 'registration':
+      return 'Registration'
+    case 'build':
+      return 'Build'
+    case 'live':
+      return 'Live'
+    case 'done':
+      return 'Done'
+    default:
+      return 'Registration'
+  }
+}
+
+async function advancePhase(direction: 'advance' | 'revert') {
+  if (!detail.value) return
+  const target = direction === 'advance' ? nextPhase.value : prevPhase.value
+  if (!target) return
+  if (
+    direction === 'revert' &&
+    !confirm(`Revert to ${phaseLabel(target)}? Phase reverses are unusual.`)
+  ) {
+    return
+  }
+  phaseSaving.value = true
+  phaseError.value = ''
+  try {
+    const res = await setMeetPhase(detail.value.meet.id, target)
+    detail.value = {
+      ...detail.value,
+      meet: { ...detail.value.meet, phase: res.phase },
+    }
+  } catch (e) {
+    phaseError.value = e instanceof Error ? e.message : 'Failed to change phase'
+  } finally {
+    phaseSaving.value = false
+  }
+}
 
 // Access dialog
 interface AccessDialog {
@@ -621,6 +687,33 @@ onMounted(load)
         </form>
       </div>
 
+      <!-- Phase indicator -->
+      <div class="phase-bar" :data-phase="detail.meet.phase ?? 'registration'">
+        <div class="phase-bar-label">
+          <span class="phase-bar-caption">Phase:</span>
+          <strong class="phase-bar-value">{{ phaseLabel(detail.meet.phase) }}</strong>
+        </div>
+        <div v-if="isAdmin" class="phase-bar-actions">
+          <button
+            class="phase-btn"
+            :disabled="!canRevertPhase || phaseSaving"
+            :title="phaseRevertTitle"
+            @click="advancePhase('revert')"
+          >
+            ← Revert
+          </button>
+          <button
+            class="phase-btn phase-btn--primary"
+            :disabled="!canAdvancePhase || phaseSaving"
+            :title="phaseAdvanceTitle"
+            @click="advancePhase('advance')"
+          >
+            Advance →
+          </button>
+        </div>
+      </div>
+      <p v-if="phaseError" class="state-msg state-msg--error">{{ phaseError }}</p>
+
       <!-- Admin code -->
       <div v-if="isAdmin" class="section">
         <div class="section-header">
@@ -1149,6 +1242,75 @@ onMounted(load)
 .btn:disabled {
   opacity: 0.5;
   cursor: default;
+}
+
+/* Phase header bar */
+.phase-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border, #ddd);
+  background: var(--bg-elevated, #f9f9f9);
+}
+
+.phase-bar[data-phase='build'] {
+  background: #fff7e6;
+  border-color: #f0c060;
+}
+.phase-bar[data-phase='live'] {
+  background: #e6f7ec;
+  border-color: #5cbf7a;
+}
+.phase-bar[data-phase='done'] {
+  background: #ececec;
+  border-color: #999;
+}
+
+.phase-bar-label {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.phase-bar-caption {
+  color: #666;
+  font-size: 0.85rem;
+}
+
+.phase-bar-value {
+  font-size: 1.05rem;
+  text-transform: capitalize;
+}
+
+.phase-bar-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.phase-btn {
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.35rem;
+  border: 1px solid var(--border, #ccc);
+  background: white;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+.phase-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.phase-btn--primary {
+  background: #2563eb;
+  color: white;
+  border-color: #2563eb;
+}
+.phase-btn--primary:disabled {
+  background: #9aa9c8;
+  border-color: #9aa9c8;
 }
 
 /* Sections */

--- a/apps/web/src/views/QuizMeetView.vue
+++ b/apps/web/src/views/QuizMeetView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
-import { MeetRole } from '@qzr/shared'
+import { MeetRole, MEET_PHASES, type MeetPhase } from '@qzr/shared'
 import {
   getMeet,
   getMyMeets,
@@ -23,7 +23,6 @@ import {
   type Church,
   type OfficialCode,
   type MeetMember,
-  type MeetPhase,
   listMembers,
   revokeMember,
 } from '../api'
@@ -82,17 +81,16 @@ const addingRoom = ref(false)
 const addRoomError = ref('')
 
 // Phase header
-const PHASES: readonly MeetPhase[] = ['registration', 'build', 'live', 'done']
 const phaseSaving = ref(false)
 const phaseError = ref('')
 
 const currentPhase = computed<MeetPhase>(() => detail.value?.meet.phase ?? 'registration')
-const phaseIdx = computed(() => PHASES.indexOf(currentPhase.value))
+const phaseIdx = computed(() => MEET_PHASES.indexOf(currentPhase.value))
 const nextPhase = computed<MeetPhase | null>(() =>
-  phaseIdx.value < PHASES.length - 1 ? PHASES[phaseIdx.value + 1]! : null,
+  phaseIdx.value < MEET_PHASES.length - 1 ? MEET_PHASES[phaseIdx.value + 1]! : null,
 )
 const prevPhase = computed<MeetPhase | null>(() =>
-  phaseIdx.value > 0 ? PHASES[phaseIdx.value - 1]! : null,
+  phaseIdx.value > 0 ? MEET_PHASES[phaseIdx.value - 1]! : null,
 )
 const canAdvancePhase = computed(() => nextPhase.value !== null)
 const canRevertPhase = computed(() => prevPhase.value !== null)
@@ -106,18 +104,8 @@ const phaseRevertTitle = computed(() =>
 )
 
 function phaseLabel(p: MeetPhase | undefined): string {
-  switch (p) {
-    case 'registration':
-      return 'Registration'
-    case 'build':
-      return 'Build'
-    case 'live':
-      return 'Live'
-    case 'done':
-      return 'Done'
-    default:
-      return 'Registration'
-  }
+  const phase = p ?? 'registration'
+  return phase[0]!.toUpperCase() + phase.slice(1)
 }
 
 async function advancePhase(direction: 'advance' | 'revert') {

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -151,6 +151,13 @@ the admin picks room count and round count.
 **Elim rules**: deferred to the elim epic; `rules.md` §"Elimination Round Brackets" is the source of
 truth.
 
+**Overtime rule**:
+
+* No overtime in prelims. Tied prelim quizzes are tied; tiebreaking happens at standings time per
+  `rules.md` §2.b.
+* Overtime allowed in elims. The scoresheet's existing OT support kicks in only for `phase='elim'`
+  quizzes.
+
 **Event rules**:
 
 * Events occupy a slot but no rooms or quizzes.
@@ -196,14 +203,16 @@ without hard-rule conflicts. Each utility is independently invocable from the ed
 
 During the `build` phase, the admin clicks "Roll Teams" for a division. This generates a random
 permutation of the registered teams and binds each team to one letter: `A` → Heritage 1, `B` → GRBC
-2, etc. The mapping is propagated to every prelim quiz seat in that division.
+2, etc. The mapping is written to `prelim_assignments` (one row per letter per division) in a single
+transaction.
 
-* Re-roll is allowed throughout `build`. There's no separate "lock" step — the `build → live` phase
-  transition is what makes the assignment coach-visible.
+* Re-roll is allowed throughout `build` — it's a transactional UPDATE on the same rows. There's no
+  separate "lock" step; the `build → live` phase transition is what makes the assignment
+  coach-visible.
 * Admin can override individual letter→team assignments before advancing to `live` (drag a team chip
-  onto a letter slot).
-* In `live`, edits to team→letter assignments are still possible but constrained: completed quizzes
-  (`scheduled_quizzes.completedAt` set) are immutable.
+  onto a letter slot — single-row UPDATE).
+* In `live`, edits to letter→team assignments are still possible but constrained: completed quizzes
+  (`scheduled_quizzes.completedAt` set) won't accept seat changes that would alter their results.
 
 ### 5.3 Late teams
 
@@ -216,11 +225,14 @@ quizzes.
 
 ## 6. Stats break — the pivot
 
-Per `rules.md` §2.a, the transition is deterministic once team count is known. Per division, the
-admin:
+Stats break is admin-triggered per division. The admin clicks "Advance to Stats Break" on a division
+once its prelims have completed; from then on, that division's elim slots are auto-filled as
+standings finalize and intermediate (XY/XYZ/XXYYZZ) results land. Per `rules.md` §2.a, the
+transition is deterministic once team count is known. Per division, the admin:
 
 1. Reviews prelim standings (sum of 3 prelim quiz scores per team, per `rules.md` §1.a).
-   Tiebreakers: quiz score at end of question 20 (§1.a.iv).
+   Tiebreakers, per `rules.md` §2.b: head-to-head competition first, then total prelim points, then
+   fewest errors. (Verify against current rulebook.)
 2. Looks up the tournament shape for team count:
 
    | Team count | Structure                                                                                                |
@@ -234,6 +246,10 @@ admin:
 3. Flips `teams.consolation=true` for teams headed to consolation. For the "> 24 teams" shape,
    consolation membership is finalised _after_ XYZ and XXYYZZ resolve, not at the break itself.
 4. Generates the elim schedule using the selected bracket template (A / B / C).
+
+After step 4, the elim quiz seats carry seedRefs (e.g., `prelimRank(4)`, `place(quizA, 2)`) and
+those seedRefs auto-resolve to teamIds in the `seed_resolutions` table (see §8) as prior quizzes
+complete. The admin doesn't manually fill in elim seats — the system propagates results.
 
 `teams.consolation` is the authoritative lane marker, written at stats break and updated by the elim
 result pipeline. A team's `division` is never rewritten.
@@ -257,14 +273,27 @@ present in meets > 24 teams.
 
 **Seed-reference formats**:
 
-| Format                                     | Meaning                                      |
-| ------------------------------------------ | -------------------------------------------- |
-| `prelimSeed(n)`                            | Team ranked `n` from prelim standings        |
-| `place(quizId, p)`                         | Team that placed `p` in a given bracket quiz |
-| `xyzTop3(rank)` / `xyzBottom6(rank)`       | XYZ advancers / fall-throughs                |
-| `xxyyzzTop3(rank)` / `xxyyzzBottom6(rank)` | XXYYZZ equivalents                           |
-| `winner(quizId)` / `loser(quizId)`         | Convenience for championship series          |
-| `tiebreaker(candidates)`                   | Unresolved tied teams (`rules.md` §2.b)      |
+| Format                                     | Meaning                                                                                 |
+| ------------------------------------------ | --------------------------------------------------------------------------------------- |
+| `prelimSeed(n)`                            | Team ranked `n` from prelim standings                                                   |
+| `xyRank(n)`                                | Team at "new `n`" position after XY/XYZ rerank (e.g., `xyRank(11)` = sample's `new 11`) |
+| `place(quizId, p)`                         | Team that placed `p` in a given bracket quiz                                            |
+| `xyzTop3(rank)` / `xyzBottom6(rank)`       | XYZ advancers / fall-throughs                                                           |
+| `xxyyzzTop3(rank)` / `xxyyzzBottom6(rank)` | XXYYZZ equivalents                                                                      |
+| `winner(quizId)` / `loser(quizId)`         | Convenience for championship series                                                     |
+| `tiebreaker(candidates)`                   | Unresolved tied teams (`rules.md` §2.b)                                                 |
+
+The "`new N`" labels seen on sample schedules (`new 11`, `new 15`, etc.) refer to placement after
+the XY/XYZ intermediate quizzes finish: a team that started at prelim rank 12 may end up at `new 11`
+once intermediate results are factored in. Encoded as `xyRank(N)` in the data model.
+
+### Def vs resolution layering
+
+Elim quiz seats carry only the **def** — the seedRef. The **resolution** (which concrete team a
+given seedRef currently points to) lives in a separate table (`seed_resolutions`, see §8). This
+matters because the same seedRef appears in multiple seats (e.g. `place(quizB, 2)` could feed two
+downstream bracket quizzes), and a single resolution row keeps them consistent. The same pattern
+applies to prelim seats with their `letter` def → `prelim_assignments` resolution.
 
 ## 8. Data model
 
@@ -333,9 +362,8 @@ export const scheduledQuizzes = sqliteTable('scheduled_quizzes', {
   completedAt: integer('completed_at', { mode: 'timestamp' }), // set when results land — gates immutability
 })
 
-// Three seats per quiz. Identifier shape depends on phase:
-//   prelim — `letter` ('A'–'U') from the rules.md table; `teamId` filled when admin runs "Roll Teams"
-//   elim   — `seedRef` JSON; `teamId` filled as prior quizzes resolve
+// Three seats per quiz. Holds only the def — letter (prelim) or seedRef (elim).
+// The team binding lives in a separate resolution table (see below).
 export const scheduledQuizSeats = sqliteTable('scheduled_quiz_seats', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   quizId: integer('quiz_id')
@@ -343,9 +371,45 @@ export const scheduledQuizSeats = sqliteTable('scheduled_quiz_seats', {
     .references(() => scheduledQuizzes.id, { onDelete: 'cascade' }),
   seatNumber: integer('seat_number').notNull(),
   letter: text('letter'), // 'A'–'U' — set at composition time for prelim seats
-  teamId: integer('team_id').references(() => teams.id, { onDelete: 'set null' }),
-  seedRef: text('seed_ref'),
+  seedRef: text('seed_ref'), // JSON — set at composition time for elim seats
 })
+
+// Resolution layer — prelim. (meetId, division, letter) → teamId.
+// One row per letter per division. "Roll Teams" writes here; re-roll = transactional UPDATE.
+export const prelimAssignments = sqliteTable(
+  'prelim_assignments',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    meetId: integer('meet_id')
+      .notNull()
+      .references(() => quizMeets.id, { onDelete: 'cascade' }),
+    division: text('division').notNull(),
+    letter: text('letter').notNull(), // 'A'–'U'
+    teamId: integer('team_id')
+      .notNull()
+      .references(() => teams.id, { onDelete: 'cascade' }),
+    assignedAt: integer('assigned_at', { mode: 'timestamp' }).notNull(),
+  },
+  (t) => [unique().on(t.meetId, t.division, t.letter)],
+)
+
+// Resolution layer — elim. (meetId, seedRef) → teamId.
+// Filled by the result-linkage pipeline as prior quizzes complete.
+export const seedResolutions = sqliteTable(
+  'seed_resolutions',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    meetId: integer('meet_id')
+      .notNull()
+      .references(() => quizMeets.id, { onDelete: 'cascade' }),
+    seedRef: text('seed_ref').notNull(), // canonical JSON form, e.g. '{"k":"place","quiz":42,"p":2}'
+    teamId: integer('team_id')
+      .notNull()
+      .references(() => teams.id, { onDelete: 'cascade' }),
+    resolvedAt: integer('resolved_at', { mode: 'timestamp' }).notNull(),
+  },
+  (t) => [unique().on(t.meetId, t.seedRef)],
+)
 ```
 
 **Notes**:
@@ -354,15 +418,20 @@ export const scheduledQuizSeats = sqliteTable('scheduled_quiz_seats', {
   meaningful when `phase='elim'`.
 * `scheduled_quizzes.completedAt` is set by the result-linkage path (#16) when results land for a
   quiz. Editor blocks edits to any seat on a completed quiz.
-* Prelim seats start with `letter` set and `teamId` null. "Roll Teams" (during `build` phase) fills
-  `teamId` for every prelim seat in a division by random A→Team mapping.
-* Elim seats start with `seedRef` set; `teamId` fills in as prior quizzes resolve (issue `#16`).
+* `scheduled_quiz_seats` carry only the def (letter or seedRef). To render "what team is in seat X",
+  JOIN through `prelim_assignments` (for letters) or `seed_resolutions` (for seedRefs).
+* "Roll Teams" (during `build` phase) writes one `prelim_assignments` row per letter per division in
+  a single transaction. Re-roll is just an UPDATE of the same rows.
+* Elim seedRefs auto-resolve into `seed_resolutions` as XY/XYZ/bracket quizzes complete (#16).
+* "Un-resolve" (admin marks a quiz incomplete to redo it) is a clean delete from `seed_resolutions`
+  for the affected refs; downstream seat reads naturally show null again.
 * Events live on `meet_slots` with `kind='event'`, no child `scheduled_quizzes`.
 * `teams.division` is immutable. `teams.consolation` starts false, set post-stats-break or post-XYZ.
 
-**First-delivery scope cut**: the initial schema PR ships these tables, but only writes
-`phase='prelim'` rows. The `lane`, `bracketLabel`, and `seedRef` columns exist from day one but stay
-unused until the elim epic.
+**First-delivery scope cut**: the initial schema PR ships all of the above tables, but only the
+prelim path writes rows. Elim columns (`scheduled_quizzes.lane`, `bracketLabel`,
+`scheduled_quiz_seats.seedRef`, `seed_resolutions`) exist from day one but stay unused until the
+elim epic.
 
 ## 9. UX — the builder (primary experience)
 
@@ -470,14 +539,23 @@ Wrap-up [phase: done — admin manual]
 
 ## 11. Open questions
 
+All remaining questions concern the elim phase; none block prelim implementation.
+
 1. Is `docs/rules.md` complete vs the official PDF? Flagged as uncertain.
 2. Sample schedules show "Quiz X" and "Quiz Y" only (6 teams), but `rules.md` §2.a specifies XYZ (9
-   teams). Is X+Y (no Z) a variant used for smaller fields?
-3. `new 11` / `new 15` placeholders in sample schedules — confirm naming convention for
-   XYZ-to-consolation transitions.
-4. Championship-series termination: auto-generate Quiz H/I/etc. or admin-added on demand?
-5. Tie-breaker quizzes for positions 6/15/24 (`rules.md` §2.b) — on-demand rows or pre-scheduled?
-6. Late teams during elims — current assumption: prelims only. Confirm.
-7. Bracket auto-advance vs manual confirm when Quiz A's result lands.
-8. Keep both `teams.consolation` and `scheduled_quizzes.lane`, or collapse one into the other?
-   Proposal keeps both.
+   teams). Is X+Y (no Z) a variant used for smaller fields, or does the sample reflect a different
+   meet's house rules?
+3. Which of Bracket A / B / C did the Finals 2023 sample use? Visual inspection of the sample should
+   pin this down.
+4. Tiebreaker rule confirmation — `rules.md` §2.b says head-to-head, then total prelim points, then
+   fewest errors. Verify this matches current rulebook practice.
+5. Championship-series termination (`rules.md` §3 "win twice"): auto-generate Quiz H/I/etc.
+   on-demand as results land, or admin-added manually?
+6. Tie-breaker quizzes for positions 6/15/24 (`rules.md` §2.b): pre-scheduled in the elim grid, or
+   on-demand only when a tie actually occurs?
+7. Late teams during elims — current assumption: prelims only, late elim entries handled with manual
+   editor swaps and no automated rebalancing. Confirm.
+8. Bracket auto-advance vs manual confirm: when a bracket quiz's result is submitted, should the
+   `seed_resolutions` write happen automatically, or wait for admin confirmation?
+9. Keep both `teams.consolation` and `scheduled_quizzes.lane`, or collapse one into the other?
+   Current proposal keeps both since they have different lifecycles.

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -319,6 +319,11 @@ export const divisionStates = sqliteTable('division_states', {
 })
 
 // A named physical location within a meet.
+// This is the existing official_codes table renamed: it already exists per-meet,
+// already has a label conventionally meaning "Room A"/etc., and already carries
+// the codeHash that gates official-role access for that room. We rename label →
+// name, add sortOrder for grid display, and make codeHash nullable so admins can
+// create rooms in the build phase without immediately issuing an official code.
 export const meetRooms = sqliteTable('meet_rooms', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   meetId: integer('meet_id')
@@ -326,6 +331,7 @@ export const meetRooms = sqliteTable('meet_rooms', {
     .references(() => quizMeets.id, { onDelete: 'cascade' }),
   name: text('name').notNull(),
   sortOrder: integer('sort_order').notNull(),
+  codeHash: text('code_hash'), // nullable; null = no official code issued yet
 })
 
 // A row in the left-hand time column. May hold quizzes or a non-quiz event.

--- a/packages/api/migrations/0002_lovely_ultimo.sql
+++ b/packages/api/migrations/0002_lovely_ultimo.sql
@@ -1,0 +1,103 @@
+ALTER TABLE `official_codes` RENAME TO `meet_rooms`;--> statement-breakpoint
+ALTER TABLE `meet_rooms` RENAME COLUMN "label" TO "name";--> statement-breakpoint
+CREATE TABLE `division_states` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`meet_id` integer NOT NULL,
+	`division` text NOT NULL,
+	`state` text DEFAULT 'prelim_running' NOT NULL,
+	`transitioned_at` integer NOT NULL,
+	FOREIGN KEY (`meet_id`) REFERENCES `quiz_meets`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `division_states_meet_id_division_unique` ON `division_states` (`meet_id`,`division`);--> statement-breakpoint
+CREATE TABLE `meet_slots` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`meet_id` integer NOT NULL,
+	`start_at` integer NOT NULL,
+	`duration_minutes` integer NOT NULL,
+	`kind` text NOT NULL,
+	`event_label` text,
+	`sort_order` integer NOT NULL,
+	FOREIGN KEY (`meet_id`) REFERENCES `quiz_meets`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `prelim_assignments` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`meet_id` integer NOT NULL,
+	`division` text NOT NULL,
+	`letter` text NOT NULL,
+	`team_id` integer NOT NULL,
+	`assigned_at` integer NOT NULL,
+	FOREIGN KEY (`meet_id`) REFERENCES `quiz_meets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`team_id`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `prelim_assignments_meet_id_division_letter_unique` ON `prelim_assignments` (`meet_id`,`division`,`letter`);--> statement-breakpoint
+CREATE TABLE `scheduled_quiz_seats` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`quiz_id` integer NOT NULL,
+	`seat_number` integer NOT NULL,
+	`letter` text,
+	`seed_ref` text,
+	FOREIGN KEY (`quiz_id`) REFERENCES `scheduled_quizzes`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `scheduled_quizzes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`meet_id` integer NOT NULL,
+	`slot_id` integer NOT NULL,
+	`room_id` integer NOT NULL,
+	`division` text NOT NULL,
+	`phase` text NOT NULL,
+	`lane` text,
+	`label` text NOT NULL,
+	`bracket_label` text,
+	`published_at` integer,
+	`completed_at` integer,
+	FOREIGN KEY (`meet_id`) REFERENCES `quiz_meets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`slot_id`) REFERENCES `meet_slots`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`room_id`) REFERENCES `meet_rooms`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `seed_resolutions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`meet_id` integer NOT NULL,
+	`seed_ref` text NOT NULL,
+	`team_id` integer NOT NULL,
+	`resolved_at` integer NOT NULL,
+	FOREIGN KEY (`meet_id`) REFERENCES `quiz_meets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`team_id`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `seed_resolutions_meet_id_seed_ref_unique` ON `seed_resolutions` (`meet_id`,`seed_ref`);--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_meet_rooms` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`meet_id` integer NOT NULL,
+	`name` text NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`code_hash` text,
+	FOREIGN KEY (`meet_id`) REFERENCES `quiz_meets`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_meet_rooms`("id", "meet_id", "name", "sort_order", "code_hash") SELECT "id", "meet_id", "name", "sort_order", "code_hash" FROM `meet_rooms`;--> statement-breakpoint
+DROP TABLE `meet_rooms`;--> statement-breakpoint
+ALTER TABLE `__new_meet_rooms` RENAME TO `meet_rooms`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+ALTER TABLE `official_memberships` RENAME COLUMN "official_code_id" TO "room_id";--> statement-breakpoint
+CREATE TABLE `__new_official_memberships` (
+	`account_id` text NOT NULL,
+	`meet_id` integer NOT NULL,
+	`room_id` integer NOT NULL,
+	FOREIGN KEY (`account_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`meet_id`) REFERENCES `quiz_meets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`room_id`) REFERENCES `meet_rooms`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_official_memberships`("account_id", "meet_id", "room_id") SELECT "account_id", "meet_id", "room_id" FROM `official_memberships`;--> statement-breakpoint
+DROP TABLE `official_memberships`;--> statement-breakpoint
+ALTER TABLE `__new_official_memberships` RENAME TO `official_memberships`;--> statement-breakpoint
+CREATE UNIQUE INDEX `official_memberships_account_id_meet_id_room_id_unique` ON `official_memberships` (`account_id`,`meet_id`,`room_id`);--> statement-breakpoint
+ALTER TABLE `quiz_meets` ADD `phase` text DEFAULT 'registration' NOT NULL;--> statement-breakpoint
+ALTER TABLE `quiz_meets` ADD `registration_closes_at` integer;--> statement-breakpoint
+ALTER TABLE `quiz_meets` ADD `meet_starts_at` integer;

--- a/packages/api/migrations/meta/0002_snapshot.json
+++ b/packages/api/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1505 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "31afe175-e860-4ab1-94ca-c725b5b53c94",
+  "prevId": "55d7f769-e986-452f-89e4-b0b7022c0fdd",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "admin_memberships": {
+      "name": "admin_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "admin_memberships_account_id_meet_id_unique": {
+          "name": "admin_memberships_account_id_meet_id_unique",
+          "columns": [
+            "account_id",
+            "meet_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "admin_memberships_account_id_user_id_fk": {
+          "name": "admin_memberships_account_id_user_id_fk",
+          "tableFrom": "admin_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "admin_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "admin_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "churches": {
+      "name": "churches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coach_code_hash": {
+          "name": "coach_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "churches_meet_id_quiz_meets_id_fk": {
+          "name": "churches_meet_id_quiz_meets_id_fk",
+          "tableFrom": "churches",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coach_memberships": {
+      "name": "coach_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "church_id": {
+          "name": "church_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "coach_memberships_account_id_church_id_unique": {
+          "name": "coach_memberships_account_id_church_id_unique",
+          "columns": [
+            "account_id",
+            "church_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "coach_memberships_account_id_user_id_fk": {
+          "name": "coach_memberships_account_id_user_id_fk",
+          "tableFrom": "coach_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_memberships_church_id_churches_id_fk": {
+          "name": "coach_memberships_church_id_churches_id_fk",
+          "tableFrom": "coach_memberships",
+          "tableTo": "churches",
+          "columnsFrom": [
+            "church_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "coach_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "coach_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "division_states": {
+      "name": "division_states",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'prelim_running'"
+        },
+        "transitioned_at": {
+          "name": "transitioned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "division_states_meet_id_division_unique": {
+          "name": "division_states_meet_id_division_unique",
+          "columns": [
+            "meet_id",
+            "division"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "division_states_meet_id_quiz_meets_id_fk": {
+          "name": "division_states_meet_id_quiz_meets_id_fk",
+          "tableFrom": "division_states",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meet_rooms": {
+      "name": "meet_rooms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meet_rooms_meet_id_quiz_meets_id_fk": {
+          "name": "meet_rooms_meet_id_quiz_meets_id_fk",
+          "tableFrom": "meet_rooms",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meet_slots": {
+      "name": "meet_slots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_label": {
+          "name": "event_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meet_slots_meet_id_quiz_meets_id_fk": {
+          "name": "meet_slots_meet_id_quiz_meets_id_fk",
+          "tableFrom": "meet_slots",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "official_memberships": {
+      "name": "official_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "official_memberships_account_id_meet_id_room_id_unique": {
+          "name": "official_memberships_account_id_meet_id_room_id_unique",
+          "columns": [
+            "account_id",
+            "meet_id",
+            "room_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "official_memberships_account_id_user_id_fk": {
+          "name": "official_memberships_account_id_user_id_fk",
+          "tableFrom": "official_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "official_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "official_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "official_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "official_memberships_room_id_meet_rooms_id_fk": {
+          "name": "official_memberships_room_id_meet_rooms_id_fk",
+          "tableFrom": "official_memberships",
+          "tableTo": "meet_rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prelim_assignments": {
+      "name": "prelim_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "letter": {
+          "name": "letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prelim_assignments_meet_id_division_letter_unique": {
+          "name": "prelim_assignments_meet_id_division_letter_unique",
+          "columns": [
+            "meet_id",
+            "division",
+            "letter"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "prelim_assignments_meet_id_quiz_meets_id_fk": {
+          "name": "prelim_assignments_meet_id_quiz_meets_id_fk",
+          "tableFrom": "prelim_assignments",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prelim_assignments_team_id_teams_id_fk": {
+          "name": "prelim_assignments_team_id_teams_id_fk",
+          "tableFrom": "prelim_assignments",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_meets": {
+      "name": "quiz_meets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_from": {
+          "name": "date_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_to": {
+          "name": "date_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_code_hash": {
+          "name": "admin_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "viewer_code": {
+          "name": "viewer_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "divisions": {
+          "name": "divisions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'registration'"
+        },
+        "registration_closes_at": {
+          "name": "registration_closes_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meet_starts_at": {
+          "name": "meet_starts_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quizzer_identities": {
+      "name": "quizzer_identities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_quiz_seats": {
+      "name": "scheduled_quiz_seats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seat_number": {
+          "name": "seat_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "letter": {
+          "name": "letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seed_ref": {
+          "name": "seed_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_quiz_seats_quiz_id_scheduled_quizzes_id_fk": {
+          "name": "scheduled_quiz_seats_quiz_id_scheduled_quizzes_id_fk",
+          "tableFrom": "scheduled_quiz_seats",
+          "tableTo": "scheduled_quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_quizzes": {
+      "name": "scheduled_quizzes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lane": {
+          "name": "lane",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bracket_label": {
+          "name": "bracket_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_quizzes_meet_id_quiz_meets_id_fk": {
+          "name": "scheduled_quizzes_meet_id_quiz_meets_id_fk",
+          "tableFrom": "scheduled_quizzes",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_quizzes_slot_id_meet_slots_id_fk": {
+          "name": "scheduled_quizzes_slot_id_meet_slots_id_fk",
+          "tableFrom": "scheduled_quizzes",
+          "tableTo": "meet_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_quizzes_room_id_meet_rooms_id_fk": {
+          "name": "scheduled_quizzes_room_id_meet_rooms_id_fk",
+          "tableFrom": "scheduled_quizzes",
+          "tableTo": "meet_rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "seed_resolutions": {
+      "name": "seed_resolutions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed_ref": {
+          "name": "seed_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "seed_resolutions_meet_id_seed_ref_unique": {
+          "name": "seed_resolutions_meet_id_seed_ref_unique",
+          "columns": [
+            "meet_id",
+            "seed_ref"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "seed_resolutions_meet_id_quiz_meets_id_fk": {
+          "name": "seed_resolutions_meet_id_quiz_meets_id_fk",
+          "tableFrom": "seed_resolutions",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seed_resolutions_team_id_teams_id_fk": {
+          "name": "seed_resolutions_team_id_teams_id_fk",
+          "tableFrom": "seed_resolutions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_rosters": {
+      "name": "team_rosters",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quizzer_id": {
+          "name": "quizzer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_rosters_team_id_quizzer_id_unique": {
+          "name": "team_rosters_team_id_quizzer_id_unique",
+          "columns": [
+            "team_id",
+            "quizzer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_rosters_team_id_teams_id_fk": {
+          "name": "team_rosters_team_id_teams_id_fk",
+          "tableFrom": "team_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_rosters_quizzer_id_quizzer_identities_id_fk": {
+          "name": "team_rosters_quizzer_id_quizzer_identities_id_fk",
+          "tableFrom": "team_rosters",
+          "tableTo": "quizzer_identities",
+          "columnsFrom": [
+            "quizzer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "church_id": {
+          "name": "church_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consolation": {
+          "name": "consolation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_meet_id_quiz_meets_id_fk": {
+          "name": "teams_meet_id_quiz_meets_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_church_id_churches_id_fk": {
+          "name": "teams_church_id_churches_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "churches",
+          "columnsFrom": [
+            "church_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "viewer_memberships": {
+      "name": "viewer_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "viewer_memberships_account_id_meet_id_unique": {
+          "name": "viewer_memberships_account_id_meet_id_unique",
+          "columns": [
+            "account_id",
+            "meet_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "viewer_memberships_account_id_user_id_fk": {
+          "name": "viewer_memberships_account_id_user_id_fk",
+          "tableFrom": "viewer_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "viewer_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "viewer_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "viewer_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {
+      "\"official_codes\"": "\"meet_rooms\""
+    },
+    "columns": {
+      "\"meet_rooms\".\"label\"": "\"meet_rooms\".\"name\"",
+      "\"official_memberships\".\"official_code_id\"": "\"official_memberships\".\"room_id\""
+    }
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775340386560,
       "tag": "0001_colorful_serpent_society",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1777404626713,
+      "tag": "0002_lovely_ultimo",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/__tests__/scheduler.spec.ts
+++ b/packages/api/src/__tests__/scheduler.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { eq } from 'drizzle-orm'
+import * as schema from '../db/schema'
+import { autoAdvancePhases } from '../scheduler'
+import { createTestDb } from '../test-db'
+import type { Db } from '../lib/db'
+
+async function seedMeet(
+  db: Db,
+  name: string,
+  opts: {
+    phase?: 'registration' | 'build' | 'live' | 'done'
+    registrationClosesAt?: Date | null
+    meetStartsAt?: Date | null
+  } = {},
+) {
+  const [meet] = await db
+    .insert(schema.quizMeets)
+    .values({
+      name,
+      dateFrom: '2026-01-01',
+      adminCodeHash: 'x',
+      viewerCode: name.toLowerCase().replace(/\s+/g, '-'),
+      createdAt: new Date(),
+      phase: opts.phase ?? 'registration',
+      registrationClosesAt: opts.registrationClosesAt ?? null,
+      meetStartsAt: opts.meetStartsAt ?? null,
+    })
+    .returning()
+  return meet!
+}
+
+describe('autoAdvancePhases', () => {
+  let db: Db
+
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('does nothing when no timestamps set', async () => {
+    await seedMeet(db, 'Quiet')
+    const res = await autoAdvancePhases(db)
+    expect(res).toEqual({ promotedToBuild: 0, promotedToLive: 0 })
+  })
+
+  it('promotes registration → build when registrationClosesAt has passed', async () => {
+    const past = new Date(Date.now() - 60_000)
+    const meet = await seedMeet(db, 'Past', { registrationClosesAt: past })
+
+    const res = await autoAdvancePhases(db)
+    expect(res.promotedToBuild).toBe(1)
+
+    const [updated] = await db
+      .select({ phase: schema.quizMeets.phase })
+      .from(schema.quizMeets)
+      .where(eq(schema.quizMeets.id, meet.id))
+    expect(updated?.phase).toBe('build')
+  })
+
+  it('does not promote when registrationClosesAt is in the future', async () => {
+    const future = new Date(Date.now() + 60_000)
+    await seedMeet(db, 'Future', { registrationClosesAt: future })
+
+    const res = await autoAdvancePhases(db)
+    expect(res.promotedToBuild).toBe(0)
+  })
+
+  it('promotes build → live when meetStartsAt has passed', async () => {
+    const past = new Date(Date.now() - 60_000)
+    const meet = await seedMeet(db, 'Starting', {
+      phase: 'build',
+      meetStartsAt: past,
+    })
+
+    const res = await autoAdvancePhases(db)
+    expect(res.promotedToLive).toBe(1)
+
+    const [updated] = await db
+      .select({ phase: schema.quizMeets.phase })
+      .from(schema.quizMeets)
+      .where(eq(schema.quizMeets.id, meet.id))
+    expect(updated?.phase).toBe('live')
+  })
+
+  it('does not skip from registration directly to live in one tick', async () => {
+    const past = new Date(Date.now() - 60_000)
+    const meet = await seedMeet(db, 'Both', {
+      registrationClosesAt: past,
+      meetStartsAt: past,
+    })
+
+    const res = await autoAdvancePhases(db)
+    expect(res.promotedToBuild).toBe(1)
+    expect(res.promotedToLive).toBe(0)
+
+    const [updated] = await db
+      .select({ phase: schema.quizMeets.phase })
+      .from(schema.quizMeets)
+      .where(eq(schema.quizMeets.id, meet.id))
+    expect(updated?.phase).toBe('build')
+
+    // Second tick brings it to live
+    const res2 = await autoAdvancePhases(db)
+    expect(res2.promotedToLive).toBe(1)
+
+    const [final] = await db
+      .select({ phase: schema.quizMeets.phase })
+      .from(schema.quizMeets)
+      .where(eq(schema.quizMeets.id, meet.id))
+    expect(final?.phase).toBe('live')
+  })
+
+  it('is idempotent — re-running does nothing once caught up', async () => {
+    const past = new Date(Date.now() - 60_000)
+    await seedMeet(db, 'Caught Up', {
+      phase: 'live',
+      registrationClosesAt: past,
+      meetStartsAt: past,
+    })
+
+    const res = await autoAdvancePhases(db)
+    expect(res).toEqual({ promotedToBuild: 0, promotedToLive: 0 })
+  })
+
+  it('handles multiple meets in one pass', async () => {
+    const past = new Date(Date.now() - 60_000)
+    await seedMeet(db, 'M1', { registrationClosesAt: past })
+    await seedMeet(db, 'M2', { registrationClosesAt: past })
+    await seedMeet(db, 'M3', { phase: 'build', meetStartsAt: past })
+
+    const res = await autoAdvancePhases(db)
+    expect(res.promotedToBuild).toBe(2)
+    expect(res.promotedToLive).toBe(1)
+  })
+})

--- a/packages/api/src/__tests__/scheduler.spec.ts
+++ b/packages/api/src/__tests__/scheduler.spec.ts
@@ -3,32 +3,8 @@ import { eq } from 'drizzle-orm'
 import * as schema from '../db/schema'
 import { autoAdvancePhases } from '../scheduler'
 import { createTestDb } from '../test-db'
+import { seedMeet } from '../test-utils'
 import type { Db } from '../lib/db'
-
-async function seedMeet(
-  db: Db,
-  name: string,
-  opts: {
-    phase?: 'registration' | 'build' | 'live' | 'done'
-    registrationClosesAt?: Date | null
-    meetStartsAt?: Date | null
-  } = {},
-) {
-  const [meet] = await db
-    .insert(schema.quizMeets)
-    .values({
-      name,
-      dateFrom: '2026-01-01',
-      adminCodeHash: 'x',
-      viewerCode: name.toLowerCase().replace(/\s+/g, '-'),
-      createdAt: new Date(),
-      phase: opts.phase ?? 'registration',
-      registrationClosesAt: opts.registrationClosesAt ?? null,
-      meetStartsAt: opts.meetStartsAt ?? null,
-    })
-    .returning()
-  return meet!
-}
 
 describe('autoAdvancePhases', () => {
   let db: Db

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -67,15 +67,27 @@ export const quizMeets = sqliteTable('quiz_meets', {
   viewerCode: text('viewer_code').notNull(), // admin-set human-readable slug
   divisions: text('divisions').notNull().default('[]'), // JSON string[]
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  phase: text('phase', {
+    enum: ['registration', 'build', 'live', 'done'],
+  })
+    .notNull()
+    .default('registration'),
+  registrationClosesAt: integer('registration_closes_at', { mode: 'timestamp' }),
+  meetStartsAt: integer('meet_starts_at', { mode: 'timestamp' }),
 })
 
-export const officialCodes = sqliteTable('official_codes', {
+// A named physical location within a meet. Renamed from `official_codes` — this
+// row both defines the room (name, sortOrder for grid display) and optionally
+// carries the official-access codeHash. `codeHash` is nullable: admins can
+// create rooms in the `build` phase before issuing an official code.
+export const meetRooms = sqliteTable('meet_rooms', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   meetId: integer('meet_id')
     .notNull()
     .references(() => quizMeets.id, { onDelete: 'cascade' }),
-  label: text('label').notNull(), // e.g. "Room A"
-  codeHash: text('code_hash').notNull(),
+  name: text('name').notNull(),
+  sortOrder: integer('sort_order').notNull().default(0),
+  codeHash: text('code_hash'),
 })
 
 // ---- Meet memberships ----
@@ -119,11 +131,11 @@ export const officialMemberships = sqliteTable(
     meetId: integer('meet_id')
       .notNull()
       .references(() => quizMeets.id, { onDelete: 'cascade' }),
-    officialCodeId: integer('official_code_id')
+    roomId: integer('room_id')
       .notNull()
-      .references(() => officialCodes.id, { onDelete: 'cascade' }),
+      .references(() => meetRooms.id, { onDelete: 'cascade' }),
   },
-  (t) => [unique().on(t.accountId, t.meetId, t.officialCodeId)],
+  (t) => [unique().on(t.accountId, t.meetId, t.roomId)],
 )
 
 export const viewerMemberships = sqliteTable(
@@ -182,6 +194,113 @@ export const teamRosters = sqliteTable(
   (t) => [unique().on(t.teamId, t.quizzerId)],
 )
 
+// ---- Schedule ----
+
+// Per-division state machine inside the `live` meet phase.
+// Transitions: prelim_running → stats_break → elim_running → division_done.
+export const divisionStates = sqliteTable(
+  'division_states',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    meetId: integer('meet_id')
+      .notNull()
+      .references(() => quizMeets.id, { onDelete: 'cascade' }),
+    division: text('division').notNull(),
+    state: text('state', {
+      enum: ['prelim_running', 'stats_break', 'elim_running', 'division_done'],
+    })
+      .notNull()
+      .default('prelim_running'),
+    transitionedAt: integer('transitioned_at', { mode: 'timestamp' }).notNull(),
+  },
+  (t) => [unique().on(t.meetId, t.division)],
+)
+
+// A time-column row on the schedule grid. `kind='quiz'` hosts scheduledQuizzes
+// across rooms; `kind='event'` spans all rooms (Breakfast, Stats Break, etc.).
+export const meetSlots = sqliteTable('meet_slots', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  meetId: integer('meet_id')
+    .notNull()
+    .references(() => quizMeets.id, { onDelete: 'cascade' }),
+  startAt: integer('start_at', { mode: 'timestamp' }).notNull(),
+  durationMinutes: integer('duration_minutes').notNull(),
+  kind: text('kind', { enum: ['quiz', 'event'] }).notNull(),
+  eventLabel: text('event_label'), // null for quiz slots
+  sortOrder: integer('sort_order').notNull(),
+})
+
+// One 3-team quiz at (slot, room). Prelim or elim.
+// `completedAt` is set by the result-linkage pipeline and gates immutability.
+export const scheduledQuizzes = sqliteTable('scheduled_quizzes', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  meetId: integer('meet_id')
+    .notNull()
+    .references(() => quizMeets.id, { onDelete: 'cascade' }),
+  slotId: integer('slot_id')
+    .notNull()
+    .references(() => meetSlots.id, { onDelete: 'cascade' }),
+  roomId: integer('room_id')
+    .notNull()
+    .references(() => meetRooms.id, { onDelete: 'cascade' }),
+  division: text('division').notNull(),
+  phase: text('phase', { enum: ['prelim', 'elim'] }).notNull(),
+  lane: text('lane', { enum: ['main', 'consolation', 'intermediate'] }), // elim only
+  label: text('label').notNull(), // e.g. "Div 1 Quiz 1", "Div 2 Quiz A"
+  bracketLabel: text('bracket_label'), // elim only; e.g. "A", "D", "X"
+  publishedAt: integer('published_at', { mode: 'timestamp' }),
+  completedAt: integer('completed_at', { mode: 'timestamp' }),
+})
+
+// Three seats per quiz. Holds only the def — letter (prelim) or seedRef (elim).
+// The team binding lives in prelim_assignments or seed_resolutions.
+export const scheduledQuizSeats = sqliteTable('scheduled_quiz_seats', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  quizId: integer('quiz_id')
+    .notNull()
+    .references(() => scheduledQuizzes.id, { onDelete: 'cascade' }),
+  seatNumber: integer('seat_number').notNull(),
+  letter: text('letter'), // 'A'–'U' for prelim seats
+  seedRef: text('seed_ref'), // JSON for elim seats
+})
+
+// Resolution layer — prelim. (meetId, division, letter) → teamId.
+// "Roll Teams" writes here; re-roll is a transactional UPDATE on the same rows.
+export const prelimAssignments = sqliteTable(
+  'prelim_assignments',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    meetId: integer('meet_id')
+      .notNull()
+      .references(() => quizMeets.id, { onDelete: 'cascade' }),
+    division: text('division').notNull(),
+    letter: text('letter').notNull(),
+    teamId: integer('team_id')
+      .notNull()
+      .references(() => teams.id, { onDelete: 'cascade' }),
+    assignedAt: integer('assigned_at', { mode: 'timestamp' }).notNull(),
+  },
+  (t) => [unique().on(t.meetId, t.division, t.letter)],
+)
+
+// Resolution layer — elim. (meetId, seedRef) → teamId. Written by the
+// result-linkage pipeline as prior quizzes complete.
+export const seedResolutions = sqliteTable(
+  'seed_resolutions',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    meetId: integer('meet_id')
+      .notNull()
+      .references(() => quizMeets.id, { onDelete: 'cascade' }),
+    seedRef: text('seed_ref').notNull(),
+    teamId: integer('team_id')
+      .notNull()
+      .references(() => teams.id, { onDelete: 'cascade' }),
+    resolvedAt: integer('resolved_at', { mode: 'timestamp' }).notNull(),
+  },
+  (t) => [unique().on(t.meetId, t.seedRef)],
+)
+
 // ---- Inferred types ----
 
 export type User = typeof user.$inferSelect
@@ -189,10 +308,16 @@ export type Session = typeof session.$inferSelect
 export type Account = typeof account.$inferSelect
 export type Verification = typeof verification.$inferSelect
 export type QuizMeet = typeof quizMeets.$inferSelect
-export type OfficialCode = typeof officialCodes.$inferSelect
+export type MeetRoom = typeof meetRooms.$inferSelect
 export type AdminMembership = typeof adminMemberships.$inferSelect
 export type CoachMembership = typeof coachMemberships.$inferSelect
 export type Church = typeof churches.$inferSelect
 export type Team = typeof teams.$inferSelect
 export type QuizzerIdentity = typeof quizzerIdentities.$inferSelect
 export type TeamRoster = typeof teamRosters.$inferSelect
+export type DivisionState = typeof divisionStates.$inferSelect
+export type MeetSlot = typeof meetSlots.$inferSelect
+export type ScheduledQuiz = typeof scheduledQuizzes.$inferSelect
+export type ScheduledQuizSeat = typeof scheduledQuizSeats.$inferSelect
+export type PrelimAssignment = typeof prelimAssignments.$inferSelect
+export type SeedResolution = typeof seedResolutions.$inferSelect

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { integer, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core'
-import { AccountRole } from '@qzr/shared'
+import { AccountRole, MEET_PHASES, DIVISION_STATES } from '@qzr/shared'
 
 // ---- Better Auth core tables ----
 
@@ -67,19 +67,13 @@ export const quizMeets = sqliteTable('quiz_meets', {
   viewerCode: text('viewer_code').notNull(), // admin-set human-readable slug
   divisions: text('divisions').notNull().default('[]'), // JSON string[]
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
-  phase: text('phase', {
-    enum: ['registration', 'build', 'live', 'done'],
-  })
-    .notNull()
-    .default('registration'),
+  phase: text('phase', { enum: MEET_PHASES }).notNull().default('registration'),
   registrationClosesAt: integer('registration_closes_at', { mode: 'timestamp' }),
   meetStartsAt: integer('meet_starts_at', { mode: 'timestamp' }),
 })
 
-// A named physical location within a meet. Renamed from `official_codes` — this
-// row both defines the room (name, sortOrder for grid display) and optionally
-// carries the official-access codeHash. `codeHash` is nullable: admins can
-// create rooms in the `build` phase before issuing an official code.
+// A named physical location within a meet (renamed from `official_codes`).
+// codeHash is nullable so admins can create rooms in 'build' before issuing codes.
 export const meetRooms = sqliteTable('meet_rooms', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   meetId: integer('meet_id')
@@ -206,11 +200,7 @@ export const divisionStates = sqliteTable(
       .notNull()
       .references(() => quizMeets.id, { onDelete: 'cascade' }),
     division: text('division').notNull(),
-    state: text('state', {
-      enum: ['prelim_running', 'stats_break', 'elim_running', 'division_done'],
-    })
-      .notNull()
-      .default('prelim_running'),
+    state: text('state', { enum: DIVISION_STATES }).notNull().default('prelim_running'),
     transitionedAt: integer('transitioned_at', { mode: 'timestamp' }).notNull(),
   },
   (t) => [unique().on(t.meetId, t.division)],

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -56,7 +56,7 @@ app.route('/api', churches)
 export { app }
 
 export default {
-  fetch: app.fetch.bind(app),
+  fetch: app.fetch,
   async scheduled(_controller: ScheduledController, env: Bindings, ctx: ExecutionContext) {
     ctx.waitUntil(
       autoAdvancePhases(createDb(env.DB)).then((res) => {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -10,6 +10,7 @@ import { join } from './routes/join'
 import { memberships } from './routes/memberships'
 import { churches } from './routes/churches'
 import { phase } from './routes/phase'
+import { schedule } from './routes/schedule'
 import { createAuth } from './lib/auth'
 
 const app = new Hono<{ Bindings: Bindings; Variables: SessionVariables }>()
@@ -44,6 +45,7 @@ app.on(['GET', 'POST', 'OPTIONS'], '/api/auth/*', (c) => createAuth(c.env).handl
 app.use('/api/*', sessionMiddleware())
 app.route('/api/meets', meets)
 app.route('/api/meets', phase)
+app.route('/api/meets', schedule)
 app.route('/api/join', join)
 app.route('/api/my-meets', memberships)
 app.route('/api', churches)

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
+import type { ScheduledController, ExecutionContext } from '@cloudflare/workers-types'
 import type { Bindings } from './bindings'
 import type { SessionVariables } from './middleware/session'
 import { sessionMiddleware } from './middleware/session'
@@ -12,6 +13,8 @@ import { churches } from './routes/churches'
 import { phase } from './routes/phase'
 import { schedule } from './routes/schedule'
 import { createAuth } from './lib/auth'
+import { createDb } from './lib/db'
+import { autoAdvancePhases } from './scheduler'
 
 const app = new Hono<{ Bindings: Bindings; Variables: SessionVariables }>()
 
@@ -50,4 +53,17 @@ app.route('/api/join', join)
 app.route('/api/my-meets', memberships)
 app.route('/api', churches)
 
-export default app
+export { app }
+
+export default {
+  fetch: app.fetch.bind(app),
+  async scheduled(_controller: ScheduledController, env: Bindings, ctx: ExecutionContext) {
+    ctx.waitUntil(
+      autoAdvancePhases(createDb(env.DB)).then((res) => {
+        if (res.promotedToBuild > 0 || res.promotedToLive > 0) {
+          console.log('phase auto-advance', res)
+        }
+      }),
+    )
+  },
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,6 +9,7 @@ import { meets } from './routes/meets'
 import { join } from './routes/join'
 import { memberships } from './routes/memberships'
 import { churches } from './routes/churches'
+import { phase } from './routes/phase'
 import { createAuth } from './lib/auth'
 
 const app = new Hono<{ Bindings: Bindings; Variables: SessionVariables }>()
@@ -42,6 +43,7 @@ app.on(['GET', 'POST', 'OPTIONS'], '/api/auth/*', (c) => createAuth(c.env).handl
 // Session middleware for all /api/* routes (except auth, handled above)
 app.use('/api/*', sessionMiddleware())
 app.route('/api/meets', meets)
+app.route('/api/meets', phase)
 app.route('/api/join', join)
 app.route('/api/my-meets', memberships)
 app.route('/api', churches)

--- a/packages/api/src/lib/permissions.ts
+++ b/packages/api/src/lib/permissions.ts
@@ -1,0 +1,24 @@
+import { eq, and } from 'drizzle-orm'
+import { AccountRole } from '@qzr/shared'
+import * as schema from '../db/schema'
+import type { Db } from './db'
+
+/** True if the user is a superuser or has an admin membership for the given meet. */
+export async function isAdminOrSuperuser(
+  db: Db,
+  userId: string,
+  role: AccountRole,
+  meetId: number,
+): Promise<boolean> {
+  if (role === AccountRole.Superuser) return true
+  const [row] = await db
+    .select()
+    .from(schema.adminMemberships)
+    .where(
+      and(
+        eq(schema.adminMemberships.accountId, userId),
+        eq(schema.adminMemberships.meetId, meetId),
+      ),
+    )
+  return !!row
+}

--- a/packages/api/src/routes/__tests__/health.spec.ts
+++ b/packages/api/src/routes/__tests__/health.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import app from '../../index'
+import { app } from '../../index'
 
 // Minimal Bindings stub — only what the health route touches
 const env = { ENVIRONMENT: 'test', DB: {} as D1Database }

--- a/packages/api/src/routes/__tests__/join.spec.ts
+++ b/packages/api/src/routes/__tests__/join.spec.ts
@@ -70,8 +70,8 @@ async function seedOfficialCode(db: Db, meetId: number, label: string) {
   const codeHash = await hashCode(code)
 
   const [row] = await db
-    .insert(schema.officialCodes)
-    .values({ meetId, label, codeHash })
+    .insert(schema.meetRooms)
+    .values({ meetId, name: label, codeHash })
     .returning()
 
   return { officialCode: row!, code }

--- a/packages/api/src/routes/__tests__/memberships.spec.ts
+++ b/packages/api/src/routes/__tests__/memberships.spec.ts
@@ -96,14 +96,14 @@ describe('GET /api/my-meets', () => {
   it('returns official memberships with room label', async () => {
     const meet = await seedMeet(db, 'Official Meet')
     const [code] = await db
-      .insert(schema.officialCodes)
-      .values({ meetId: meet.id, label: 'Room A', codeHash: await hashCode('test') })
+      .insert(schema.meetRooms)
+      .values({ meetId: meet.id, name: 'Room A', codeHash: await hashCode('test') })
       .returning()
 
     await db.insert(schema.officialMemberships).values({
       accountId: testUser.id,
       meetId: meet.id,
-      officialCodeId: code!.id,
+      roomId: code!.id,
     })
 
     const res = await app.request('/api/my-meets', {}, env)

--- a/packages/api/src/routes/__tests__/phase.spec.ts
+++ b/packages/api/src/routes/__tests__/phase.spec.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { eq } from 'drizzle-orm'
+import type { Bindings } from '../../bindings'
+import type { SessionVariables } from '../../middleware/session'
+import { phase } from '../phase'
+import * as schema from '../../db/schema'
+import { mockSession, mockDb, testSuperuser, testUser, jsonOf } from '../../test-utils'
+import { createTestDb } from '../../test-db'
+import type { Db } from '../../lib/db'
+
+const env = { ENVIRONMENT: 'test' } as unknown as Bindings
+
+function createApp(user: typeof testSuperuser | typeof testUser | null, db: Db) {
+  const app = new Hono<{ Bindings: Bindings; Variables: SessionVariables & { db: Db } }>()
+  app.use('*', mockSession(user))
+  app.use('*', mockDb(db))
+  app.route('/api/meets', phase)
+  return app
+}
+
+function postJson(body: Record<string, unknown>) {
+  return {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }
+}
+
+async function seedMeet(db: Db, name = 'Test Meet') {
+  const [meet] = await db
+    .insert(schema.quizMeets)
+    .values({
+      name,
+      dateFrom: '2026-01-01',
+      adminCodeHash: 'x',
+      viewerCode: name.toLowerCase().replace(/\s+/g, '-'),
+      createdAt: new Date(),
+    })
+    .returning()
+  return meet!
+}
+
+describe('POST /api/meets/:id/phase', () => {
+  let db: Db
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(async () => {
+    db = await createTestDb()
+    app = createApp(testSuperuser, db)
+  })
+
+  it('advances registration → build', async () => {
+    const meet = await seedMeet(db)
+    const res = await app.request(`/api/meets/${meet.id}/phase`, postJson({ phase: 'build' }), env)
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ phase: string; reversed: boolean }>(res)
+    expect(body.phase).toBe('build')
+    expect(body.reversed).toBe(false)
+
+    const [updated] = await db
+      .select({ phase: schema.quizMeets.phase })
+      .from(schema.quizMeets)
+      .where(eq(schema.quizMeets.id, meet.id))
+    expect(updated?.phase).toBe('build')
+  })
+
+  it('flags reverse transitions', async () => {
+    const meet = await seedMeet(db)
+    await db.update(schema.quizMeets).set({ phase: 'live' }).where(eq(schema.quizMeets.id, meet.id))
+
+    const res = await app.request(`/api/meets/${meet.id}/phase`, postJson({ phase: 'build' }), env)
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ phase: string; reversed: boolean }>(res)
+    expect(body.phase).toBe('build')
+    expect(body.reversed).toBe(true)
+  })
+
+  it('rejects multi-step transitions', async () => {
+    const meet = await seedMeet(db)
+    const res = await app.request(`/api/meets/${meet.id}/phase`, postJson({ phase: 'live' }), env)
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects invalid phase value', async () => {
+    const meet = await seedMeet(db)
+    const res = await app.request(`/api/meets/${meet.id}/phase`, postJson({ phase: 'bogus' }), env)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns unchanged when target equals current', async () => {
+    const meet = await seedMeet(db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/phase`,
+      postJson({ phase: 'registration' }),
+      env,
+    )
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ unchanged?: boolean }>(res)
+    expect(body.unchanged).toBe(true)
+  })
+
+  it('requires admin', async () => {
+    const meet = await seedMeet(db)
+    const userApp = createApp(testUser, db)
+    const res = await userApp.request(
+      `/api/meets/${meet.id}/phase`,
+      postJson({ phase: 'build' }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 404 for missing meet', async () => {
+    const res = await app.request('/api/meets/99999/phase', postJson({ phase: 'build' }), env)
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('POST /api/meets/:id/divisions/:division/state', () => {
+  let db: Db
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(async () => {
+    db = await createTestDb()
+    app = createApp(testSuperuser, db)
+  })
+
+  async function liveMeet(name = 'Live Meet') {
+    const meet = await seedMeet(db, name)
+    await db.update(schema.quizMeets).set({ phase: 'live' }).where(eq(schema.quizMeets.id, meet.id))
+    return meet
+  }
+
+  it('initializes division at prelim_running implicitly on first transition', async () => {
+    const meet = await liveMeet()
+    const res = await app.request(
+      `/api/meets/${meet.id}/divisions/Division 1/state`,
+      postJson({ state: 'stats_break' }),
+      env,
+    )
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ state: string }>(res)
+    expect(body.state).toBe('stats_break')
+
+    const [row] = await db
+      .select()
+      .from(schema.divisionStates)
+      .where(eq(schema.divisionStates.meetId, meet.id))
+    expect(row?.state).toBe('stats_break')
+  })
+
+  it('rejects multi-step from implicit prelim_running', async () => {
+    const meet = await liveMeet()
+    const res = await app.request(
+      `/api/meets/${meet.id}/divisions/Division 1/state`,
+      postJson({ state: 'elim_running' }),
+      env,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('advances stats_break → elim_running', async () => {
+    const meet = await liveMeet()
+    await db.insert(schema.divisionStates).values({
+      meetId: meet.id,
+      division: 'Division 1',
+      state: 'stats_break',
+      transitionedAt: new Date(),
+    })
+
+    const res = await app.request(
+      `/api/meets/${meet.id}/divisions/Division 1/state`,
+      postJson({ state: 'elim_running' }),
+      env,
+    )
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ state: string }>(res)
+    expect(body.state).toBe('elim_running')
+  })
+
+  it('flags reverse transitions', async () => {
+    const meet = await liveMeet()
+    await db.insert(schema.divisionStates).values({
+      meetId: meet.id,
+      division: 'Division 1',
+      state: 'elim_running',
+      transitionedAt: new Date(),
+    })
+
+    const res = await app.request(
+      `/api/meets/${meet.id}/divisions/Division 1/state`,
+      postJson({ state: 'stats_break' }),
+      env,
+    )
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ state: string; reversed: boolean }>(res)
+    expect(body.state).toBe('stats_break')
+    expect(body.reversed).toBe(true)
+  })
+
+  it('rejects state changes when meet is not live', async () => {
+    const meet = await seedMeet(db) // phase='registration'
+    const res = await app.request(
+      `/api/meets/${meet.id}/divisions/Division 1/state`,
+      postJson({ state: 'stats_break' }),
+      env,
+    )
+    expect(res.status).toBe(409)
+  })
+
+  it('requires admin', async () => {
+    const meet = await liveMeet()
+    const userApp = createApp(testUser, db)
+    const res = await userApp.request(
+      `/api/meets/${meet.id}/divisions/Division 1/state`,
+      postJson({ state: 'stats_break' }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('GET /api/meets/:id/divisions/state', () => {
+  let db: Db
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(async () => {
+    db = await createTestDb()
+    app = createApp(testSuperuser, db)
+  })
+
+  it('returns empty list when no transitions yet', async () => {
+    const meet = await seedMeet(db)
+    const res = await app.request(`/api/meets/${meet.id}/divisions/state`, {}, env)
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ divisionStates: unknown[] }>(res)
+    expect(body.divisionStates).toEqual([])
+  })
+
+  it('returns recorded states', async () => {
+    const meet = await seedMeet(db)
+    await db.insert(schema.divisionStates).values([
+      {
+        meetId: meet.id,
+        division: 'Division 1',
+        state: 'stats_break',
+        transitionedAt: new Date(),
+      },
+      {
+        meetId: meet.id,
+        division: 'Division 2',
+        state: 'elim_running',
+        transitionedAt: new Date(),
+      },
+    ])
+
+    const res = await app.request(`/api/meets/${meet.id}/divisions/state`, {}, env)
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ divisionStates: { division: string; state: string }[] }>(res)
+    expect(body.divisionStates).toHaveLength(2)
+    const states = body.divisionStates.reduce<Record<string, string>>(
+      (acc, r) => ({ ...acc, [r.division]: r.state }),
+      {},
+    )
+    expect(states['Division 1']).toBe('stats_break')
+    expect(states['Division 2']).toBe('elim_running')
+  })
+})

--- a/packages/api/src/routes/__tests__/phase.spec.ts
+++ b/packages/api/src/routes/__tests__/phase.spec.ts
@@ -5,7 +5,15 @@ import type { Bindings } from '../../bindings'
 import type { SessionVariables } from '../../middleware/session'
 import { phase } from '../phase'
 import * as schema from '../../db/schema'
-import { mockSession, mockDb, testSuperuser, testUser, jsonOf } from '../../test-utils'
+import {
+  mockSession,
+  mockDb,
+  testSuperuser,
+  testUser,
+  jsonOf,
+  jsonRequest,
+  seedMeet,
+} from '../../test-utils'
 import { createTestDb } from '../../test-db'
 import type { Db } from '../../lib/db'
 
@@ -19,27 +27,7 @@ function createApp(user: typeof testSuperuser | typeof testUser | null, db: Db) 
   return app
 }
 
-function postJson(body: Record<string, unknown>) {
-  return {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  }
-}
-
-async function seedMeet(db: Db, name = 'Test Meet') {
-  const [meet] = await db
-    .insert(schema.quizMeets)
-    .values({
-      name,
-      dateFrom: '2026-01-01',
-      adminCodeHash: 'x',
-      viewerCode: name.toLowerCase().replace(/\s+/g, '-'),
-      createdAt: new Date(),
-    })
-    .returning()
-  return meet!
-}
+const postJson = (body: Record<string, unknown>) => jsonRequest('POST', body)
 
 describe('POST /api/meets/:id/phase', () => {
   let db: Db

--- a/packages/api/src/routes/__tests__/phase.spec.ts
+++ b/packages/api/src/routes/__tests__/phase.spec.ts
@@ -254,4 +254,11 @@ describe('GET /api/meets/:id/divisions/state', () => {
     expect(states['Division 1']).toBe('stats_break')
     expect(states['Division 2']).toBe('elim_running')
   })
+
+  it('requires admin', async () => {
+    const meet = await seedMeet(db)
+    const userApp = createApp(testUser, db)
+    const res = await userApp.request(`/api/meets/${meet.id}/divisions/state`, {}, env)
+    expect(res.status).toBe(403)
+  })
 })

--- a/packages/api/src/routes/__tests__/schedule.spec.ts
+++ b/packages/api/src/routes/__tests__/schedule.spec.ts
@@ -5,7 +5,15 @@ import type { Bindings } from '../../bindings'
 import type { SessionVariables } from '../../middleware/session'
 import { schedule } from '../schedule'
 import * as schema from '../../db/schema'
-import { mockSession, mockDb, testSuperuser, testUser, jsonOf } from '../../test-utils'
+import {
+  mockSession,
+  mockDb,
+  testSuperuser,
+  testUser,
+  jsonOf,
+  jsonRequest,
+  seedMeet,
+} from '../../test-utils'
 import { createTestDb } from '../../test-db'
 import type { Db } from '../../lib/db'
 
@@ -19,35 +27,8 @@ function createApp(user: typeof testSuperuser | typeof testUser | null, db: Db) 
   return app
 }
 
-function postJson(body: Record<string, unknown>) {
-  return {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  }
-}
-
-function patchJson(body: Record<string, unknown>) {
-  return {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  }
-}
-
-async function seedMeet(db: Db, name = 'Test Meet') {
-  const [meet] = await db
-    .insert(schema.quizMeets)
-    .values({
-      name,
-      dateFrom: '2026-01-01',
-      adminCodeHash: 'x',
-      viewerCode: name.toLowerCase().replace(/\s+/g, '-'),
-      createdAt: new Date(),
-    })
-    .returning()
-  return meet!
-}
+const postJson = (body: Record<string, unknown>) => jsonRequest('POST', body)
+const patchJson = (body: Record<string, unknown>) => jsonRequest('PATCH', body)
 
 async function seedRoom(db: Db, meetId: number, name: string, sortOrder = 0) {
   const [room] = await db.insert(schema.meetRooms).values({ meetId, name, sortOrder }).returning()

--- a/packages/api/src/routes/__tests__/schedule.spec.ts
+++ b/packages/api/src/routes/__tests__/schedule.spec.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { eq } from 'drizzle-orm'
+import type { Bindings } from '../../bindings'
+import type { SessionVariables } from '../../middleware/session'
+import { schedule } from '../schedule'
+import * as schema from '../../db/schema'
+import { mockSession, mockDb, testSuperuser, testUser, jsonOf } from '../../test-utils'
+import { createTestDb } from '../../test-db'
+import type { Db } from '../../lib/db'
+
+const env = { ENVIRONMENT: 'test' } as unknown as Bindings
+
+function createApp(user: typeof testSuperuser | typeof testUser | null, db: Db) {
+  const app = new Hono<{ Bindings: Bindings; Variables: SessionVariables & { db: Db } }>()
+  app.use('*', mockSession(user))
+  app.use('*', mockDb(db))
+  app.route('/api/meets', schedule)
+  return app
+}
+
+function postJson(body: Record<string, unknown>) {
+  return {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }
+}
+
+function patchJson(body: Record<string, unknown>) {
+  return {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }
+}
+
+async function seedMeet(db: Db, name = 'Test Meet') {
+  const [meet] = await db
+    .insert(schema.quizMeets)
+    .values({
+      name,
+      dateFrom: '2026-01-01',
+      adminCodeHash: 'x',
+      viewerCode: name.toLowerCase().replace(/\s+/g, '-'),
+      createdAt: new Date(),
+    })
+    .returning()
+  return meet!
+}
+
+async function seedRoom(db: Db, meetId: number, name: string, sortOrder = 0) {
+  const [room] = await db.insert(schema.meetRooms).values({ meetId, name, sortOrder }).returning()
+  return room!
+}
+
+async function seedSlot(db: Db, meetId: number, sortOrder = 0) {
+  const [slot] = await db
+    .insert(schema.meetSlots)
+    .values({
+      meetId,
+      startAt: new Date('2026-01-01T20:00:00Z'),
+      durationMinutes: 25,
+      kind: 'quiz',
+      sortOrder,
+    })
+    .returning()
+  return slot!
+}
+
+describe('GET /api/meets/:id/rooms', () => {
+  let db: Db
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(async () => {
+    db = await createTestDb()
+    app = createApp(testSuperuser, db)
+  })
+
+  it('returns rooms ordered by sortOrder then id', async () => {
+    const meet = await seedMeet(db)
+    await seedRoom(db, meet.id, 'Room B', 1)
+    await seedRoom(db, meet.id, 'Room A', 0)
+
+    const res = await app.request(`/api/meets/${meet.id}/rooms`, {}, env)
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ rooms: { name: string; sortOrder: number; hasCode: boolean }[] }>(
+      res,
+    )
+    expect(body.rooms.map((r) => r.name)).toEqual(['Room A', 'Room B'])
+    expect(body.rooms[0]!.hasCode).toBe(false)
+  })
+
+  it('reflects hasCode when codeHash is set', async () => {
+    const meet = await seedMeet(db)
+    await db.insert(schema.meetRooms).values({
+      meetId: meet.id,
+      name: 'Room A',
+      sortOrder: 0,
+      codeHash: 'somehash',
+    })
+
+    const res = await app.request(`/api/meets/${meet.id}/rooms`, {}, env)
+    const body = await jsonOf<{ rooms: { hasCode: boolean }[] }>(res)
+    expect(body.rooms[0]!.hasCode).toBe(true)
+  })
+})
+
+describe('PATCH /api/meets/:id/rooms/:roomId', () => {
+  let db: Db
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(async () => {
+    db = await createTestDb()
+    app = createApp(testSuperuser, db)
+  })
+
+  it('renames a room', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Room A')
+
+    const res = await app.request(
+      `/api/meets/${meet.id}/rooms/${room.id}`,
+      patchJson({ name: 'Sanctuary' }),
+      env,
+    )
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ room: { name: string } }>(res)
+    expect(body.room.name).toBe('Sanctuary')
+  })
+
+  it('updates sortOrder', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Room A', 0)
+
+    const res = await app.request(
+      `/api/meets/${meet.id}/rooms/${room.id}`,
+      patchJson({ sortOrder: 5 }),
+      env,
+    )
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ room: { sortOrder: number } }>(res)
+    expect(body.room.sortOrder).toBe(5)
+  })
+
+  it('rejects unknown room', async () => {
+    const meet = await seedMeet(db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/rooms/9999`,
+      patchJson({ name: 'Nope' }),
+      env,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('requires admin', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Room A')
+    const userApp = createApp(testUser, db)
+    const res = await userApp.request(
+      `/api/meets/${meet.id}/rooms/${room.id}`,
+      patchJson({ name: 'Nope' }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('slots CRUD', () => {
+  let db: Db
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(async () => {
+    db = await createTestDb()
+    app = createApp(testSuperuser, db)
+  })
+
+  it('creates, lists, updates, deletes a slot', async () => {
+    const meet = await seedMeet(db)
+
+    const created = await app.request(
+      `/api/meets/${meet.id}/slots`,
+      postJson({
+        startAt: '2026-01-01T20:00:00Z',
+        durationMinutes: 25,
+        kind: 'quiz',
+        sortOrder: 0,
+      }),
+      env,
+    )
+    expect(created.status).toBe(201)
+    const { slot } = await jsonOf<{ slot: { id: number } }>(created)
+
+    const list = await app.request(`/api/meets/${meet.id}/slots`, {}, env)
+    expect(list.status).toBe(200)
+    const listed = await jsonOf<{ slots: unknown[] }>(list)
+    expect(listed.slots).toHaveLength(1)
+
+    const patched = await app.request(
+      `/api/meets/${meet.id}/slots/${slot.id}`,
+      patchJson({ durationMinutes: 30 }),
+      env,
+    )
+    expect(patched.status).toBe(200)
+    const patchedBody = await jsonOf<{ slot: { durationMinutes: number } }>(patched)
+    expect(patchedBody.slot.durationMinutes).toBe(30)
+
+    const deleted = await app.request(
+      `/api/meets/${meet.id}/slots/${slot.id}`,
+      { method: 'DELETE' },
+      env,
+    )
+    expect(deleted.status).toBe(200)
+  })
+
+  it('rejects invalid kind', async () => {
+    const meet = await seedMeet(db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/slots`,
+      postJson({ startAt: 0, durationMinutes: 25, kind: 'bogus', sortOrder: 0 }),
+      env,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('creates an event slot with a label', async () => {
+    const meet = await seedMeet(db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/slots`,
+      postJson({
+        startAt: '2026-01-02T08:00:00Z',
+        durationMinutes: 60,
+        kind: 'event',
+        eventLabel: 'Breakfast',
+        sortOrder: 5,
+      }),
+      env,
+    )
+    expect(res.status).toBe(201)
+    const body = await jsonOf<{ slot: { kind: string; eventLabel: string } }>(res)
+    expect(body.slot.kind).toBe('event')
+    expect(body.slot.eventLabel).toBe('Breakfast')
+  })
+})
+
+describe('quizzes + seats CRUD', () => {
+  let db: Db
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(async () => {
+    db = await createTestDb()
+    app = createApp(testSuperuser, db)
+  })
+
+  it('creates a quiz with seats and lists it back', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Room A')
+    const slot = await seedSlot(db, meet.id)
+
+    const created = await app.request(
+      `/api/meets/${meet.id}/quizzes`,
+      postJson({
+        slotId: slot.id,
+        roomId: room.id,
+        division: 'Division 1',
+        phase: 'prelim',
+        label: 'Div 1 Quiz 1',
+        seats: [
+          { seatNumber: 1, letter: 'A' },
+          { seatNumber: 2, letter: 'B' },
+          { seatNumber: 3, letter: 'C' },
+        ],
+      }),
+      env,
+    )
+    expect(created.status).toBe(201)
+
+    const list = await app.request(`/api/meets/${meet.id}/quizzes`, {}, env)
+    expect(list.status).toBe(200)
+    const body = await jsonOf<{ quizzes: { label: string; seats: { letter: string }[] }[] }>(list)
+    expect(body.quizzes).toHaveLength(1)
+    expect(body.quizzes[0]!.label).toBe('Div 1 Quiz 1')
+    expect(body.quizzes[0]!.seats).toHaveLength(3)
+    const letters = body.quizzes[0]!.seats.map((s) => s.letter).sort()
+    expect(letters).toEqual(['A', 'B', 'C'])
+  })
+
+  it('blocks edits and deletes on completed quizzes', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Room A')
+    const slot = await seedSlot(db, meet.id)
+    const [quiz] = await db
+      .insert(schema.scheduledQuizzes)
+      .values({
+        meetId: meet.id,
+        slotId: slot.id,
+        roomId: room.id,
+        division: 'Division 1',
+        phase: 'prelim',
+        label: 'Done Quiz',
+        completedAt: new Date(),
+      })
+      .returning()
+
+    const patchRes = await app.request(
+      `/api/meets/${meet.id}/quizzes/${quiz!.id}`,
+      patchJson({ label: 'Renamed' }),
+      env,
+    )
+    expect(patchRes.status).toBe(409)
+
+    const deleteRes = await app.request(
+      `/api/meets/${meet.id}/quizzes/${quiz!.id}`,
+      { method: 'DELETE' },
+      env,
+    )
+    expect(deleteRes.status).toBe(409)
+
+    const seatsRes = await app.request(
+      `/api/meets/${meet.id}/quizzes/${quiz!.id}/seats`,
+      patchJson({ seats: [{ seatNumber: 1, letter: 'A' }] }),
+      env,
+    )
+    expect(seatsRes.status).toBe(409)
+  })
+
+  it('replaces seats transactionally', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Room A')
+    const slot = await seedSlot(db, meet.id)
+    const [quiz] = await db
+      .insert(schema.scheduledQuizzes)
+      .values({
+        meetId: meet.id,
+        slotId: slot.id,
+        roomId: room.id,
+        division: 'Division 1',
+        phase: 'prelim',
+        label: 'Q1',
+      })
+      .returning()
+    await db.insert(schema.scheduledQuizSeats).values([
+      { quizId: quiz!.id, seatNumber: 1, letter: 'A' },
+      { quizId: quiz!.id, seatNumber: 2, letter: 'B' },
+    ])
+
+    const res = await app.request(
+      `/api/meets/${meet.id}/quizzes/${quiz!.id}/seats`,
+      patchJson({
+        seats: [
+          { seatNumber: 1, letter: 'X' },
+          { seatNumber: 2, letter: 'Y' },
+          { seatNumber: 3, letter: 'Z' },
+        ],
+      }),
+      env,
+    )
+    expect(res.status).toBe(200)
+
+    const stored = await db
+      .select()
+      .from(schema.scheduledQuizSeats)
+      .where(eq(schema.scheduledQuizSeats.quizId, quiz!.id))
+    const letters = stored.map((s) => s.letter).sort()
+    expect(letters).toEqual(['X', 'Y', 'Z'])
+  })
+
+  it('requires admin for mutations', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Room A')
+    const slot = await seedSlot(db, meet.id)
+    const userApp = createApp(testUser, db)
+
+    const res = await userApp.request(
+      `/api/meets/${meet.id}/quizzes`,
+      postJson({
+        slotId: slot.id,
+        roomId: room.id,
+        division: 'Division 1',
+        phase: 'prelim',
+        label: 'Nope',
+      }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/api/src/routes/churches.ts
+++ b/packages/api/src/routes/churches.ts
@@ -5,6 +5,7 @@ import type { SessionVariables } from '../middleware/session'
 import { requireAuth, requireSuperuser, getUser } from '../middleware/session'
 import { createDb, type Db } from '../lib/db'
 import { generateCode, hashCode } from '../lib/codes'
+import { isAdminOrSuperuser } from '../lib/permissions'
 import * as schema from '../db/schema'
 import { AccountRole } from '@qzr/shared'
 
@@ -27,21 +28,6 @@ churches.use('*', async (c, next) => {
 
 function getDb(c: { get(key: 'db'): Db }): Db {
   return c.get('db')
-}
-
-/** Returns true if the user is a superuser or has an admin membership for the given meet. */
-async function isAdminOrSuperuser(db: Db, userId: string, role: AccountRole, meetId: number) {
-  if (role === AccountRole.Superuser) return true
-  const [row] = await db
-    .select()
-    .from(schema.adminMemberships)
-    .where(
-      and(
-        eq(schema.adminMemberships.accountId, userId),
-        eq(schema.adminMemberships.meetId, meetId),
-      ),
-    )
-  return !!row
 }
 
 /** Returns true if the user can edit the given church (coach membership, admin, or superuser). */

--- a/packages/api/src/routes/join.ts
+++ b/packages/api/src/routes/join.ts
@@ -133,12 +133,12 @@ join.post('/', requireAuth(), async (c) => {
   // 2c. Try official codes
   const [officialMatch] = await db
     .select({
-      codeId: schema.officialCodes.id,
-      meetId: schema.officialCodes.meetId,
-      label: schema.officialCodes.label,
+      codeId: schema.meetRooms.id,
+      meetId: schema.meetRooms.meetId,
+      label: schema.meetRooms.name,
     })
-    .from(schema.officialCodes)
-    .where(eq(schema.officialCodes.codeHash, codeHash))
+    .from(schema.meetRooms)
+    .where(eq(schema.meetRooms.codeHash, codeHash))
 
   if (officialMatch) {
     const [meet] = await db
@@ -154,14 +154,14 @@ join.post('/', requireAuth(), async (c) => {
           and(
             eq(schema.officialMemberships.accountId, user.id),
             eq(schema.officialMemberships.meetId, officialMatch.meetId),
-            eq(schema.officialMemberships.officialCodeId, officialMatch.codeId),
+            eq(schema.officialMemberships.roomId, officialMatch.codeId),
           ),
         )
       if (!existing) {
         await db.insert(schema.officialMemberships).values({
           accountId: user.id,
           meetId: officialMatch.meetId,
-          officialCodeId: officialMatch.codeId,
+          roomId: officialMatch.codeId,
         })
       }
       return c.json({
@@ -213,12 +213,12 @@ join.post('/guest', async (c) => {
 
   const [officialMatch] = await db
     .select({
-      codeId: schema.officialCodes.id,
-      meetId: schema.officialCodes.meetId,
-      label: schema.officialCodes.label,
+      codeId: schema.meetRooms.id,
+      meetId: schema.meetRooms.meetId,
+      label: schema.meetRooms.name,
     })
-    .from(schema.officialCodes)
-    .where(eq(schema.officialCodes.codeHash, codeHash))
+    .from(schema.meetRooms)
+    .where(eq(schema.meetRooms.codeHash, codeHash))
 
   if (officialMatch) {
     const [meet] = await db

--- a/packages/api/src/routes/meets.ts
+++ b/packages/api/src/routes/meets.ts
@@ -88,11 +88,6 @@ meets.get('/:id', async (c) => {
 
   const id = meet.id
 
-  const roomsP = db
-    .select({ id: schema.meetRooms.id, label: schema.meetRooms.name })
-    .from(schema.meetRooms)
-    .where(eq(schema.meetRooms.meetId, id))
-
   if (user.role !== AccountRole.Superuser) {
     const [[admin], [coach], [official], [viewer]] = await Promise.all([
       db
@@ -135,7 +130,12 @@ meets.get('/:id', async (c) => {
     if (!admin && !coach && !official && !viewer) return c.json({ error: 'Forbidden' }, 403)
   }
 
-  return c.json({ meet: formatMeet(meet), officialCodes: await roomsP })
+  const codes = await db
+    .select({ id: schema.meetRooms.id, label: schema.meetRooms.name })
+    .from(schema.meetRooms)
+    .where(eq(schema.meetRooms.meetId, id))
+
+  return c.json({ meet: formatMeet(meet), officialCodes: codes })
 })
 
 meets.patch('/:id', async (c) => {
@@ -166,11 +166,22 @@ meets.patch('/:id', async (c) => {
     updates.divisions = JSON.stringify(body.divisions.map((d: string) => d.trim()).filter(Boolean))
   }
   if ('registrationClosesAt' in body) {
-    updates.registrationClosesAt =
-      body.registrationClosesAt == null ? null : new Date(body.registrationClosesAt)
+    if (body.registrationClosesAt == null) {
+      updates.registrationClosesAt = null
+    } else {
+      const d = new Date(body.registrationClosesAt)
+      if (Number.isNaN(d.getTime())) return c.json({ error: 'Invalid registrationClosesAt' }, 400)
+      updates.registrationClosesAt = d
+    }
   }
   if ('meetStartsAt' in body) {
-    updates.meetStartsAt = body.meetStartsAt == null ? null : new Date(body.meetStartsAt)
+    if (body.meetStartsAt == null) {
+      updates.meetStartsAt = null
+    } else {
+      const d = new Date(body.meetStartsAt)
+      if (Number.isNaN(d.getTime())) return c.json({ error: 'Invalid meetStartsAt' }, 400)
+      updates.meetStartsAt = d
+    }
   }
 
   if (Object.keys(updates).length === 0) {

--- a/packages/api/src/routes/meets.ts
+++ b/packages/api/src/routes/meets.ts
@@ -5,6 +5,7 @@ import type { SessionVariables } from '../middleware/session'
 import { requireAuth, requireSuperuser, getUser } from '../middleware/session'
 import { createDb, type Db } from '../lib/db'
 import { generateCode, hashCode } from '../lib/codes'
+import { isAdminOrSuperuser } from '../lib/permissions'
 import * as schema from '../db/schema'
 import { AccountRole, MeetRole } from '@qzr/shared'
 
@@ -29,21 +30,6 @@ meets.use('*', async (c, next) => {
 
 function getDb(c: { get(key: 'db'): Db }): Db {
   return c.get('db')
-}
-
-/** Returns true if the user is a superuser or has an admin membership for the given meet. */
-async function isAdminOrSuperuser(db: Db, userId: string, role: AccountRole, meetId: number) {
-  if (role === AccountRole.Superuser) return true
-  const [row] = await db
-    .select()
-    .from(schema.adminMemberships)
-    .where(
-      and(
-        eq(schema.adminMemberships.accountId, userId),
-        eq(schema.adminMemberships.meetId, meetId),
-      ),
-    )
-  return !!row
 }
 
 // ---- Meet CRUD ----

--- a/packages/api/src/routes/meets.ts
+++ b/packages/api/src/routes/meets.ts
@@ -155,14 +155,23 @@ meets.patch('/:id', async (c) => {
     dateTo?: string
     viewerCode?: string
     divisions?: string[]
+    registrationClosesAt?: string | number | null
+    meetStartsAt?: string | number | null
   }>()
-  const updates: Record<string, string | null> = {}
+  const updates: Record<string, string | number | Date | null> = {}
   if (body.name?.trim()) updates.name = body.name.trim()
   if (body.dateFrom?.trim()) updates.dateFrom = body.dateFrom.trim()
   if ('dateTo' in body) updates.dateTo = body.dateTo?.trim() ?? null
   if (body.viewerCode?.trim()) updates.viewerCode = body.viewerCode.trim()
   if (Array.isArray(body.divisions) && body.divisions.length > 0) {
     updates.divisions = JSON.stringify(body.divisions.map((d: string) => d.trim()).filter(Boolean))
+  }
+  if ('registrationClosesAt' in body) {
+    updates.registrationClosesAt =
+      body.registrationClosesAt == null ? null : new Date(body.registrationClosesAt)
+  }
+  if ('meetStartsAt' in body) {
+    updates.meetStartsAt = body.meetStartsAt == null ? null : new Date(body.meetStartsAt)
   }
 
   if (Object.keys(updates).length === 0) {
@@ -467,6 +476,9 @@ function formatMeet(meet: schema.QuizMeet) {
     viewerCode: meet.viewerCode,
     divisions: JSON.parse(meet.divisions) as string[],
     createdAt: meet.createdAt,
+    phase: meet.phase,
+    registrationClosesAt: meet.registrationClosesAt,
+    meetStartsAt: meet.meetStartsAt,
   }
 }
 

--- a/packages/api/src/routes/meets.ts
+++ b/packages/api/src/routes/meets.ts
@@ -88,7 +88,11 @@ meets.get('/:id', async (c) => {
 
   const id = meet.id
 
-  // Superusers have access to all meets; others must have a membership
+  const roomsP = db
+    .select({ id: schema.meetRooms.id, label: schema.meetRooms.name })
+    .from(schema.meetRooms)
+    .where(eq(schema.meetRooms.meetId, id))
+
   if (user.role !== AccountRole.Superuser) {
     const [[admin], [coach], [official], [viewer]] = await Promise.all([
       db
@@ -131,12 +135,7 @@ meets.get('/:id', async (c) => {
     if (!admin && !coach && !official && !viewer) return c.json({ error: 'Forbidden' }, 403)
   }
 
-  const codes = await db
-    .select({ id: schema.meetRooms.id, label: schema.meetRooms.name })
-    .from(schema.meetRooms)
-    .where(eq(schema.meetRooms.meetId, id))
-
-  return c.json({ meet: formatMeet(meet), officialCodes: codes })
+  return c.json({ meet: formatMeet(meet), officialCodes: await roomsP })
 })
 
 meets.patch('/:id', async (c) => {

--- a/packages/api/src/routes/meets.ts
+++ b/packages/api/src/routes/meets.ts
@@ -146,9 +146,9 @@ meets.get('/:id', async (c) => {
   }
 
   const codes = await db
-    .select({ id: schema.officialCodes.id, label: schema.officialCodes.label })
-    .from(schema.officialCodes)
-    .where(eq(schema.officialCodes.meetId, id))
+    .select({ id: schema.meetRooms.id, label: schema.meetRooms.name })
+    .from(schema.meetRooms)
+    .where(eq(schema.meetRooms.meetId, id))
 
   return c.json({ meet: formatMeet(meet), officialCodes: codes })
 })
@@ -268,11 +268,11 @@ meets.post('/:id/official-codes', async (c) => {
   const codeHash = await hashCode(code)
 
   const [created] = await db
-    .insert(schema.officialCodes)
-    .values({ meetId, label: body.label.trim(), codeHash })
+    .insert(schema.meetRooms)
+    .values({ meetId, name: body.label.trim(), codeHash })
     .returning()
 
-  return c.json({ officialCode: { id: created!.id, label: created!.label }, code }, 201)
+  return c.json({ officialCode: { id: created!.id, label: created!.name }, code }, 201)
 })
 
 meets.delete('/:id/official-codes/:codeId', async (c) => {
@@ -289,9 +289,9 @@ meets.delete('/:id/official-codes/:codeId', async (c) => {
   }
 
   const deleted = await db
-    .delete(schema.officialCodes)
-    .where(eq(schema.officialCodes.id, codeId))
-    .returning({ id: schema.officialCodes.id })
+    .delete(schema.meetRooms)
+    .where(eq(schema.meetRooms.id, codeId))
+    .returning({ id: schema.meetRooms.id })
 
   if (deleted.length === 0) return c.json({ error: 'Official code not found' }, 404)
   return c.json({ deleted: true })
@@ -314,10 +314,10 @@ meets.post('/:id/official-codes/:codeId/rotate', async (c) => {
   const codeHash = await hashCode(code)
 
   const [updated] = await db
-    .update(schema.officialCodes)
+    .update(schema.meetRooms)
     .set({ codeHash })
-    .where(eq(schema.officialCodes.id, codeId))
-    .returning({ id: schema.officialCodes.id, label: schema.officialCodes.label })
+    .where(eq(schema.meetRooms.id, codeId))
+    .returning({ id: schema.meetRooms.id, label: schema.meetRooms.name })
 
   if (!updated) return c.json({ error: 'Official code not found' }, 404)
   return c.json({ officialCode: updated, code })
@@ -331,7 +331,7 @@ interface MeetMember {
   email: string
   role: MeetRole
   churchId?: number
-  officialCodeId?: number
+  officialCodeId?: number // preserved API field name (maps to room id)
 }
 
 meets.get('/:id/members', async (c) => {
@@ -369,7 +369,7 @@ meets.get('/:id/members', async (c) => {
         userId: schema.officialMemberships.accountId,
         name: schema.user.name,
         email: schema.user.email,
-        officialCodeId: schema.officialMemberships.officialCodeId,
+        officialCodeId: schema.officialMemberships.roomId,
       })
       .from(schema.officialMemberships)
       .innerJoin(schema.user, eq(schema.officialMemberships.accountId, schema.user.id))
@@ -446,7 +446,7 @@ meets.delete('/:id/members/:userId', async (c) => {
         and(
           eq(schema.officialMemberships.accountId, targetUserId),
           eq(schema.officialMemberships.meetId, meetId),
-          eq(schema.officialMemberships.officialCodeId, body.officialCodeId),
+          eq(schema.officialMemberships.roomId, body.officialCodeId),
         ),
       )
       .returning()

--- a/packages/api/src/routes/memberships.ts
+++ b/packages/api/src/routes/memberships.ts
@@ -113,14 +113,11 @@ memberships.get('/', async (c) => {
       meetId: schema.officialMemberships.meetId,
       meetName: schema.quizMeets.name,
       viewerCode: schema.quizMeets.viewerCode,
-      label: schema.officialCodes.label,
+      label: schema.meetRooms.name,
     })
     .from(schema.officialMemberships)
     .innerJoin(schema.quizMeets, eq(schema.officialMemberships.meetId, schema.quizMeets.id))
-    .innerJoin(
-      schema.officialCodes,
-      eq(schema.officialMemberships.officialCodeId, schema.officialCodes.id),
-    )
+    .innerJoin(schema.meetRooms, eq(schema.officialMemberships.roomId, schema.meetRooms.id))
     .where(eq(schema.officialMemberships.accountId, user.id))
 
   for (const row of officialRows) {

--- a/packages/api/src/routes/phase.ts
+++ b/packages/api/src/routes/phase.ts
@@ -174,7 +174,12 @@ phase.get('/:id/divisions/state', async (c) => {
   const meetId = Number(c.req.param('id'))
   if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
 
+  const user = getUser(c)
   const db = getDb(c)
+  if (!(await isAdminOrSuperuser(db, user.id, user.role, meetId))) {
+    return c.json({ error: 'Admin or superuser access required' }, 403)
+  }
+
   const rows = await db
     .select({
       division: schema.divisionStates.division,

--- a/packages/api/src/routes/phase.ts
+++ b/packages/api/src/routes/phase.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { eq, and } from 'drizzle-orm'
+import { MEET_PHASES, DIVISION_STATES, type MeetPhase, type DivisionStateValue } from '@qzr/shared'
 import type { Bindings } from '../bindings'
 import type { SessionVariables } from '../middleware/session'
 import { requireAuth, getUser } from '../middleware/session'
@@ -27,27 +28,32 @@ function getDb(c: { get(key: 'db'): Db }): Db {
   return c.get('db')
 }
 
-const MEET_PHASES = ['registration', 'build', 'live', 'done'] as const
-type MeetPhase = (typeof MEET_PHASES)[number]
+/**
+ * Single-step state-machine validator. Reused for both meet phase and per-division
+ * state because they share the exact same forward/reverse/multi-step semantics.
+ */
+type TransitionResult<T> =
+  | { kind: 'ok'; reversed: boolean }
+  | { kind: 'unchanged' }
+  | { kind: 'multi-step'; from: T; to: T }
+  | { kind: 'invalid' }
 
-const DIVISION_STATES = ['prelim_running', 'stats_break', 'elim_running', 'division_done'] as const
-type DivisionStateValue = (typeof DIVISION_STATES)[number]
-
-function phaseIndex(p: MeetPhase): number {
-  return MEET_PHASES.indexOf(p)
-}
-
-function divisionStateIndex(s: DivisionStateValue): number {
-  return DIVISION_STATES.indexOf(s)
+function validateTransition<T extends string>(
+  seq: readonly T[],
+  from: T,
+  to: T,
+): TransitionResult<T> {
+  if (!seq.includes(to)) return { kind: 'invalid' }
+  const fromIdx = seq.indexOf(from)
+  const toIdx = seq.indexOf(to)
+  if (toIdx === fromIdx) return { kind: 'unchanged' }
+  if (Math.abs(toIdx - fromIdx) > 1) return { kind: 'multi-step', from, to }
+  return { kind: 'ok', reversed: toIdx < fromIdx }
 }
 
 /**
- * POST /api/meets/:id/phase
- * Body: { phase: 'registration' | 'build' | 'live' | 'done' }
- *
- * Advance or revert the meet phase. Forward transitions require single-step
- * advance (no jumping registration → live). Reverse transitions are allowed
- * but flagged in the response so the UI can warn the admin.
+ * Advance or revert the meet phase. Single-step only; reverses are allowed
+ * but flagged in the response so the UI can warn.
  */
 phase.post('/:id/phase', async (c) => {
   const meetId = Number(c.req.param('id'))
@@ -60,9 +66,6 @@ phase.post('/:id/phase', async (c) => {
   }
 
   const body = await c.req.json<{ phase: MeetPhase }>()
-  if (!MEET_PHASES.includes(body.phase)) {
-    return c.json({ error: 'Invalid phase' }, 400)
-  }
 
   const [meet] = await db
     .select({ id: schema.quizMeets.id, phase: schema.quizMeets.phase })
@@ -70,33 +73,29 @@ phase.post('/:id/phase', async (c) => {
     .where(eq(schema.quizMeets.id, meetId))
   if (!meet) return c.json({ error: 'Meet not found' }, 404)
 
-  const fromIdx = phaseIndex(meet.phase as MeetPhase)
-  const toIdx = phaseIndex(body.phase)
-  const reversed = toIdx < fromIdx
-  if (Math.abs(toIdx - fromIdx) > 1) {
-    return c.json(
-      { error: 'Phase transitions must be single-step', from: meet.phase, to: body.phase },
-      400,
-    )
+  const result = validateTransition(MEET_PHASES, meet.phase as MeetPhase, body.phase)
+  switch (result.kind) {
+    case 'invalid':
+      return c.json({ error: 'Invalid phase' }, 400)
+    case 'multi-step':
+      return c.json(
+        { error: 'Phase transitions must be single-step', from: result.from, to: result.to },
+        400,
+      )
+    case 'unchanged':
+      return c.json({ phase: meet.phase, reversed: false, unchanged: true })
+    case 'ok':
+      await db
+        .update(schema.quizMeets)
+        .set({ phase: body.phase })
+        .where(eq(schema.quizMeets.id, meetId))
+      return c.json({ phase: body.phase, reversed: result.reversed })
   }
-  if (toIdx === fromIdx) {
-    return c.json({ phase: meet.phase, reversed: false, unchanged: true })
-  }
-
-  await db
-    .update(schema.quizMeets)
-    .set({ phase: body.phase })
-    .where(eq(schema.quizMeets.id, meetId))
-
-  return c.json({ phase: body.phase, reversed })
 })
 
 /**
- * POST /api/meets/:id/divisions/:division/state
- * Body: { state: 'prelim_running' | 'stats_break' | 'elim_running' | 'division_done' }
- *
  * Advance or revert a per-division state inside the meet's `live` phase.
- * Single-step only; reverses allowed and flagged.
+ * Single-step only; reverses are allowed and flagged.
  */
 phase.post('/:id/divisions/:division/state', async (c) => {
   const meetId = Number(c.req.param('id'))
@@ -111,9 +110,6 @@ phase.post('/:id/divisions/:division/state', async (c) => {
   }
 
   const body = await c.req.json<{ state: DivisionStateValue }>()
-  if (!DIVISION_STATES.includes(body.state)) {
-    return c.json({ error: 'Invalid state' }, 400)
-  }
 
   const [meet] = await db
     .select({ id: schema.quizMeets.id, phase: schema.quizMeets.phase })
@@ -134,64 +130,46 @@ phase.post('/:id/divisions/:division/state', async (c) => {
       and(eq(schema.divisionStates.meetId, meetId), eq(schema.divisionStates.division, division)),
     )
 
-  const now = new Date()
-  if (!existing) {
-    // First transition for this division — initialize at 'prelim_running' implicitly.
-    if (body.state !== 'prelim_running') {
-      const targetIdx = divisionStateIndex(body.state)
-      if (targetIdx > 1) {
-        return c.json(
-          {
-            error: 'Division state transitions must be single-step',
-            from: 'prelim_running',
-            to: body.state,
-          },
-          400,
-        )
+  // No prior row → implicit starting state is 'prelim_running'.
+  const fromState: DivisionStateValue = (existing?.state as DivisionStateValue) ?? 'prelim_running'
+  const result = validateTransition(DIVISION_STATES, fromState, body.state)
+  switch (result.kind) {
+    case 'invalid':
+      return c.json({ error: 'Invalid state' }, 400)
+    case 'multi-step':
+      return c.json(
+        {
+          error: 'Division state transitions must be single-step',
+          from: result.from,
+          to: result.to,
+        },
+        400,
+      )
+    case 'unchanged':
+      return c.json({ state: fromState, reversed: false, unchanged: true })
+    case 'ok': {
+      const now = new Date()
+      if (existing) {
+        await db
+          .update(schema.divisionStates)
+          .set({ state: body.state, transitionedAt: now })
+          .where(
+            and(
+              eq(schema.divisionStates.meetId, meetId),
+              eq(schema.divisionStates.division, division),
+            ),
+          )
+      } else {
+        await db
+          .insert(schema.divisionStates)
+          .values({ meetId, division, state: body.state, transitionedAt: now })
       }
+      return c.json({ state: body.state, reversed: result.reversed })
     }
-    await db.insert(schema.divisionStates).values({
-      meetId,
-      division,
-      state: body.state,
-      transitionedAt: now,
-    })
-    return c.json({ state: body.state, reversed: false })
   }
-
-  const fromIdx = divisionStateIndex(existing.state as DivisionStateValue)
-  const toIdx = divisionStateIndex(body.state)
-  const reversed = toIdx < fromIdx
-  if (Math.abs(toIdx - fromIdx) > 1) {
-    return c.json(
-      {
-        error: 'Division state transitions must be single-step',
-        from: existing.state,
-        to: body.state,
-      },
-      400,
-    )
-  }
-  if (toIdx === fromIdx) {
-    return c.json({ state: existing.state, reversed: false, unchanged: true })
-  }
-
-  await db
-    .update(schema.divisionStates)
-    .set({ state: body.state, transitionedAt: now })
-    .where(
-      and(eq(schema.divisionStates.meetId, meetId), eq(schema.divisionStates.division, division)),
-    )
-
-  return c.json({ state: body.state, reversed })
 })
 
-/**
- * GET /api/meets/:id/divisions/state
- *
- * Lists current state for every division in the meet (registered in division_states).
- * Divisions without a row are implicitly at 'prelim_running'.
- */
+/** Lists transitioned division states. Divisions without a row are implicitly 'prelim_running'. */
 phase.get('/:id/divisions/state', async (c) => {
   const meetId = Number(c.req.param('id'))
   if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)

--- a/packages/api/src/routes/phase.ts
+++ b/packages/api/src/routes/phase.ts
@@ -1,0 +1,210 @@
+import { Hono } from 'hono'
+import { eq, and } from 'drizzle-orm'
+import type { Bindings } from '../bindings'
+import type { SessionVariables } from '../middleware/session'
+import { requireAuth, getUser } from '../middleware/session'
+import { createDb, type Db } from '../lib/db'
+import { isAdminOrSuperuser } from '../lib/permissions'
+import * as schema from '../db/schema'
+
+interface PhaseVariables extends SessionVariables {
+  db: Db
+}
+
+type Env = { Bindings: Bindings; Variables: PhaseVariables }
+
+export const phase = new Hono<Env>()
+
+phase.use('*', requireAuth())
+phase.use('*', async (c, next) => {
+  if (!c.get('db')) {
+    c.set('db', createDb(c.env.DB) as unknown as Db)
+  }
+  await next()
+})
+
+function getDb(c: { get(key: 'db'): Db }): Db {
+  return c.get('db')
+}
+
+const MEET_PHASES = ['registration', 'build', 'live', 'done'] as const
+type MeetPhase = (typeof MEET_PHASES)[number]
+
+const DIVISION_STATES = ['prelim_running', 'stats_break', 'elim_running', 'division_done'] as const
+type DivisionStateValue = (typeof DIVISION_STATES)[number]
+
+function phaseIndex(p: MeetPhase): number {
+  return MEET_PHASES.indexOf(p)
+}
+
+function divisionStateIndex(s: DivisionStateValue): number {
+  return DIVISION_STATES.indexOf(s)
+}
+
+/**
+ * POST /api/meets/:id/phase
+ * Body: { phase: 'registration' | 'build' | 'live' | 'done' }
+ *
+ * Advance or revert the meet phase. Forward transitions require single-step
+ * advance (no jumping registration → live). Reverse transitions are allowed
+ * but flagged in the response so the UI can warn the admin.
+ */
+phase.post('/:id/phase', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const user = getUser(c)
+  const db = getDb(c)
+  if (!(await isAdminOrSuperuser(db, user.id, user.role, meetId))) {
+    return c.json({ error: 'Admin or superuser access required' }, 403)
+  }
+
+  const body = await c.req.json<{ phase: MeetPhase }>()
+  if (!MEET_PHASES.includes(body.phase)) {
+    return c.json({ error: 'Invalid phase' }, 400)
+  }
+
+  const [meet] = await db
+    .select({ id: schema.quizMeets.id, phase: schema.quizMeets.phase })
+    .from(schema.quizMeets)
+    .where(eq(schema.quizMeets.id, meetId))
+  if (!meet) return c.json({ error: 'Meet not found' }, 404)
+
+  const fromIdx = phaseIndex(meet.phase as MeetPhase)
+  const toIdx = phaseIndex(body.phase)
+  const reversed = toIdx < fromIdx
+  if (Math.abs(toIdx - fromIdx) > 1) {
+    return c.json(
+      { error: 'Phase transitions must be single-step', from: meet.phase, to: body.phase },
+      400,
+    )
+  }
+  if (toIdx === fromIdx) {
+    return c.json({ phase: meet.phase, reversed: false, unchanged: true })
+  }
+
+  await db
+    .update(schema.quizMeets)
+    .set({ phase: body.phase })
+    .where(eq(schema.quizMeets.id, meetId))
+
+  return c.json({ phase: body.phase, reversed })
+})
+
+/**
+ * POST /api/meets/:id/divisions/:division/state
+ * Body: { state: 'prelim_running' | 'stats_break' | 'elim_running' | 'division_done' }
+ *
+ * Advance or revert a per-division state inside the meet's `live` phase.
+ * Single-step only; reverses allowed and flagged.
+ */
+phase.post('/:id/divisions/:division/state', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+  const division = c.req.param('division')
+  if (!division) return c.json({ error: 'Division required' }, 400)
+
+  const user = getUser(c)
+  const db = getDb(c)
+  if (!(await isAdminOrSuperuser(db, user.id, user.role, meetId))) {
+    return c.json({ error: 'Admin or superuser access required' }, 403)
+  }
+
+  const body = await c.req.json<{ state: DivisionStateValue }>()
+  if (!DIVISION_STATES.includes(body.state)) {
+    return c.json({ error: 'Invalid state' }, 400)
+  }
+
+  const [meet] = await db
+    .select({ id: schema.quizMeets.id, phase: schema.quizMeets.phase })
+    .from(schema.quizMeets)
+    .where(eq(schema.quizMeets.id, meetId))
+  if (!meet) return c.json({ error: 'Meet not found' }, 404)
+  if (meet.phase !== 'live') {
+    return c.json(
+      { error: 'Division state transitions only allowed when meet is live', meetPhase: meet.phase },
+      409,
+    )
+  }
+
+  const [existing] = await db
+    .select()
+    .from(schema.divisionStates)
+    .where(
+      and(eq(schema.divisionStates.meetId, meetId), eq(schema.divisionStates.division, division)),
+    )
+
+  const now = new Date()
+  if (!existing) {
+    // First transition for this division — initialize at 'prelim_running' implicitly.
+    if (body.state !== 'prelim_running') {
+      const targetIdx = divisionStateIndex(body.state)
+      if (targetIdx > 1) {
+        return c.json(
+          {
+            error: 'Division state transitions must be single-step',
+            from: 'prelim_running',
+            to: body.state,
+          },
+          400,
+        )
+      }
+    }
+    await db.insert(schema.divisionStates).values({
+      meetId,
+      division,
+      state: body.state,
+      transitionedAt: now,
+    })
+    return c.json({ state: body.state, reversed: false })
+  }
+
+  const fromIdx = divisionStateIndex(existing.state as DivisionStateValue)
+  const toIdx = divisionStateIndex(body.state)
+  const reversed = toIdx < fromIdx
+  if (Math.abs(toIdx - fromIdx) > 1) {
+    return c.json(
+      {
+        error: 'Division state transitions must be single-step',
+        from: existing.state,
+        to: body.state,
+      },
+      400,
+    )
+  }
+  if (toIdx === fromIdx) {
+    return c.json({ state: existing.state, reversed: false, unchanged: true })
+  }
+
+  await db
+    .update(schema.divisionStates)
+    .set({ state: body.state, transitionedAt: now })
+    .where(
+      and(eq(schema.divisionStates.meetId, meetId), eq(schema.divisionStates.division, division)),
+    )
+
+  return c.json({ state: body.state, reversed })
+})
+
+/**
+ * GET /api/meets/:id/divisions/state
+ *
+ * Lists current state for every division in the meet (registered in division_states).
+ * Divisions without a row are implicitly at 'prelim_running'.
+ */
+phase.get('/:id/divisions/state', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const db = getDb(c)
+  const rows = await db
+    .select({
+      division: schema.divisionStates.division,
+      state: schema.divisionStates.state,
+      transitionedAt: schema.divisionStates.transitionedAt,
+    })
+    .from(schema.divisionStates)
+    .where(eq(schema.divisionStates.meetId, meetId))
+
+  return c.json({ divisionStates: rows })
+})

--- a/packages/api/src/routes/schedule.ts
+++ b/packages/api/src/routes/schedule.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from 'hono'
-import { eq, and, asc, inArray } from 'drizzle-orm'
+import { eq, and, asc, inArray, sql } from 'drizzle-orm'
 import type { Bindings } from '../bindings'
 import type { SessionVariables } from '../middleware/session'
 import { requireAuth, getUser } from '../middleware/session'
@@ -48,7 +48,7 @@ schedule.get('/:id/rooms', async (c) => {
       id: schema.meetRooms.id,
       name: schema.meetRooms.name,
       sortOrder: schema.meetRooms.sortOrder,
-      hasCode: schema.meetRooms.codeHash,
+      hasCode: sql<number>`(${schema.meetRooms.codeHash} IS NOT NULL)`,
     })
     .from(schema.meetRooms)
     .where(eq(schema.meetRooms.meetId, meetId))
@@ -59,7 +59,7 @@ schedule.get('/:id/rooms', async (c) => {
       id: r.id,
       name: r.name,
       sortOrder: r.sortOrder,
-      hasCode: r.hasCode !== null,
+      hasCode: Boolean(r.hasCode),
     })),
   })
 })
@@ -91,7 +91,7 @@ schedule.patch('/:id/rooms/:roomId', async (c) => {
       id: schema.meetRooms.id,
       name: schema.meetRooms.name,
       sortOrder: schema.meetRooms.sortOrder,
-      hasCode: schema.meetRooms.codeHash,
+      codeHash: schema.meetRooms.codeHash,
     })
 
   if (!updated) return c.json({ error: 'Room not found' }, 404)
@@ -100,7 +100,7 @@ schedule.patch('/:id/rooms/:roomId', async (c) => {
       id: updated.id,
       name: updated.name,
       sortOrder: updated.sortOrder,
-      hasCode: updated.hasCode !== null,
+      hasCode: updated.codeHash !== null,
     },
   })
 })
@@ -145,7 +145,7 @@ schedule.post('/:id/slots', async (c) => {
     return c.json({ error: 'sortOrder is required' }, 400)
   }
 
-  const startAt = typeof body.startAt === 'number' ? new Date(body.startAt) : new Date(body.startAt)
+  const startAt = new Date(body.startAt)
   if (Number.isNaN(startAt.getTime())) return c.json({ error: 'Invalid startAt' }, 400)
 
   const db = getDb(c)
@@ -182,8 +182,7 @@ schedule.patch('/:id/slots/:slotId', async (c) => {
   }>()
   const updates: Record<string, unknown> = {}
   if (body.startAt !== undefined) {
-    const startAt =
-      typeof body.startAt === 'number' ? new Date(body.startAt) : new Date(body.startAt)
+    const startAt = new Date(body.startAt)
     if (Number.isNaN(startAt.getTime())) return c.json({ error: 'Invalid startAt' }, 400)
     updates.startAt = startAt
   }
@@ -397,10 +396,10 @@ schedule.delete('/:id/quizzes/:quizId', async (c) => {
 })
 
 /**
- * PATCH /api/meets/:id/quizzes/:quizId/seats
- * Body: { seats: [{ seatNumber, letter?, seedRef? }, ...] }
- *
- * Replace all seats for a quiz transactionally. Rejects if quiz is completed.
+ * Replace all seats for a quiz. NOTE: not atomic — D1 doesn't support
+ * interactive transactions, so a delete-failure-then-insert window is
+ * possible. Callers can recover by re-issuing the PATCH. Rejects if the
+ * quiz is already completed.
  */
 schedule.patch('/:id/quizzes/:quizId/seats', async (c) => {
   const meetId = Number(c.req.param('id'))

--- a/packages/api/src/routes/schedule.ts
+++ b/packages/api/src/routes/schedule.ts
@@ -1,0 +1,448 @@
+import { Hono, type Context } from 'hono'
+import { eq, and, asc, inArray } from 'drizzle-orm'
+import type { Bindings } from '../bindings'
+import type { SessionVariables } from '../middleware/session'
+import { requireAuth, getUser } from '../middleware/session'
+import { createDb, type Db } from '../lib/db'
+import { isAdminOrSuperuser } from '../lib/permissions'
+import * as schema from '../db/schema'
+
+interface ScheduleVariables extends SessionVariables {
+  db: Db
+}
+
+type Env = { Bindings: Bindings; Variables: ScheduleVariables }
+
+export const schedule = new Hono<Env>()
+
+schedule.use('*', requireAuth())
+schedule.use('*', async (c, next) => {
+  if (!c.get('db')) {
+    c.set('db', createDb(c.env.DB) as unknown as Db)
+  }
+  await next()
+})
+
+function getDb(c: { get(key: 'db'): Db }): Db {
+  return c.get('db')
+}
+
+async function requireAdmin(c: Context<Env>, meetId: number) {
+  const user = getUser(c)
+  const db = getDb(c)
+  if (!(await isAdminOrSuperuser(db, user.id, user.role, meetId))) {
+    return c.json({ error: 'Admin or superuser access required' }, 403)
+  }
+  return null
+}
+
+// ---- Rooms ----
+
+schedule.get('/:id/rooms', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const db = getDb(c)
+  const rooms = await db
+    .select({
+      id: schema.meetRooms.id,
+      name: schema.meetRooms.name,
+      sortOrder: schema.meetRooms.sortOrder,
+      hasCode: schema.meetRooms.codeHash,
+    })
+    .from(schema.meetRooms)
+    .where(eq(schema.meetRooms.meetId, meetId))
+    .orderBy(asc(schema.meetRooms.sortOrder), asc(schema.meetRooms.id))
+
+  return c.json({
+    rooms: rooms.map((r) => ({
+      id: r.id,
+      name: r.name,
+      sortOrder: r.sortOrder,
+      hasCode: r.hasCode !== null,
+    })),
+  })
+})
+
+schedule.patch('/:id/rooms/:roomId', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const roomId = Number(c.req.param('roomId'))
+  if (Number.isNaN(meetId) || Number.isNaN(roomId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const body = await c.req.json<{ name?: string; sortOrder?: number }>()
+  const updates: Record<string, string | number> = {}
+  if (typeof body.name === 'string' && body.name.trim()) updates.name = body.name.trim()
+  if (typeof body.sortOrder === 'number') updates.sortOrder = body.sortOrder
+  if (Object.keys(updates).length === 0) {
+    return c.json({ error: 'No valid fields to update' }, 400)
+  }
+
+  const db = getDb(c)
+  const [updated] = await db
+    .update(schema.meetRooms)
+    .set(updates)
+    .where(and(eq(schema.meetRooms.id, roomId), eq(schema.meetRooms.meetId, meetId)))
+    .returning({
+      id: schema.meetRooms.id,
+      name: schema.meetRooms.name,
+      sortOrder: schema.meetRooms.sortOrder,
+      hasCode: schema.meetRooms.codeHash,
+    })
+
+  if (!updated) return c.json({ error: 'Room not found' }, 404)
+  return c.json({
+    room: {
+      id: updated.id,
+      name: updated.name,
+      sortOrder: updated.sortOrder,
+      hasCode: updated.hasCode !== null,
+    },
+  })
+})
+
+// ---- Slots ----
+
+schedule.get('/:id/slots', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const db = getDb(c)
+  const slots = await db
+    .select()
+    .from(schema.meetSlots)
+    .where(eq(schema.meetSlots.meetId, meetId))
+    .orderBy(asc(schema.meetSlots.sortOrder), asc(schema.meetSlots.id))
+
+  return c.json({ slots })
+})
+
+schedule.post('/:id/slots', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const body = await c.req.json<{
+    startAt: string | number
+    durationMinutes: number
+    kind: 'quiz' | 'event'
+    eventLabel?: string | null
+    sortOrder: number
+  }>()
+  if (body.kind !== 'quiz' && body.kind !== 'event') {
+    return c.json({ error: 'kind must be quiz or event' }, 400)
+  }
+  if (typeof body.durationMinutes !== 'number' || body.durationMinutes <= 0) {
+    return c.json({ error: 'durationMinutes must be positive' }, 400)
+  }
+  if (typeof body.sortOrder !== 'number') {
+    return c.json({ error: 'sortOrder is required' }, 400)
+  }
+
+  const startAt = typeof body.startAt === 'number' ? new Date(body.startAt) : new Date(body.startAt)
+  if (Number.isNaN(startAt.getTime())) return c.json({ error: 'Invalid startAt' }, 400)
+
+  const db = getDb(c)
+  const [created] = await db
+    .insert(schema.meetSlots)
+    .values({
+      meetId,
+      startAt,
+      durationMinutes: body.durationMinutes,
+      kind: body.kind,
+      eventLabel: body.eventLabel ?? null,
+      sortOrder: body.sortOrder,
+    })
+    .returning()
+
+  return c.json({ slot: created }, 201)
+})
+
+schedule.patch('/:id/slots/:slotId', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const slotId = Number(c.req.param('slotId'))
+  if (Number.isNaN(meetId) || Number.isNaN(slotId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const body = await c.req.json<{
+    startAt?: string | number
+    durationMinutes?: number
+    eventLabel?: string | null
+    sortOrder?: number
+  }>()
+  const updates: Record<string, unknown> = {}
+  if (body.startAt !== undefined) {
+    const startAt =
+      typeof body.startAt === 'number' ? new Date(body.startAt) : new Date(body.startAt)
+    if (Number.isNaN(startAt.getTime())) return c.json({ error: 'Invalid startAt' }, 400)
+    updates.startAt = startAt
+  }
+  if (typeof body.durationMinutes === 'number' && body.durationMinutes > 0) {
+    updates.durationMinutes = body.durationMinutes
+  }
+  if ('eventLabel' in body) updates.eventLabel = body.eventLabel ?? null
+  if (typeof body.sortOrder === 'number') updates.sortOrder = body.sortOrder
+  if (Object.keys(updates).length === 0) {
+    return c.json({ error: 'No valid fields to update' }, 400)
+  }
+
+  const db = getDb(c)
+  const [updated] = await db
+    .update(schema.meetSlots)
+    .set(updates)
+    .where(and(eq(schema.meetSlots.id, slotId), eq(schema.meetSlots.meetId, meetId)))
+    .returning()
+
+  if (!updated) return c.json({ error: 'Slot not found' }, 404)
+  return c.json({ slot: updated })
+})
+
+schedule.delete('/:id/slots/:slotId', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const slotId = Number(c.req.param('slotId'))
+  if (Number.isNaN(meetId) || Number.isNaN(slotId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const db = getDb(c)
+  const deleted = await db
+    .delete(schema.meetSlots)
+    .where(and(eq(schema.meetSlots.id, slotId), eq(schema.meetSlots.meetId, meetId)))
+    .returning({ id: schema.meetSlots.id })
+
+  if (deleted.length === 0) return c.json({ error: 'Slot not found' }, 404)
+  return c.json({ deleted: true })
+})
+
+// ---- Scheduled quizzes + seats ----
+
+interface SeatInput {
+  seatNumber: number
+  letter?: string | null
+  seedRef?: string | null
+}
+
+schedule.get('/:id/quizzes', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const db = getDb(c)
+  const quizzes = await db
+    .select()
+    .from(schema.scheduledQuizzes)
+    .where(eq(schema.scheduledQuizzes.meetId, meetId))
+
+  const seats =
+    quizzes.length === 0
+      ? []
+      : await db
+          .select()
+          .from(schema.scheduledQuizSeats)
+          .where(
+            inArray(
+              schema.scheduledQuizSeats.quizId,
+              quizzes.map((q) => q.id),
+            ),
+          )
+
+  const seatsByQuiz = new Map<number, schema.ScheduledQuizSeat[]>()
+  for (const seat of seats) {
+    const arr = seatsByQuiz.get(seat.quizId) ?? []
+    arr.push(seat)
+    seatsByQuiz.set(seat.quizId, arr)
+  }
+
+  return c.json({
+    quizzes: quizzes.map((q) => ({ ...q, seats: seatsByQuiz.get(q.id) ?? [] })),
+  })
+})
+
+schedule.post('/:id/quizzes', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const body = await c.req.json<{
+    slotId: number
+    roomId: number
+    division: string
+    phase: 'prelim' | 'elim'
+    lane?: 'main' | 'consolation' | 'intermediate' | null
+    label: string
+    bracketLabel?: string | null
+    seats?: SeatInput[]
+  }>()
+  if (body.phase !== 'prelim' && body.phase !== 'elim') {
+    return c.json({ error: 'phase must be prelim or elim' }, 400)
+  }
+  if (!body.label?.trim()) return c.json({ error: 'label is required' }, 400)
+  if (typeof body.slotId !== 'number' || typeof body.roomId !== 'number') {
+    return c.json({ error: 'slotId and roomId are required' }, 400)
+  }
+
+  const db = getDb(c)
+  const [created] = await db
+    .insert(schema.scheduledQuizzes)
+    .values({
+      meetId,
+      slotId: body.slotId,
+      roomId: body.roomId,
+      division: body.division,
+      phase: body.phase,
+      lane: body.lane ?? null,
+      label: body.label.trim(),
+      bracketLabel: body.bracketLabel ?? null,
+    })
+    .returning()
+
+  if (body.seats?.length) {
+    await db.insert(schema.scheduledQuizSeats).values(
+      body.seats.map((s) => ({
+        quizId: created!.id,
+        seatNumber: s.seatNumber,
+        letter: s.letter ?? null,
+        seedRef: s.seedRef ?? null,
+      })),
+    )
+  }
+
+  return c.json({ quiz: created }, 201)
+})
+
+schedule.patch('/:id/quizzes/:quizId', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const quizId = Number(c.req.param('quizId'))
+  if (Number.isNaN(meetId) || Number.isNaN(quizId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const db = getDb(c)
+  const [existing] = await db
+    .select({ completedAt: schema.scheduledQuizzes.completedAt })
+    .from(schema.scheduledQuizzes)
+    .where(and(eq(schema.scheduledQuizzes.id, quizId), eq(schema.scheduledQuizzes.meetId, meetId)))
+  if (!existing) return c.json({ error: 'Quiz not found' }, 404)
+  if (existing.completedAt) {
+    return c.json({ error: 'Completed quizzes are immutable' }, 409)
+  }
+
+  const body = await c.req.json<{
+    slotId?: number
+    roomId?: number
+    label?: string
+    bracketLabel?: string | null
+    publishedAt?: string | number | null
+  }>()
+  const updates: Record<string, unknown> = {}
+  if (typeof body.slotId === 'number') updates.slotId = body.slotId
+  if (typeof body.roomId === 'number') updates.roomId = body.roomId
+  if (typeof body.label === 'string' && body.label.trim()) updates.label = body.label.trim()
+  if ('bracketLabel' in body) updates.bracketLabel = body.bracketLabel ?? null
+  if ('publishedAt' in body) {
+    updates.publishedAt = body.publishedAt == null ? null : new Date(body.publishedAt)
+  }
+  if (Object.keys(updates).length === 0) {
+    return c.json({ error: 'No valid fields to update' }, 400)
+  }
+
+  const [updated] = await db
+    .update(schema.scheduledQuizzes)
+    .set(updates)
+    .where(eq(schema.scheduledQuizzes.id, quizId))
+    .returning()
+
+  return c.json({ quiz: updated })
+})
+
+schedule.delete('/:id/quizzes/:quizId', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const quizId = Number(c.req.param('quizId'))
+  if (Number.isNaN(meetId) || Number.isNaN(quizId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const db = getDb(c)
+  const [existing] = await db
+    .select({ completedAt: schema.scheduledQuizzes.completedAt })
+    .from(schema.scheduledQuizzes)
+    .where(and(eq(schema.scheduledQuizzes.id, quizId), eq(schema.scheduledQuizzes.meetId, meetId)))
+  if (!existing) return c.json({ error: 'Quiz not found' }, 404)
+  if (existing.completedAt) {
+    return c.json({ error: 'Completed quizzes are immutable' }, 409)
+  }
+
+  await db.delete(schema.scheduledQuizzes).where(eq(schema.scheduledQuizzes.id, quizId))
+  return c.json({ deleted: true })
+})
+
+/**
+ * PATCH /api/meets/:id/quizzes/:quizId/seats
+ * Body: { seats: [{ seatNumber, letter?, seedRef? }, ...] }
+ *
+ * Replace all seats for a quiz transactionally. Rejects if quiz is completed.
+ */
+schedule.patch('/:id/quizzes/:quizId/seats', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const quizId = Number(c.req.param('quizId'))
+  if (Number.isNaN(meetId) || Number.isNaN(quizId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const body = await c.req.json<{ seats: SeatInput[] }>()
+  if (!Array.isArray(body.seats)) {
+    return c.json({ error: 'seats array required' }, 400)
+  }
+
+  const db = getDb(c)
+  const [existing] = await db
+    .select({ completedAt: schema.scheduledQuizzes.completedAt })
+    .from(schema.scheduledQuizzes)
+    .where(and(eq(schema.scheduledQuizzes.id, quizId), eq(schema.scheduledQuizzes.meetId, meetId)))
+  if (!existing) return c.json({ error: 'Quiz not found' }, 404)
+  if (existing.completedAt) {
+    return c.json({ error: 'Completed quizzes are immutable' }, 409)
+  }
+
+  await db.delete(schema.scheduledQuizSeats).where(eq(schema.scheduledQuizSeats.quizId, quizId))
+  if (body.seats.length > 0) {
+    await db.insert(schema.scheduledQuizSeats).values(
+      body.seats.map((s) => ({
+        quizId,
+        seatNumber: s.seatNumber,
+        letter: s.letter ?? null,
+        seedRef: s.seedRef ?? null,
+      })),
+    )
+  }
+
+  const seats = await db
+    .select()
+    .from(schema.scheduledQuizSeats)
+    .where(eq(schema.scheduledQuizSeats.quizId, quizId))
+
+  return c.json({ seats })
+})

--- a/packages/api/src/routes/schedule.ts
+++ b/packages/api/src/routes/schedule.ts
@@ -365,7 +365,7 @@ schedule.patch('/:id/quizzes/:quizId', async (c) => {
   const [updated] = await db
     .update(schema.scheduledQuizzes)
     .set(updates)
-    .where(eq(schema.scheduledQuizzes.id, quizId))
+    .where(and(eq(schema.scheduledQuizzes.id, quizId), eq(schema.scheduledQuizzes.meetId, meetId)))
     .returning()
 
   return c.json({ quiz: updated })

--- a/packages/api/src/scheduler.ts
+++ b/packages/api/src/scheduler.ts
@@ -1,38 +1,21 @@
-import { eq, and, lte, isNotNull, or } from 'drizzle-orm'
+import { and, lte, isNotNull, eq } from 'drizzle-orm'
 import * as schema from './db/schema'
 import type { Db } from './lib/db'
 
 /**
  * Auto-advance meet phases when their scheduled timestamp has passed.
- *
- * Rules:
- * - registration → build  when `registrationClosesAt <= now`
- * - build         → live   when `meetStartsAt <= now`
- *
- * Idempotent: re-running on the same DB has no effect after meets are caught up.
- * Returns counts so the caller (or tests) can assert behavior.
+ * Rules: `registration → build` at `registrationClosesAt`,
+ *        `build → live` at `meetStartsAt`. Single-step per tick — running
+ * the build→live promotion FIRST means meets just promoted out of
+ * registration this tick stay at build until the next tick.
  */
 export async function autoAdvancePhases(
   db: Db,
   now: Date = new Date(),
 ): Promise<{ promotedToBuild: number; promotedToLive: number }> {
-  // Snapshot both candidate lists BEFORE any updates so we don't cascade
-  // a meet from registration → build → live in a single tick. Single-step
-  // per call matches the manual transition rules.
-  const toBuild = await db
-    .select({ id: schema.quizMeets.id })
-    .from(schema.quizMeets)
-    .where(
-      and(
-        eq(schema.quizMeets.phase, 'registration'),
-        isNotNull(schema.quizMeets.registrationClosesAt),
-        lte(schema.quizMeets.registrationClosesAt, now),
-      ),
-    )
-
-  const toLive = await db
-    .select({ id: schema.quizMeets.id })
-    .from(schema.quizMeets)
+  const promotedToLive = await db
+    .update(schema.quizMeets)
+    .set({ phase: 'live' })
     .where(
       and(
         eq(schema.quizMeets.phase, 'build'),
@@ -40,20 +23,19 @@ export async function autoAdvancePhases(
         lte(schema.quizMeets.meetStartsAt, now),
       ),
     )
+    .returning({ id: schema.quizMeets.id })
 
-  if (toBuild.length > 0) {
-    await db
-      .update(schema.quizMeets)
-      .set({ phase: 'build' })
-      .where(or(...toBuild.map((m) => eq(schema.quizMeets.id, m.id))))
-  }
+  const promotedToBuild = await db
+    .update(schema.quizMeets)
+    .set({ phase: 'build' })
+    .where(
+      and(
+        eq(schema.quizMeets.phase, 'registration'),
+        isNotNull(schema.quizMeets.registrationClosesAt),
+        lte(schema.quizMeets.registrationClosesAt, now),
+      ),
+    )
+    .returning({ id: schema.quizMeets.id })
 
-  if (toLive.length > 0) {
-    await db
-      .update(schema.quizMeets)
-      .set({ phase: 'live' })
-      .where(or(...toLive.map((m) => eq(schema.quizMeets.id, m.id))))
-  }
-
-  return { promotedToBuild: toBuild.length, promotedToLive: toLive.length }
+  return { promotedToBuild: promotedToBuild.length, promotedToLive: promotedToLive.length }
 }

--- a/packages/api/src/scheduler.ts
+++ b/packages/api/src/scheduler.ts
@@ -1,0 +1,59 @@
+import { eq, and, lte, isNotNull, or } from 'drizzle-orm'
+import * as schema from './db/schema'
+import type { Db } from './lib/db'
+
+/**
+ * Auto-advance meet phases when their scheduled timestamp has passed.
+ *
+ * Rules:
+ * - registration → build  when `registrationClosesAt <= now`
+ * - build         → live   when `meetStartsAt <= now`
+ *
+ * Idempotent: re-running on the same DB has no effect after meets are caught up.
+ * Returns counts so the caller (or tests) can assert behavior.
+ */
+export async function autoAdvancePhases(
+  db: Db,
+  now: Date = new Date(),
+): Promise<{ promotedToBuild: number; promotedToLive: number }> {
+  // Snapshot both candidate lists BEFORE any updates so we don't cascade
+  // a meet from registration → build → live in a single tick. Single-step
+  // per call matches the manual transition rules.
+  const toBuild = await db
+    .select({ id: schema.quizMeets.id })
+    .from(schema.quizMeets)
+    .where(
+      and(
+        eq(schema.quizMeets.phase, 'registration'),
+        isNotNull(schema.quizMeets.registrationClosesAt),
+        lte(schema.quizMeets.registrationClosesAt, now),
+      ),
+    )
+
+  const toLive = await db
+    .select({ id: schema.quizMeets.id })
+    .from(schema.quizMeets)
+    .where(
+      and(
+        eq(schema.quizMeets.phase, 'build'),
+        isNotNull(schema.quizMeets.meetStartsAt),
+        lte(schema.quizMeets.meetStartsAt, now),
+      ),
+    )
+
+  if (toBuild.length > 0) {
+    await db
+      .update(schema.quizMeets)
+      .set({ phase: 'build' })
+      .where(or(...toBuild.map((m) => eq(schema.quizMeets.id, m.id))))
+  }
+
+  if (toLive.length > 0) {
+    await db
+      .update(schema.quizMeets)
+      .set({ phase: 'live' })
+      .where(or(...toLive.map((m) => eq(schema.quizMeets.id, m.id))))
+  }
+
+  return { promotedToBuild: toBuild.length, promotedToLive: toLive.length }
+}

--- a/packages/api/src/test-db.ts
+++ b/packages/api/src/test-db.ts
@@ -70,14 +70,18 @@ export async function createTestDb(): Promise<Db> {
       admin_code_hash TEXT NOT NULL,
       viewer_code TEXT NOT NULL,
       divisions TEXT NOT NULL DEFAULT '[]',
-      created_at INTEGER NOT NULL
+      created_at INTEGER NOT NULL,
+      phase TEXT NOT NULL DEFAULT 'registration',
+      registration_closes_at INTEGER,
+      meet_starts_at INTEGER
     );
 
-    CREATE TABLE official_codes (
+    CREATE TABLE meet_rooms (
       id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
       meet_id INTEGER NOT NULL REFERENCES quiz_meets(id) ON DELETE CASCADE,
-      label TEXT NOT NULL,
-      code_hash TEXT NOT NULL
+      name TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      code_hash TEXT
     );
 
     CREATE TABLE admin_memberships (
@@ -96,8 +100,8 @@ export async function createTestDb(): Promise<Db> {
     CREATE TABLE official_memberships (
       account_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
       meet_id INTEGER NOT NULL REFERENCES quiz_meets(id) ON DELETE CASCADE,
-      official_code_id INTEGER NOT NULL REFERENCES official_codes(id) ON DELETE CASCADE,
-      UNIQUE(account_id, meet_id, official_code_id)
+      room_id INTEGER NOT NULL REFERENCES meet_rooms(id) ON DELETE CASCADE,
+      UNIQUE(account_id, meet_id, room_id)
     );
 
     CREATE TABLE viewer_memberships (
@@ -132,6 +136,66 @@ export async function createTestDb(): Promise<Db> {
       quizzer_id INTEGER NOT NULL REFERENCES quizzer_identities(id),
       name TEXT NOT NULL,
       UNIQUE(team_id, quizzer_id)
+    );
+
+    CREATE TABLE division_states (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      meet_id INTEGER NOT NULL REFERENCES quiz_meets(id) ON DELETE CASCADE,
+      division TEXT NOT NULL,
+      state TEXT NOT NULL DEFAULT 'prelim_running',
+      transitioned_at INTEGER NOT NULL,
+      UNIQUE(meet_id, division)
+    );
+
+    CREATE TABLE meet_slots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      meet_id INTEGER NOT NULL REFERENCES quiz_meets(id) ON DELETE CASCADE,
+      start_at INTEGER NOT NULL,
+      duration_minutes INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      event_label TEXT,
+      sort_order INTEGER NOT NULL
+    );
+
+    CREATE TABLE scheduled_quizzes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      meet_id INTEGER NOT NULL REFERENCES quiz_meets(id) ON DELETE CASCADE,
+      slot_id INTEGER NOT NULL REFERENCES meet_slots(id) ON DELETE CASCADE,
+      room_id INTEGER NOT NULL REFERENCES meet_rooms(id) ON DELETE CASCADE,
+      division TEXT NOT NULL,
+      phase TEXT NOT NULL,
+      lane TEXT,
+      label TEXT NOT NULL,
+      bracket_label TEXT,
+      published_at INTEGER,
+      completed_at INTEGER
+    );
+
+    CREATE TABLE scheduled_quiz_seats (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      quiz_id INTEGER NOT NULL REFERENCES scheduled_quizzes(id) ON DELETE CASCADE,
+      seat_number INTEGER NOT NULL,
+      letter TEXT,
+      seed_ref TEXT
+    );
+
+    CREATE TABLE prelim_assignments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      meet_id INTEGER NOT NULL REFERENCES quiz_meets(id) ON DELETE CASCADE,
+      division TEXT NOT NULL,
+      letter TEXT NOT NULL,
+      team_id INTEGER NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+      assigned_at INTEGER NOT NULL,
+      UNIQUE(meet_id, division, letter)
+    );
+
+    CREATE TABLE seed_resolutions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      meet_id INTEGER NOT NULL REFERENCES quiz_meets(id) ON DELETE CASCADE,
+      seed_ref TEXT NOT NULL,
+      team_id INTEGER NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+      resolved_at INTEGER NOT NULL,
+      UNIQUE(meet_id, seed_ref)
     );
   `)
 

--- a/packages/api/src/test-utils.ts
+++ b/packages/api/src/test-utils.ts
@@ -47,3 +47,40 @@ export const testUser: SessionUser = {
 export async function jsonOf<T>(res: Response): Promise<T> {
   return res.json() as Promise<T>
 }
+
+/** Build a JSON-bodied request init for use with `app.request(...)`. */
+export function jsonRequest(method: string, body: Record<string, unknown>) {
+  return {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }
+}
+
+/**
+ * Insert a minimal `quiz_meets` row for tests. Use for any new spec; the older
+ * specs (join, memberships, churches) have their own copies that include
+ * different return shapes and aren't worth migrating.
+ */
+import * as schema from './db/schema'
+import type { MeetPhase } from '@qzr/shared'
+export async function seedMeet(
+  db: Db,
+  name = 'Test Meet',
+  opts: { phase?: MeetPhase; registrationClosesAt?: Date | null; meetStartsAt?: Date | null } = {},
+) {
+  const [meet] = await db
+    .insert(schema.quizMeets)
+    .values({
+      name,
+      dateFrom: '2026-01-01',
+      adminCodeHash: 'x',
+      viewerCode: name.toLowerCase().replace(/\s+/g, '-'),
+      createdAt: new Date(),
+      phase: opts.phase ?? 'registration',
+      registrationClosesAt: opts.registrationClosesAt ?? null,
+      meetStartsAt: opts.meetStartsAt ?? null,
+    })
+    .returning()
+  return meet!
+}

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -16,3 +16,8 @@ WEB_BASE_URL = "https://www.versevault.ca"
 [[routes]]
 pattern = "www.versevault.ca/api/*"
 zone_name = "versevault.ca"
+
+# Phase auto-advance: every 5 min, scan quiz_meets and promote any whose
+# registrationClosesAt or meetStartsAt timestamp has passed.
+[triggers]
+crons = ["*/5 * * * *"]

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,6 @@
 export { AccountRole, MeetRole } from './roles'
+export { MEET_PHASES, DIVISION_STATES } from './phases'
+export type { MeetPhase, DivisionStateValue } from './phases'
 export {
   QuizFileSchema,
   FILE_VERSION,

--- a/packages/shared/src/phases.ts
+++ b/packages/shared/src/phases.ts
@@ -1,0 +1,19 @@
+/**
+ * Meet-wide phase lifecycle. See `docs/scheduling.md` §2.
+ *
+ * Order is meaningful: the index in this array determines whether a transition
+ * is forward (advance), backward (revert), or invalid (multi-step).
+ */
+export const MEET_PHASES = ['registration', 'build', 'live', 'done'] as const
+export type MeetPhase = (typeof MEET_PHASES)[number]
+
+/**
+ * Per-division state inside the `live` meet phase. Same single-step semantics.
+ */
+export const DIVISION_STATES = [
+  'prelim_running',
+  'stats_break',
+  'elim_running',
+  'division_done',
+] as const
+export type DivisionStateValue = (typeof DIVISION_STATES)[number]


### PR DESCRIPTION
## Summary

PR 1 of the schedule epic (#9): foundational data layer + phase control plane. Bundles schema, API endpoints, cron auto-advance, and a phase header bar in the portal. Implements the design in [docs/scheduling.md](https://github.com/TommyAmberson/qzr-sheet/blob/master/docs/scheduling.md).

Closes #12 partially (schema + rooms/slots CRUD + phase machine). The remaining schedule sub-issues (#13 grid view, #14 editor, #39 prelim draw, #40 rule engine, #41 consolation, #42 elims, #15 late teams, #16 result linkage, #6 load teams) build on top of this PR.

## Changes

**Doc + design refinements** (3 commits):
- Refine schedule data model + rules (`new N` definition, OT rule, manual stats-break trigger, def-vs-resolution layering)
- Unify `meetRooms` with existing `officialCodes` (room IS the per-meet code holder)

**Schema** (1 commit):
- Rename `officialCodes` → `meetRooms`, add `name` (was `label`), `sortOrder`, make `codeHash` nullable
- Rename `officialMemberships.officialCodeId` → `roomId`
- Add `quizMeets.phase` (`registration`/`build`/`live`/`done`), `registrationClosesAt`, `meetStartsAt`
- New tables: `division_states`, `meet_slots`, `scheduled_quizzes`, `scheduled_quiz_seats`, `prelim_assignments`, `seed_resolutions`
- Migration `0002_lovely_ultimo.sql` (one hand-patched line to apply column rename before table rebuild — Drizzle bug workaround)

**API** (4 commits):
- Refactor: extract `isAdminOrSuperuser` to `lib/permissions.ts`
- New `phase.ts` route: `POST /api/meets/:id/phase`, `POST /api/meets/:id/divisions/:division/state`, `GET /api/meets/:id/divisions/state` (all admin-only)
- New `schedule.ts` route: rooms / slots / quizzes / seats CRUD
- New `scheduler.ts`: cron-based phase auto-advance (every 5 min via Wrangler triggers)

**Frontend** (1 commit):
- Phase header bar in `QuizMeetView.vue` with Advance/Revert controls
- New phase + division-state methods in `apps/web/src/api.ts`

**Cleanup** (2 commits):
- Simplify pass: shared `MEET_PHASES`/`DIVISION_STATES` in `@qzr/shared`, `validateTransition` helper, dropped lock concept entirely, simplified scheduler, etc.
- Code review fixes: auth gate on `GET /divisions/state`, NaN validation on timestamp inputs, `meetId` guard on quiz PATCH, removed wasted query in `getMeet`

## Wire compatibility

Internal-only rename. API endpoints (`/official-codes/...`) and response field names (`officialCodes`, `officialCodeId`, `label`) preserved — frontend continues to work without changes. New `/rooms` endpoints (rename / reorder + GET with sortOrder) and `/phase`, `/slots`, `/quizzes`, `/divisions/:d/state` are additive.

The wire-level rename to `/rooms` + `roomId` is deferred to a follow-up PR (will be marked breaking with `!`).

## Test plan

- [x] 205 API tests passing (15 new for phase, 13 new for schedule, 7 new for scheduler, 1 new for GET-divisions-state auth)
- [x] `pnpm type-check` clean across workspace
- [x] Migration applied locally with `db:migrate:local`
- [ ] Manual smoke: sign in as admin, create a meet, advance phase to build, verify coach view goes read-only at the right transitions
- [ ] Cron trigger fires in production after deploy

## Review notes

- The `0002_lovely_ultimo.sql` migration has one hand-patched line (`ALTER TABLE official_memberships RENAME COLUMN ...`). Drizzle generated a destructive migration that tried to SELECT the renamed column from the pre-rename table; the patch adds the rename before the table rebuild.
- `test-db.ts` (in-memory test DB DDL) was extended by hand to mirror the new schema. This is the existing pattern in that file, not a new violation of the migrations policy.

_Created by Claude Code_