### PR TITLE
feat: guest-via-URL access for scoresheet team loading

### DIFF
--- a/apps/scoresheet/src/App.vue
+++ b/apps/scoresheet/src/App.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import Scoresheet from './components/Scoresheet.vue'
+import { initGuestSession } from './composables/useGuestSession'
 
 const scoresheetRef = ref<InstanceType<typeof Scoresheet> | null>(null)
+
+// Fire and forget — the API client wrapper picks up the token reactively
+// once the join request resolves.
+void initGuestSession()
 
 function onDownload() {
   scoresheetRef.value?.saveFile()

--- a/apps/scoresheet/src/api.ts
+++ b/apps/scoresheet/src/api.ts
@@ -63,3 +63,20 @@ export function joinMeet(
 ): Promise<{ meet: { id: number; name: string }; role: string }> {
   return request('/api/join', { method: 'POST', body: JSON.stringify({ code }) })
 }
+
+/**
+ * Unauthenticated guest join — does NOT use the request wrapper because the
+ * wrapper attaches a Bearer token we don't have yet. Returns a 24h JWT plus
+ * the resolved meet identity.
+ */
+export async function joinMeetGuest(
+  code: string,
+): Promise<{ token: string; meet: { id: number; name: string }; role: string } | null> {
+  const res = await fetch(`${__API_URL__ || ''}/api/join/guest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  })
+  if (!res.ok) return null
+  return (await res.json()) as { token: string; meet: { id: number; name: string }; role: string }
+}

--- a/apps/scoresheet/src/api.ts
+++ b/apps/scoresheet/src/api.ts
@@ -1,8 +1,23 @@
 import { createApiClient } from '@qzr/shared'
+import { getGuestToken } from './composables/useGuestSession'
 
 declare const __API_URL__: string
 
-const request = createApiClient(__API_URL__ || '')
+const baseRequest = createApiClient(__API_URL__ || '')
+
+/**
+ * Attach `Authorization: Bearer <jwt>` whenever a guest session is active so
+ * the API's session middleware can recognize the caller. Cookie sessions take
+ * precedence on the server, so signed-in users never need the header.
+ */
+function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = getGuestToken()
+  if (!token) return baseRequest<T>(path, init)
+  return baseRequest<T>(path, {
+    ...init,
+    headers: { ...init?.headers, Authorization: `Bearer ${token}` },
+  })
+}
 
 // ---- Types ----
 

--- a/apps/scoresheet/src/components/MeetPickerDialog.vue
+++ b/apps/scoresheet/src/components/MeetPickerDialog.vue
@@ -4,10 +4,12 @@ import { ref } from 'vue'
 
 import { getMyMeets, joinMeet, type MeetSummary } from '../api'
 import { useMeetSession } from '../composables/useMeetSession'
+import { useGuestSession } from '../composables/useGuestSession'
 
 const emit = defineEmits<{ loaded: [] }>()
 
 const { loadMeet } = useMeetSession()
+const guest = useGuestSession()
 
 const dialogRef = ref<HTMLDialogElement | null>(null)
 const meets = ref<MeetSummary[]>([])
@@ -75,7 +77,23 @@ function close() {
   dialogRef.value?.close()
 }
 
-function open() {
+async function open() {
+  // Guest viewers (URL-shared meet) skip the picker — there's only one meet
+  // they have access to, so just load it.
+  if (guest.isActive.value && guest.meetId.value !== null && guest.meetName.value !== null) {
+    submitting.value = true
+    try {
+      await loadMeet(guest.meetId.value, guest.meetName.value)
+      emit('loaded')
+    } catch (e) {
+      // Fall back to opening the picker so the user can see the error.
+      error.value = (e as Error).message
+      dialogRef.value?.showModal()
+    } finally {
+      submitting.value = false
+    }
+    return
+  }
   dialogRef.value?.showModal()
   fetchMeets()
 }

--- a/apps/scoresheet/src/composables/guestSession.ts
+++ b/apps/scoresheet/src/composables/guestSession.ts
@@ -1,0 +1,104 @@
+import { ref } from 'vue'
+import { MeetRole } from '@qzr/shared'
+import { joinMeetGuest } from '../api'
+
+/**
+ * Guest session state for visitors hitting the scoresheet via a shareable
+ * URL like `/scoresheet/?meet=fall-2025`. The slug matches a meet's public
+ * `viewerCode`. The state lives in this non-`use*` module so the API client
+ * (`api.ts`) can read the token synchronously without going through Vue's
+ * composable contract.
+ */
+
+const STORAGE_KEY = 'qzr-guest-session'
+const URL_PARAM = 'meet'
+/** Skew applied to the JWT exp claim — refresh if less than this remaining. */
+const REFRESH_SKEW_MS = 5 * 60 * 1000
+
+export interface GuestSessionData {
+  token: string
+  meetId: number
+  meetName: string
+  /** Viewer code used to obtain this token; lets us refresh against the same meet. */
+  slug: string
+}
+
+export const guestSessionRef = ref<GuestSessionData | null>(loadFromStorage())
+
+/** Synchronous accessor used by the API client wrapper. */
+export function getGuestToken(): string | null {
+  return guestSessionRef.value?.token ?? null
+}
+
+export function setGuestSession(data: GuestSessionData | null): void {
+  guestSessionRef.value = data
+  persist()
+}
+
+/**
+ * Bootstrap: read `?meet=<slug>` from the URL and either reuse a fresh stored
+ * token or obtain a new one. Safe to call multiple times.
+ */
+export async function initGuestSession(): Promise<GuestSessionData | null> {
+  if (typeof window === 'undefined') return null
+  const params = new URLSearchParams(window.location.search)
+  const slug = params.get(URL_PARAM)?.trim()
+  if (!slug) return null
+
+  const existing = guestSessionRef.value
+  if (existing && existing.slug === slug && tokenIsFresh(existing.token)) {
+    return existing
+  }
+
+  const res = await joinMeetGuest(slug)
+  if (!res || res.role !== MeetRole.Viewer) return null
+  const data: GuestSessionData = {
+    token: res.token,
+    meetId: res.meet.id,
+    meetName: res.meet.name,
+    slug,
+  }
+  setGuestSession(data)
+  return data
+}
+
+/**
+ * Return true if the JWT is more than REFRESH_SKEW_MS away from expiring.
+ * We never trust the exp claim for security (the server re-verifies), only
+ * to decide when to skip a refresh round-trip.
+ */
+function tokenIsFresh(token: string): boolean {
+  try {
+    const segments = token.split('.')
+    if (segments.length < 2) return false
+    const payload = JSON.parse(atob(segments[1]!.replace(/-/g, '+').replace(/_/g, '/'))) as {
+      exp?: number
+    }
+    if (typeof payload.exp !== 'number') return false
+    return payload.exp * 1000 - Date.now() > REFRESH_SKEW_MS
+  } catch {
+    return false
+  }
+}
+
+function persist(): void {
+  if (guestSessionRef.value === null) {
+    localStorage.removeItem(STORAGE_KEY)
+  } else {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(guestSessionRef.value))
+  }
+}
+
+function loadFromStorage(): GuestSessionData | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    const data = JSON.parse(raw) as Partial<GuestSessionData>
+    // `slug` was added later — older sessions without it are treated as stale
+    // so the next initGuestSession() refreshes them with a slug-keyed entry.
+    if (!data.token || !data.meetId || !data.meetName || !data.slug) return null
+    return data as GuestSessionData
+  } catch {
+    return null
+  }
+}

--- a/apps/scoresheet/src/composables/guestSession.ts
+++ b/apps/scoresheet/src/composables/guestSession.ts
@@ -71,9 +71,11 @@ function tokenIsFresh(token: string): boolean {
   try {
     const segments = token.split('.')
     if (segments.length < 2) return false
-    const payload = JSON.parse(atob(segments[1]!.replace(/-/g, '+').replace(/_/g, '/'))) as {
-      exp?: number
-    }
+    // JWT uses unpadded base64url; atob is strict about padding in some
+    // engines (notably WebKit), so re-pad before decoding.
+    const seg = segments[1]!.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = seg + '='.repeat((4 - (seg.length % 4)) % 4)
+    const payload = JSON.parse(atob(padded)) as { exp?: number }
     if (typeof payload.exp !== 'number') return false
     return payload.exp * 1000 - Date.now() > REFRESH_SKEW_MS
   } catch {

--- a/apps/scoresheet/src/composables/useGuestSession.ts
+++ b/apps/scoresheet/src/composables/useGuestSession.ts
@@ -1,106 +1,16 @@
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
+import { guestSessionRef, setGuestSession } from './guestSession'
 
-/**
- * Guest session for visitors hitting the scoresheet via a shareable URL like
- * `/scoresheet/?meet=fall-2025`. The slug matches a meet's public viewer code.
- *
- * On bootstrap (`initGuestSession`), the URL is parsed; if a `?meet=` slug is
- * present and there's no signed-in cookie session in flight already, we POST
- * to `/api/join/guest` to obtain a 24h JWT scoped to that meet. The token is
- * stashed in localStorage so the same scoresheet tab survives a reload, and
- * the API client wrapper attaches it to outgoing requests via `getGuestToken`.
- */
-
-declare const __API_URL__: string
-
-const STORAGE_KEY = 'qzr-guest-session'
-const URL_PARAM = 'meet'
-
-export interface GuestSessionData {
-  token: string
-  meetId: number
-  meetName: string
-}
-
-const session = ref<GuestSessionData | null>(loadFromStorage())
-
-/** Synchronous accessor used by the API client wrapper. */
-export function getGuestToken(): string | null {
-  return session.value?.token ?? null
-}
+export { initGuestSession, getGuestToken } from './guestSession'
 
 export function useGuestSession() {
-  const isActive = computed(() => session.value !== null)
-  const meetId = computed(() => session.value?.meetId ?? null)
-  const meetName = computed(() => session.value?.meetName ?? null)
+  const isActive = computed(() => guestSessionRef.value !== null)
+  const meetId = computed(() => guestSessionRef.value?.meetId ?? null)
+  const meetName = computed(() => guestSessionRef.value?.meetName ?? null)
 
   function clear(): void {
-    session.value = null
-    persist()
+    setGuestSession(null)
   }
 
   return { isActive, meetId, meetName, clear }
-}
-
-/**
- * Bootstrap: read `?meet=<slug>` from the URL and either reuse an existing
- * guest session for the same meet or obtain a fresh JWT. Returns the resulting
- * session (or null if there was no slug / the join failed).
- *
- * Safe to call multiple times — re-uses an existing session for the same slug
- * without a second network call.
- */
-export async function initGuestSession(): Promise<GuestSessionData | null> {
-  if (typeof window === 'undefined') return null
-  const params = new URLSearchParams(window.location.search)
-  const slug = params.get(URL_PARAM)?.trim()
-  if (!slug) return null
-
-  // Reuse existing session if it's for the same slug — slugs map 1:1 to meetIds.
-  // We don't know the slug→meetId mapping client-side, so re-issue if anything
-  // looks off (token missing, different meetId we can't verify, etc.).
-  // Cheap to call: server returns the same JWT lifetime (24h).
-
-  try {
-    const res = await fetch(`${__API_URL__ || ''}/api/join/guest`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ code: slug }),
-    })
-    if (!res.ok) return null
-    const body = (await res.json()) as {
-      token: string
-      meet: { id: number; name: string }
-      role: string
-    }
-    if (body.role !== 'viewer') return null
-    const data: GuestSessionData = {
-      token: body.token,
-      meetId: body.meet.id,
-      meetName: body.meet.name,
-    }
-    session.value = data
-    persist()
-    return data
-  } catch {
-    return null
-  }
-}
-
-function persist() {
-  if (session.value === null) {
-    localStorage.removeItem(STORAGE_KEY)
-  } else {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(session.value))
-  }
-}
-
-function loadFromStorage(): GuestSessionData | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return null
-    return JSON.parse(raw) as GuestSessionData
-  } catch {
-    return null
-  }
 }

--- a/apps/scoresheet/src/composables/useGuestSession.ts
+++ b/apps/scoresheet/src/composables/useGuestSession.ts
@@ -1,0 +1,106 @@
+import { ref, computed } from 'vue'
+
+/**
+ * Guest session for visitors hitting the scoresheet via a shareable URL like
+ * `/scoresheet/?meet=fall-2025`. The slug matches a meet's public viewer code.
+ *
+ * On bootstrap (`initGuestSession`), the URL is parsed; if a `?meet=` slug is
+ * present and there's no signed-in cookie session in flight already, we POST
+ * to `/api/join/guest` to obtain a 24h JWT scoped to that meet. The token is
+ * stashed in localStorage so the same scoresheet tab survives a reload, and
+ * the API client wrapper attaches it to outgoing requests via `getGuestToken`.
+ */
+
+declare const __API_URL__: string
+
+const STORAGE_KEY = 'qzr-guest-session'
+const URL_PARAM = 'meet'
+
+export interface GuestSessionData {
+  token: string
+  meetId: number
+  meetName: string
+}
+
+const session = ref<GuestSessionData | null>(loadFromStorage())
+
+/** Synchronous accessor used by the API client wrapper. */
+export function getGuestToken(): string | null {
+  return session.value?.token ?? null
+}
+
+export function useGuestSession() {
+  const isActive = computed(() => session.value !== null)
+  const meetId = computed(() => session.value?.meetId ?? null)
+  const meetName = computed(() => session.value?.meetName ?? null)
+
+  function clear(): void {
+    session.value = null
+    persist()
+  }
+
+  return { isActive, meetId, meetName, clear }
+}
+
+/**
+ * Bootstrap: read `?meet=<slug>` from the URL and either reuse an existing
+ * guest session for the same meet or obtain a fresh JWT. Returns the resulting
+ * session (or null if there was no slug / the join failed).
+ *
+ * Safe to call multiple times — re-uses an existing session for the same slug
+ * without a second network call.
+ */
+export async function initGuestSession(): Promise<GuestSessionData | null> {
+  if (typeof window === 'undefined') return null
+  const params = new URLSearchParams(window.location.search)
+  const slug = params.get(URL_PARAM)?.trim()
+  if (!slug) return null
+
+  // Reuse existing session if it's for the same slug — slugs map 1:1 to meetIds.
+  // We don't know the slug→meetId mapping client-side, so re-issue if anything
+  // looks off (token missing, different meetId we can't verify, etc.).
+  // Cheap to call: server returns the same JWT lifetime (24h).
+
+  try {
+    const res = await fetch(`${__API_URL__ || ''}/api/join/guest`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: slug }),
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as {
+      token: string
+      meet: { id: number; name: string }
+      role: string
+    }
+    if (body.role !== 'viewer') return null
+    const data: GuestSessionData = {
+      token: body.token,
+      meetId: body.meet.id,
+      meetName: body.meet.name,
+    }
+    session.value = data
+    persist()
+    return data
+  } catch {
+    return null
+  }
+}
+
+function persist() {
+  if (session.value === null) {
+    localStorage.removeItem(STORAGE_KEY)
+  } else {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session.value))
+  }
+}
+
+function loadFromStorage(): GuestSessionData | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    return JSON.parse(raw) as GuestSessionData
+  } catch {
+    return null
+  }
+}

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -116,8 +116,36 @@ the finished session cookie — OAuth client secrets never leave the server.
 
 ### Guest JWTs (officials and viewers without accounts)
 
-Short-lived signed JWTs issued server-side. Scoped to a single meet, expire after 24 hours or when
-the meet ends. No refresh — re-enter the code to get a new token. Stored in `localStorage`.
+Short-lived signed JWTs issued server-side by `POST /api/join/guest`. Scoped to a single meet,
+expire after 24 hours or when the meet ends. No refresh endpoint — re-enter the code (or revisit the
+URL) to get a new token. Stored in `localStorage`.
+
+**Wire format:** the client attaches the token as `Authorization: Bearer <jwt>` to outgoing API
+calls. `sessionMiddleware` checks the Better Auth cookie session first; if present, the cookie wins
+and the Bearer header is ignored, so signed-in users never produce ambiguity.
+
+**Server-side gate:** the per-route helper `isViewerOf(c, db, meetId)` admits superusers, members of
+the meet (any role), and guests whose JWT `meetId` matches. Mutation routes still require a real
+signed-in user via `requireAuth()`; reads use the lighter `requireAuthOrGuest()`.
+
+**URL-shareable viewer access (scoresheet):** the scoresheet auto-joins as a guest viewer when
+opened with `?meet=<viewerCode>`:
+
+```
+https://www.versevault.ca/scoresheet/?meet=fall-2025
+```
+
+`useGuestSession` parses the slug, posts to `/api/join/guest`, stashes the JWT, and the meet's
+roster becomes selectable in "Load teams from meet" without sign-in. The token is reused across
+reloads as long as its decoded `exp` claim has more than 5 min remaining; otherwise a fresh
+`/api/join/guest` call refreshes it.
+
+**Roadmap:** today only `?meet=<viewerCode>` is wired (viewer role only). The same pattern can be
+extended to `?official=<code>` for room-scoped officials and any other code-bearing roles — the
+server-side guest JWT issuance already handles official codes; only the client URL handler and a
+permission helper analogous to `isViewerOf` are missing. Putting official codes in URLs leaks them
+into browser history / referrers / logs, so admins should treat shared official URLs as one-shot and
+rotate the code afterward.
 
 ### Password hashing
 

--- a/docs/roles-and-access.md
+++ b/docs/roles-and-access.md
@@ -48,6 +48,8 @@ Superusers have implicit full access to all meets — no membership rows needed.
 * Read-only access to the meet's public data (standings, stats, schedules)
 * Intended for quizzers, parents, and spectators
 * **No account required** — same guest JWT mechanism as officials
+* **URL-shareable**: `https://www.versevault.ca/scoresheet/?meet=<viewerCode>` auto-issues a guest
+  viewer JWT and pre-selects the meet in "Load teams from meet"; no sign-in needed
 
 ## Resources and Codes
 

--- a/packages/api/src/lib/permissions.ts
+++ b/packages/api/src/lib/permissions.ts
@@ -1,7 +1,9 @@
 import { eq, and } from 'drizzle-orm'
+import type { Context } from 'hono'
 import { AccountRole } from '@qzr/shared'
 import * as schema from '../db/schema'
 import type { Db } from './db'
+import type { SessionVariables } from '../middleware/session'
 
 /** True if the user is a superuser or has an admin membership for the given meet. */
 export async function isAdminOrSuperuser(
@@ -21,4 +23,63 @@ export async function isAdminOrSuperuser(
       ),
     )
   return !!row
+}
+
+/**
+ * True if the requester can view the given meet — superuser, any signed-in
+ * member of the meet (admin / coach / official / viewer), or a guest whose
+ * JWT was issued for this meetId. Use as a per-request gate before serving
+ * meet/church/team/quizzer reads.
+ */
+export async function isViewerOf<E extends { Variables: SessionVariables }>(
+  c: Context<E>,
+  db: Db,
+  meetId: number,
+): Promise<boolean> {
+  const guest = c.get('guest')
+  if (guest && guest.meetId === meetId) return true
+
+  const user = c.get('user')
+  if (!user) return false
+  if (user.role === AccountRole.Superuser) return true
+
+  const [[admin], [coach], [official], [viewer]] = await Promise.all([
+    db
+      .select({ id: schema.adminMemberships.accountId })
+      .from(schema.adminMemberships)
+      .where(
+        and(
+          eq(schema.adminMemberships.accountId, user.id),
+          eq(schema.adminMemberships.meetId, meetId),
+        ),
+      ),
+    db
+      .select({ id: schema.coachMemberships.accountId })
+      .from(schema.coachMemberships)
+      .where(
+        and(
+          eq(schema.coachMemberships.accountId, user.id),
+          eq(schema.coachMemberships.meetId, meetId),
+        ),
+      ),
+    db
+      .select({ id: schema.officialMemberships.accountId })
+      .from(schema.officialMemberships)
+      .where(
+        and(
+          eq(schema.officialMemberships.accountId, user.id),
+          eq(schema.officialMemberships.meetId, meetId),
+        ),
+      ),
+    db
+      .select({ id: schema.viewerMemberships.accountId })
+      .from(schema.viewerMemberships)
+      .where(
+        and(
+          eq(schema.viewerMemberships.accountId, user.id),
+          eq(schema.viewerMemberships.meetId, meetId),
+        ),
+      ),
+  ])
+  return !!(admin || coach || official || viewer)
 }

--- a/packages/api/src/lib/permissions.ts
+++ b/packages/api/src/lib/permissions.ts
@@ -1,4 +1,4 @@
-import { eq, and } from 'drizzle-orm'
+import { eq, and, sql } from 'drizzle-orm'
 import type { Context } from 'hono'
 import { AccountRole } from '@qzr/shared'
 import * as schema from '../db/schema'
@@ -43,43 +43,25 @@ export async function isViewerOf<E extends { Variables: SessionVariables }>(
   if (!user) return false
   if (user.role === AccountRole.Superuser) return true
 
-  const [[admin], [coach], [official], [viewer]] = await Promise.all([
-    db
-      .select({ id: schema.adminMemberships.accountId })
-      .from(schema.adminMemberships)
-      .where(
-        and(
-          eq(schema.adminMemberships.accountId, user.id),
-          eq(schema.adminMemberships.meetId, meetId),
-        ),
-      ),
-    db
-      .select({ id: schema.coachMemberships.accountId })
-      .from(schema.coachMemberships)
-      .where(
-        and(
-          eq(schema.coachMemberships.accountId, user.id),
-          eq(schema.coachMemberships.meetId, meetId),
-        ),
-      ),
-    db
-      .select({ id: schema.officialMemberships.accountId })
-      .from(schema.officialMemberships)
-      .where(
-        and(
-          eq(schema.officialMemberships.accountId, user.id),
-          eq(schema.officialMemberships.meetId, meetId),
-        ),
-      ),
-    db
-      .select({ id: schema.viewerMemberships.accountId })
-      .from(schema.viewerMemberships)
-      .where(
-        and(
-          eq(schema.viewerMemberships.accountId, user.id),
-          eq(schema.viewerMemberships.meetId, meetId),
-        ),
-      ),
-  ])
-  return !!(admin || coach || official || viewer)
+  // Single round-trip: any membership row across the four tables means viewer.
+  const result = await db.get<{ found: number }>(
+    sql`SELECT EXISTS (
+      SELECT 1 FROM ${schema.adminMemberships}
+        WHERE ${schema.adminMemberships.accountId} = ${user.id}
+          AND ${schema.adminMemberships.meetId} = ${meetId}
+      UNION ALL
+      SELECT 1 FROM ${schema.coachMemberships}
+        WHERE ${schema.coachMemberships.accountId} = ${user.id}
+          AND ${schema.coachMemberships.meetId} = ${meetId}
+      UNION ALL
+      SELECT 1 FROM ${schema.officialMemberships}
+        WHERE ${schema.officialMemberships.accountId} = ${user.id}
+          AND ${schema.officialMemberships.meetId} = ${meetId}
+      UNION ALL
+      SELECT 1 FROM ${schema.viewerMemberships}
+        WHERE ${schema.viewerMemberships.accountId} = ${user.id}
+          AND ${schema.viewerMemberships.meetId} = ${meetId}
+    ) AS found`,
+  )
+  return Boolean(result?.found)
 }

--- a/packages/api/src/middleware/session.ts
+++ b/packages/api/src/middleware/session.ts
@@ -54,11 +54,24 @@ export function sessionMiddleware(): MiddlewareHandler<{
   }
 }
 
-/**
- * 401 if neither a signed-in user nor a guest JWT is present.
- * Must be used after sessionMiddleware.
- */
+/** 401 if no signed-in user. Mutation routes that need a real account use this. */
 export function requireAuth(): MiddlewareHandler<{
+  Bindings: Bindings
+  Variables: SessionVariables
+}> {
+  return async (c, next) => {
+    if (!c.get('user')) {
+      return c.json({ error: 'Authentication required' }, 401)
+    }
+    await next()
+  }
+}
+
+/**
+ * 401 if neither a signed-in user nor a guest JWT is present. Read routes
+ * that admit anonymous guest viewers (with a valid guest JWT) use this.
+ */
+export function requireAuthOrGuest(): MiddlewareHandler<{
   Bindings: Bindings
   Variables: SessionVariables
 }> {

--- a/packages/api/src/middleware/session.ts
+++ b/packages/api/src/middleware/session.ts
@@ -1,6 +1,7 @@
 import type { Context, MiddlewareHandler } from 'hono'
 import type { Bindings } from '../bindings'
 import { createAuth } from '../lib/auth'
+import { verifyGuestJwt, type GuestPayload } from '../lib/jwt'
 import { AccountRole } from '@qzr/shared'
 
 export interface SessionUser {
@@ -12,11 +13,16 @@ export interface SessionUser {
 
 export interface SessionVariables {
   user: SessionUser | null
+  guest: GuestPayload | null
 }
 
 /**
- * Read the Better Auth session from request cookies and set `c.var.user`.
- * Always calls next — sets user to null if no valid session.
+ * Read the Better Auth session from request cookies and/or a guest JWT from
+ * the `Authorization: Bearer` header. Sets `c.var.user` and `c.var.guest` —
+ * both nullable. Always calls next.
+ *
+ * A signed-in cookie session takes precedence: when both are present, `user`
+ * is set and `guest` is left null so downstream code doesn't double-count.
  */
 export function sessionMiddleware(): MiddlewareHandler<{
   Bindings: Bindings
@@ -33,21 +39,31 @@ export function sessionMiddleware(): MiddlewareHandler<{
         name: session.user.name,
         role: (session.user.role as AccountRole) ?? AccountRole.Normal,
       })
+      c.set('guest', null)
     } else {
       c.set('user', null)
+      const authHeader = c.req.header('Authorization')
+      const token = authHeader?.startsWith('Bearer ')
+        ? authHeader.slice('Bearer '.length).trim()
+        : null
+      const guest = token ? await verifyGuestJwt(token, c.env.BETTER_AUTH_SECRET) : null
+      c.set('guest', guest)
     }
 
     await next()
   }
 }
 
-/** 401 if no authenticated session. Must be used after sessionMiddleware. */
+/**
+ * 401 if neither a signed-in user nor a guest JWT is present.
+ * Must be used after sessionMiddleware.
+ */
 export function requireAuth(): MiddlewareHandler<{
   Bindings: Bindings
   Variables: SessionVariables
 }> {
   return async (c, next) => {
-    if (!c.get('user')) {
+    if (!c.get('user') && !c.get('guest')) {
       return c.json({ error: 'Authentication required' }, 401)
     }
     await next()
@@ -71,4 +87,11 @@ export function requireSuperuser(): MiddlewareHandler<{
 /** Helper to extract the authenticated user (non-null). Use after requireAuth. */
 export function getUser<E extends { Variables: SessionVariables }>(c: Context<E>): SessionUser {
   return c.get('user')!
+}
+
+/** Helper to read the guest JWT payload (nullable). Set by sessionMiddleware. */
+export function getGuest<E extends { Variables: SessionVariables }>(
+  c: Context<E>,
+): GuestPayload | null {
+  return c.get('guest')
 }

--- a/packages/api/src/middleware/session.ts
+++ b/packages/api/src/middleware/session.ts
@@ -40,16 +40,16 @@ export function sessionMiddleware(): MiddlewareHandler<{
         role: (session.user.role as AccountRole) ?? AccountRole.Normal,
       })
       c.set('guest', null)
-    } else {
-      c.set('user', null)
-      const authHeader = c.req.header('Authorization')
-      const token = authHeader?.startsWith('Bearer ')
-        ? authHeader.slice('Bearer '.length).trim()
-        : null
-      const guest = token ? await verifyGuestJwt(token, c.env.BETTER_AUTH_SECRET) : null
-      c.set('guest', guest)
+      await next()
+      return
     }
 
+    c.set('user', null)
+    const authHeader = c.req.header('Authorization')
+    const token = authHeader?.startsWith('Bearer ')
+      ? authHeader.slice('Bearer '.length).trim()
+      : null
+    c.set('guest', token ? await verifyGuestJwt(token, c.env.BETTER_AUTH_SECRET) : null)
     await next()
   }
 }

--- a/packages/api/src/routes/__tests__/churches.spec.ts
+++ b/packages/api/src/routes/__tests__/churches.spec.ts
@@ -405,8 +405,17 @@ describe('GET /api/churches/:churchId/teams', () => {
     expect(body.teams).toHaveLength(2)
   })
 
-  it('allows any authenticated member to read teams for any church', async () => {
+  it('forbids non-member readers (per-meet viewer scope)', async () => {
     const app = createApp(testUser, db)
+    const meet = await seedMeet(db)
+    const church = await seedChurch(db, meet.id)
+
+    const res = await app.request(`/api/churches/${church.id}/teams`, {}, env)
+    expect(res.status).toBe(403)
+  })
+
+  it('allows superuser to read teams for any church', async () => {
+    const app = createApp(testSuperuser, db)
     const meet = await seedMeet(db)
     const church = await seedChurch(db, meet.id)
 
@@ -576,6 +585,7 @@ describe('GET /api/meets/:meetId/teams', () => {
   it('returns empty list when meet has no teams', async () => {
     const app = createApp(testUser, db)
     const meet = await seedMeet(db)
+    await seedAdminMembership(db, testUser.id, meet.id)
 
     const res = await app.request(`/api/meets/${meet.id}/teams`, {}, env)
     expect(res.status).toBe(200)
@@ -586,6 +596,7 @@ describe('GET /api/meets/:meetId/teams', () => {
   it('returns teams with all church fields', async () => {
     const app = createApp(testUser, db)
     const meet = await seedMeet(db)
+    await seedAdminMembership(db, testUser.id, meet.id)
     const church = await seedChurch(db, meet.id, 'Grace Church')
     const team = await seedTeam(db, meet.id, church.id, 'Open')
 
@@ -622,6 +633,7 @@ describe('GET /api/meets/:meetId/teams', () => {
     const app = createApp(testUser, db)
     const meetA = await seedMeet(db)
     const meetB = await seedMeet(db)
+    await seedAdminMembership(db, testUser.id, meetA.id)
     const churchA = await seedChurch(db, meetA.id, 'Alpha')
     const churchB = await seedChurch(db, meetB.id, 'Beta')
     await seedTeam(db, meetA.id, churchA.id)
@@ -636,6 +648,7 @@ describe('GET /api/meets/:meetId/teams', () => {
   it('returns teams ordered by church name then team number', async () => {
     const app = createApp(testUser, db)
     const meet = await seedMeet(db)
+    await seedAdminMembership(db, testUser.id, meet.id)
     const zebra = await seedChurch(db, meet.id, 'Zebra Church')
     const alpha = await seedChurch(db, meet.id, 'Alpha Church')
     await seedTeam(db, meet.id, zebra.id)
@@ -661,6 +674,7 @@ describe('GET /api/meets/:meetId/teams', () => {
   it('returns consolation: false for a normal team', async () => {
     const app = createApp(testUser, db)
     const meet = await seedMeet(db)
+    await seedAdminMembership(db, testUser.id, meet.id)
     const church = await seedChurch(db, meet.id)
     await seedTeam(db, meet.id, church.id)
 
@@ -672,6 +686,7 @@ describe('GET /api/meets/:meetId/teams', () => {
   it('returns consolation: true for a consolation team', async () => {
     const app = createApp(testUser, db)
     const meet = await seedMeet(db)
+    await seedAdminMembership(db, testUser.id, meet.id)
     const church = await seedChurch(db, meet.id)
     const team = await seedTeam(db, meet.id, church.id)
     await db.update(schema.teams).set({ consolation: true }).where(eq(schema.teams.id, team.id))
@@ -696,6 +711,7 @@ describe('GET /api/meets/:meetId/teams', () => {
         createdAt: new Date(),
       })
       .returning()
+    await seedAdminMembership(db, testUser.id, meet!.id)
 
     const res = await app.request(`/api/meets/${meet!.id}/teams`, {}, env)
     const body = await res.json<{ teams: unknown[]; meetDivisions: string[] }>()
@@ -705,6 +721,7 @@ describe('GET /api/meets/:meetId/teams', () => {
   it('returns meetDivisions as empty array when meet has no divisions set', async () => {
     const app = createApp(testUser, db)
     const meet = await seedMeet(db) // divisions defaults to '[]'
+    await seedAdminMembership(db, testUser.id, meet.id)
 
     const res = await app.request(`/api/meets/${meet.id}/teams`, {}, env)
     const body = await res.json<{ teams: unknown[]; meetDivisions: string[] }>()

--- a/packages/api/src/routes/churches.ts
+++ b/packages/api/src/routes/churches.ts
@@ -2,10 +2,10 @@ import { Hono } from 'hono'
 import { eq, and, inArray, sql } from 'drizzle-orm'
 import type { Bindings } from '../bindings'
 import type { SessionVariables } from '../middleware/session'
-import { requireAuth, requireSuperuser, getUser } from '../middleware/session'
+import { requireAuth, requireAuthOrGuest, requireSuperuser, getUser } from '../middleware/session'
 import { createDb, type Db } from '../lib/db'
 import { generateCode, hashCode } from '../lib/codes'
-import { isAdminOrSuperuser } from '../lib/permissions'
+import { isAdminOrSuperuser, isViewerOf } from '../lib/permissions'
 import * as schema from '../db/schema'
 import { AccountRole } from '@qzr/shared'
 
@@ -17,7 +17,9 @@ type Env = { Bindings: Bindings; Variables: ChurchesVariables }
 
 export const churches = new Hono<Env>()
 
-churches.use('*', requireAuth())
+// Reads (GET) admit guests with a meet-scoped JWT; mutations gate via
+// requireAuth + canEditChurch / isAdminOrSuperuser per-route.
+churches.use('*', requireAuthOrGuest())
 
 churches.use('*', async (c, next) => {
   if (!c.get('db')) {
@@ -62,6 +64,7 @@ churches.get('/meets/:meetId/churches', async (c) => {
   if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
 
   const db = getDb(c)
+  if (!(await isViewerOf(c, db, meetId))) return c.json({ error: 'Forbidden' }, 403)
 
   // Left join teams so churches with no teams still appear; count per church in one query.
   const rows = await db
@@ -87,7 +90,7 @@ churches.get('/meets/:meetId/churches', async (c) => {
  * Creates a church for the meet. Requires superuser or admin membership.
  * Generates a coach code for the church on creation.
  */
-churches.post('/meets/:meetId/churches', async (c) => {
+churches.post('/meets/:meetId/churches', requireAuth(), async (c) => {
   const meetId = Number(c.req.param('meetId'))
   if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
 
@@ -127,7 +130,7 @@ churches.post('/meets/:meetId/churches', async (c) => {
  *
  * Updates a church's name and/or shortName. Requires admin or superuser.
  */
-churches.patch('/churches/:churchId', async (c) => {
+churches.patch('/churches/:churchId', requireAuth(), async (c) => {
   const churchId = Number(c.req.param('churchId'))
   if (Number.isNaN(churchId)) return c.json({ error: 'Invalid church ID' }, 400)
 
@@ -166,7 +169,7 @@ churches.patch('/churches/:churchId', async (c) => {
  * Deletes a church, its teams, rosters, and coach memberships (via CASCADE).
  * Requires admin or superuser.
  */
-churches.delete('/churches/:churchId', async (c) => {
+churches.delete('/churches/:churchId', requireAuth(), async (c) => {
   const churchId = Number(c.req.param('churchId'))
   if (Number.isNaN(churchId)) return c.json({ error: 'Invalid church ID' }, 400)
 
@@ -191,7 +194,7 @@ churches.delete('/churches/:churchId', async (c) => {
  * Rotates the coach code for a church. Accepts { clearMembers: boolean }.
  * Requires admin or superuser.
  */
-churches.post('/churches/:churchId/rotate-coach-code', async (c) => {
+churches.post('/churches/:churchId/rotate-coach-code', requireAuth(), async (c) => {
   const churchId = Number(c.req.param('churchId'))
   if (Number.isNaN(churchId)) return c.json({ error: 'Invalid church ID' }, 400)
 
@@ -235,6 +238,7 @@ churches.get('/churches/:churchId/teams', async (c) => {
   const db = getDb(c)
   const [church] = await db.select().from(schema.churches).where(eq(schema.churches.id, churchId))
   if (!church) return c.json({ error: 'Church not found' }, 404)
+  if (!(await isViewerOf(c, db, church.meetId))) return c.json({ error: 'Forbidden' }, 403)
 
   const rows = await db
     .select({
@@ -255,7 +259,7 @@ churches.get('/churches/:churchId/teams', async (c) => {
  *
  * Creates a team under a church. Requires coach, admin, or superuser access.
  */
-churches.post('/churches/:churchId/teams', async (c) => {
+churches.post('/churches/:churchId/teams', requireAuth(), async (c) => {
   const churchId = Number(c.req.param('churchId'))
   if (Number.isNaN(churchId)) return c.json({ error: 'Invalid church ID' }, 400)
 
@@ -295,7 +299,7 @@ churches.post('/churches/:churchId/teams', async (c) => {
  *
  * Updates a team's division. Requires coach, admin, or superuser access.
  */
-churches.patch('/teams/:teamId', async (c) => {
+churches.patch('/teams/:teamId', requireAuth(), async (c) => {
   const teamId = Number(c.req.param('teamId'))
   if (Number.isNaN(teamId)) return c.json({ error: 'Invalid team ID' }, 400)
 
@@ -332,7 +336,7 @@ churches.patch('/teams/:teamId', async (c) => {
  *
  * Deletes a team and its entire roster. Requires coach, admin, or superuser access.
  */
-churches.delete('/teams/:teamId', async (c) => {
+churches.delete('/teams/:teamId', requireAuth(), async (c) => {
   const teamId = Number(c.req.param('teamId'))
   if (Number.isNaN(teamId)) return c.json({ error: 'Invalid team ID' }, 400)
 
@@ -357,7 +361,7 @@ churches.delete('/teams/:teamId', async (c) => {
  * Marks a team as consolation. Requires admin or superuser access.
  * Called at stats break when teams are split into the consolation bracket.
  */
-churches.post('/teams/:teamId/consolation', async (c) => {
+churches.post('/teams/:teamId/consolation', requireAuth(), async (c) => {
   const teamId = Number(c.req.param('teamId'))
   if (Number.isNaN(teamId)) return c.json({ error: 'Invalid team ID' }, 400)
 
@@ -385,7 +389,7 @@ churches.post('/teams/:teamId/consolation', async (c) => {
  *
  * Removes consolation status from a team. Requires admin or superuser access.
  */
-churches.delete('/teams/:teamId/consolation', async (c) => {
+churches.delete('/teams/:teamId/consolation', requireAuth(), async (c) => {
   const teamId = Number(c.req.param('teamId'))
   if (Number.isNaN(teamId)) return c.json({ error: 'Invalid team ID' }, 400)
 
@@ -418,6 +422,12 @@ churches.get('/teams/:teamId/quizzers', async (c) => {
   if (Number.isNaN(teamId)) return c.json({ error: 'Invalid team ID' }, 400)
 
   const db = getDb(c)
+  const [team] = await db
+    .select({ meetId: schema.teams.meetId })
+    .from(schema.teams)
+    .where(eq(schema.teams.id, teamId))
+  if (!team) return c.json({ error: 'Team not found' }, 404)
+  if (!(await isViewerOf(c, db, team.meetId))) return c.json({ error: 'Forbidden' }, 403)
 
   const rows = await db
     .select({ quizzerId: schema.teamRosters.quizzerId, name: schema.teamRosters.name })
@@ -430,7 +440,7 @@ churches.get('/teams/:teamId/quizzers', async (c) => {
 /**
  * POST /api/teams/:teamId/quizzers
  */
-churches.post('/teams/:teamId/quizzers', async (c) => {
+churches.post('/teams/:teamId/quizzers', requireAuth(), async (c) => {
   const teamId = Number(c.req.param('teamId'))
   if (Number.isNaN(teamId)) return c.json({ error: 'Invalid team ID' }, 400)
 
@@ -459,7 +469,7 @@ churches.post('/teams/:teamId/quizzers', async (c) => {
 /**
  * PATCH /api/teams/:teamId/quizzers/:quizzerId
  */
-churches.patch('/teams/:teamId/quizzers/:quizzerId', async (c) => {
+churches.patch('/teams/:teamId/quizzers/:quizzerId', requireAuth(), async (c) => {
   const teamId = Number(c.req.param('teamId'))
   const quizzerId = Number(c.req.param('quizzerId'))
   if (Number.isNaN(teamId) || Number.isNaN(quizzerId)) return c.json({ error: 'Invalid ID' }, 400)
@@ -490,7 +500,7 @@ churches.patch('/teams/:teamId/quizzers/:quizzerId', async (c) => {
 /**
  * DELETE /api/teams/:teamId/quizzers/:quizzerId
  */
-churches.delete('/teams/:teamId/quizzers/:quizzerId', async (c) => {
+churches.delete('/teams/:teamId/quizzers/:quizzerId', requireAuth(), async (c) => {
   const teamId = Number(c.req.param('teamId'))
   const quizzerId = Number(c.req.param('quizzerId'))
   if (Number.isNaN(teamId) || Number.isNaN(quizzerId)) return c.json({ error: 'Invalid ID' }, 400)
@@ -537,7 +547,7 @@ interface RosterSyncPayload {
  * Client sends desired state: ordered teams (with division + quizzer names) and unassigned pool.
  * Temp IDs (negative) signal new teams/quizzers; server returns the resolved state.
  */
-churches.post('/churches/:churchId/roster/sync', async (c) => {
+churches.post('/churches/:churchId/roster/sync', requireAuth(), async (c) => {
   const churchId = Number(c.req.param('churchId'))
   if (Number.isNaN(churchId)) return c.json({ error: 'Invalid church ID' }, 400)
 
@@ -751,6 +761,7 @@ churches.get('/meets/:meetId/teams', async (c) => {
   if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
 
   const db = getDb(c)
+  if (!(await isViewerOf(c, db, meetId))) return c.json({ error: 'Forbidden' }, 403)
 
   const [[meetRow], rows] = await Promise.all([
     db
@@ -789,6 +800,7 @@ churches.get('/meets/:meetId/roster/export', async (c) => {
   if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
 
   const db = getDb(c)
+  if (!(await isViewerOf(c, db, meetId))) return c.json({ error: 'Forbidden' }, 403)
 
   const rows = await db
     .select({
@@ -820,7 +832,7 @@ churches.get('/meets/:meetId/roster/export', async (c) => {
  * Skips quizzers already on a team by name.
  * Requires admin or superuser.
  */
-churches.post('/meets/:meetId/roster/import', async (c) => {
+churches.post('/meets/:meetId/roster/import', requireAuth(), async (c) => {
   const meetId = Number(c.req.param('meetId'))
   if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
 

--- a/packages/api/src/routes/meets.ts
+++ b/packages/api/src/routes/meets.ts
@@ -2,10 +2,10 @@ import { Hono } from 'hono'
 import { eq, and } from 'drizzle-orm'
 import type { Bindings } from '../bindings'
 import type { SessionVariables } from '../middleware/session'
-import { requireAuth, requireSuperuser, getUser } from '../middleware/session'
+import { requireAuth, requireAuthOrGuest, requireSuperuser, getUser } from '../middleware/session'
 import { createDb, type Db } from '../lib/db'
 import { generateCode, hashCode } from '../lib/codes'
-import { isAdminOrSuperuser } from '../lib/permissions'
+import { isAdminOrSuperuser, isViewerOf } from '../lib/permissions'
 import * as schema from '../db/schema'
 import { AccountRole, MeetRole } from '@qzr/shared'
 
@@ -17,8 +17,9 @@ type Env = { Bindings: Bindings; Variables: MeetsVariables }
 
 const meets = new Hono<Env>()
 
-// All meet management routes require auth; mutations require superuser
-meets.use('*', requireAuth())
+// Reads admit guest JWTs (scoped per-meet); mutations gate via requireAuth on the
+// individual route below.
+meets.use('*', requireAuthOrGuest())
 
 // Inject DB from env binding (overridable in tests via the db variable)
 meets.use('*', async (c, next) => {
@@ -77,7 +78,6 @@ meets.get('/:id', async (c) => {
   const param = c.req.param('id')
   const numericId = Number(param)
 
-  const user = getUser(c)
   const db = getDb(c)
 
   const [meet] = Number.isNaN(numericId)
@@ -88,47 +88,7 @@ meets.get('/:id', async (c) => {
 
   const id = meet.id
 
-  if (user.role !== AccountRole.Superuser) {
-    const [[admin], [coach], [official], [viewer]] = await Promise.all([
-      db
-        .select({ meetId: schema.adminMemberships.meetId })
-        .from(schema.adminMemberships)
-        .where(
-          and(
-            eq(schema.adminMemberships.accountId, user.id),
-            eq(schema.adminMemberships.meetId, id),
-          ),
-        ),
-      db
-        .select({ meetId: schema.coachMemberships.meetId })
-        .from(schema.coachMemberships)
-        .where(
-          and(
-            eq(schema.coachMemberships.accountId, user.id),
-            eq(schema.coachMemberships.meetId, id),
-          ),
-        ),
-      db
-        .select({ meetId: schema.officialMemberships.meetId })
-        .from(schema.officialMemberships)
-        .where(
-          and(
-            eq(schema.officialMemberships.accountId, user.id),
-            eq(schema.officialMemberships.meetId, id),
-          ),
-        ),
-      db
-        .select({ meetId: schema.viewerMemberships.meetId })
-        .from(schema.viewerMemberships)
-        .where(
-          and(
-            eq(schema.viewerMemberships.accountId, user.id),
-            eq(schema.viewerMemberships.meetId, id),
-          ),
-        ),
-    ])
-    if (!admin && !coach && !official && !viewer) return c.json({ error: 'Forbidden' }, 403)
-  }
+  if (!(await isViewerOf(c, db, id))) return c.json({ error: 'Forbidden' }, 403)
 
   const codes = await db
     .select({ id: schema.meetRooms.id, label: schema.meetRooms.name })
@@ -138,7 +98,7 @@ meets.get('/:id', async (c) => {
   return c.json({ meet: formatMeet(meet), officialCodes: codes })
 })
 
-meets.patch('/:id', async (c) => {
+meets.patch('/:id', requireAuth(), async (c) => {
   const id = Number(c.req.param('id'))
   if (Number.isNaN(id)) return c.json({ error: 'Invalid meet ID' }, 400)
 
@@ -213,7 +173,7 @@ meets.delete('/:id', requireSuperuser(), async (c) => {
 
 // ---- Admin code rotation ----
 
-meets.post('/:id/rotate-admin-code', async (c) => {
+meets.post('/:id/rotate-admin-code', requireAuth(), async (c) => {
   const id = Number(c.req.param('id'))
   if (Number.isNaN(id)) return c.json({ error: 'Invalid meet ID' }, 400)
 
@@ -250,7 +210,7 @@ meets.post('/:id/rotate-admin-code', async (c) => {
 
 // ---- Official codes ----
 
-meets.post('/:id/official-codes', async (c) => {
+meets.post('/:id/official-codes', requireAuth(), async (c) => {
   const meetId = Number(c.req.param('id'))
   if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
 
@@ -280,7 +240,7 @@ meets.post('/:id/official-codes', async (c) => {
   return c.json({ officialCode: { id: created!.id, label: created!.name }, code }, 201)
 })
 
-meets.delete('/:id/official-codes/:codeId', async (c) => {
+meets.delete('/:id/official-codes/:codeId', requireAuth(), async (c) => {
   const meetId = Number(c.req.param('id'))
   const codeId = Number(c.req.param('codeId'))
   if (Number.isNaN(meetId) || Number.isNaN(codeId)) {
@@ -302,7 +262,7 @@ meets.delete('/:id/official-codes/:codeId', async (c) => {
   return c.json({ deleted: true })
 })
 
-meets.post('/:id/official-codes/:codeId/rotate', async (c) => {
+meets.post('/:id/official-codes/:codeId/rotate', requireAuth(), async (c) => {
   const meetId = Number(c.req.param('id'))
   const codeId = Number(c.req.param('codeId'))
   if (Number.isNaN(meetId) || Number.isNaN(codeId)) {
@@ -339,7 +299,7 @@ interface MeetMember {
   officialCodeId?: number // preserved API field name (maps to room id)
 }
 
-meets.get('/:id/members', async (c) => {
+meets.get('/:id/members', requireAuth(), async (c) => {
   const meetId = Number(c.req.param('id'))
   if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
 
@@ -400,7 +360,7 @@ meets.get('/:id/members', async (c) => {
   return c.json({ members })
 })
 
-meets.delete('/:id/members/:userId', async (c) => {
+meets.delete('/:id/members/:userId', requireAuth(), async (c) => {
   const meetId = Number(c.req.param('id'))
   if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
   const targetUserId = c.req.param('userId')

--- a/packages/api/src/routes/meets.ts
+++ b/packages/api/src/routes/meets.ts
@@ -95,7 +95,13 @@ meets.get('/:id', async (c) => {
     .from(schema.meetRooms)
     .where(eq(schema.meetRooms.meetId, id))
 
-  return c.json({ meet: formatMeet(meet), officialCodes: codes })
+  // Guests get a redacted view: no viewerCode (they could re-share it) and no
+  // official-code list. Signed-in members get the full payload.
+  const isGuest = !!c.get('guest')
+  return c.json({
+    meet: formatMeet(meet, { redactSensitive: isGuest }),
+    officialCodes: isGuest ? [] : codes,
+  })
 })
 
 meets.patch('/:id', requireAuth(), async (c) => {
@@ -437,13 +443,13 @@ meets.delete('/:id/members/:userId', requireAuth(), async (c) => {
 
 // ---- Helpers ----
 
-function formatMeet(meet: schema.QuizMeet) {
+function formatMeet(meet: schema.QuizMeet, opts: { redactSensitive?: boolean } = {}) {
   return {
     id: meet.id,
     name: meet.name,
     dateFrom: meet.dateFrom,
     dateTo: meet.dateTo,
-    viewerCode: meet.viewerCode,
+    viewerCode: opts.redactSensitive ? null : meet.viewerCode,
     divisions: JSON.parse(meet.divisions) as string[],
     createdAt: meet.createdAt,
     phase: meet.phase,

--- a/packages/api/src/routes/meets.ts
+++ b/packages/api/src/routes/meets.ts
@@ -71,7 +71,7 @@ meets.post('/', requireSuperuser(), async (c) => {
 
 meets.get('/', requireSuperuser(), async (c) => {
   const rows = await getDb(c).select().from(schema.quizMeets)
-  return c.json({ meets: rows.map(formatMeet) })
+  return c.json({ meets: rows.map((m) => formatMeet(m)) })
 })
 
 meets.get('/:id', async (c) => {


### PR DESCRIPTION
## Summary

Closes most of #10 (Guest access). Lets a quiz-master open the scoresheet via a shareable URL like `/scoresheet/?meet=fall-2025` and load that meet's roster without signing in.

The guest JWT plumbing (`POST /api/join/guest` + `verifyGuestJwt`) already existed; this PR turns the previously dead-end token into a working flow.

## Changes

**Backend**
- `sessionMiddleware` now also parses `Authorization: Bearer <jwt>` and verifies via the existing `verifyGuestJwt`. Cookie session takes precedence; guest token is set on `c.var.guest` (separate from `user`).
- New `requireAuthOrGuest()` middleware. Read-heavy routers (meets, churches) switched to it; mutation routes (POST/PATCH/DELETE) get explicit per-route `requireAuth()` to keep the user-only contract.
- New `isViewerOf(c, db, meetId)` permission helper — true for superuser, any member of the meet, or a guest whose JWT meetId matches. Single `UNION ALL` round-trip across the four membership tables.
- `GET /api/meets/:id` and the previously-permissive churches/teams/quizzers GETs are now scoped via `isViewerOf`. **Behavioral change**: any-authenticated-user reads on those endpoints are no longer allowed; the caller must be a member of the meet (or a guest with a JWT for that meet).
- `GET /api/meets/:id` redacts `viewerCode` and the official-codes list for guest callers (security fix from local review — official-role guests would otherwise see the meet's plaintext viewer code).

**Frontend (scoresheet)**
- New `composables/guestSession.ts` (data layer + ref + `getGuestToken` accessor + localStorage round-trip + JWT-exp freshness check).
- `composables/useGuestSession.ts` is now the Vue glue (computed exports + clear).
- On app mount, `initGuestSession()` parses `?meet=<slug>`, calls `joinMeetGuest`, stashes the 24h JWT in localStorage. Skips the network call when the stored token is still fresh (>5 min remaining) and matches the URL slug.
- `apps/scoresheet/src/api.ts` wraps the shared client to attach `Authorization: Bearer <token>` whenever a guest token is present.
- `MeetPickerDialog` skips the picker and auto-loads the guest meet's teams when a guest session is active.

## Wire compatibility / behavioral changes

- **Breaking**: any signed-in user previously got 200 from `GET /api/meets/:meetId/churches`, `GET /api/churches/:churchId/teams`, `GET /api/teams/:teamId/quizzers`, `GET /api/meets/:meetId/teams`, and `GET /api/meets/:meetId/roster/export`. Now they need a membership in that meet (or be superuser, or a guest of that meet). This tightens an over-permissive read surface — flagged with `!` in the second commit.
- **Backwards-compatible**: API endpoint paths and response field names unchanged. Cookie-based signed-in flow still works without modification.

## Test plan

- [x] 206 API tests passing (added: per-meet scope tests, guest JWT recognition implicit through wrapper)
- [x] `pnpm type-check` clean across workspace
- [x] Local 5-agent code review run before opening; 4 high-confidence findings fixed in the simplify pass (`refactor: simplify pass on guest-access PR`)
- [x] Local security review run; 1 medium finding fixed (`fix(api): redact viewerCode for guest viewers`)
- [ ] Manual smoke: sign out, visit `http://localhost:5173/?meet=<existing-viewer-code>`, confirm scoresheet auto-loads the meet's teams without sign-in
- [ ] Manual smoke: bad slug `?meet=does-not-exist` is a graceful no-op; sign-in path still works
- [ ] Manual smoke: signed-in users still see full meet detail with `viewerCode` and official codes

## Notes for review

- The 4-table membership UNION ALL in `isViewerOf` replaces a 4-call `Promise.all` — single DB round-trip.
- JWT freshness check decodes `exp` client-side without verifying signature (server still re-verifies on every request); used only to skip an unnecessary refetch round-trip.
- `requireAuth` per-mutation-route was deliberately preferred over enforcing non-null in `getUser` — keeps the type contract honest and lets read routes admit guest callers.

_Created by Claude Code_