### PR TITLE
fix(scoresheet): tutorial unlinks meet for its duration

### DIFF
--- a/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
@@ -188,3 +188,67 @@ describe('useTutorial — snapshot safety', () => {
     expect(s.cells.value[0]![0]![0]).toBe(CellValue.Correct)
   })
 })
+
+describe('useTutorial — meet link', () => {
+  it('clears the meet link on start and restores it on finish', async () => {
+    const { useMeetSession } = await import('../useMeetSession')
+    const meet = useMeetSession()
+    // Plant a session directly so we don't depend on a network roundtrip.
+    meet.restoreSession({
+      meetId: 42,
+      meetName: 'Test Meet',
+      slots: [undefined, undefined, undefined],
+      teamList: [],
+      meetDivisions: ['1'],
+    })
+    expect(meet.isActive.value).toBe(true)
+
+    const s = useScoresheet()
+    const t = useTutorial(s)
+    t.start()
+    expect(meet.isActive.value).toBe(false)
+    expect(localStorage.getItem('qzr-sheet:tutorial-meet-snapshot')).toBeTruthy()
+
+    t.finish()
+    expect(meet.isActive.value).toBe(true)
+    expect(meet.meetName.value).toBe('Test Meet')
+    expect(localStorage.getItem('qzr-sheet:tutorial-meet-snapshot')).toBeNull()
+
+    meet.clearSession()
+  })
+
+  it('does not persist a meet snapshot when no meet was linked', () => {
+    const s = useScoresheet()
+    const t = useTutorial(s)
+    t.start()
+    expect(localStorage.getItem('qzr-sheet:tutorial-meet-snapshot')).toBeNull()
+    t.finish()
+  })
+
+  it('recoverFromCrash restores both quiz and meet snapshots', async () => {
+    const { useMeetSession } = await import('../useMeetSession')
+    const meet = useMeetSession()
+    meet.restoreSession({
+      meetId: 7,
+      meetName: 'Crash Meet',
+      slots: [undefined, undefined, undefined],
+      teamList: [],
+      meetDivisions: [],
+    })
+
+    const s = useScoresheet()
+    const t = useTutorial(s)
+    t.start()
+    // Simulate a crash mid-tutorial: clear in-memory session state via a
+    // fresh tutorial instance pointing at a fresh scoresheet.
+    const s2 = useScoresheet()
+    meet.clearSession()
+    const t2 = useTutorial(s2)
+
+    expect(t2.recoverFromCrash()).toBe(true)
+    expect(meet.isActive.value).toBe(true)
+    expect(meet.meetName.value).toBe('Crash Meet')
+
+    meet.clearSession()
+  })
+})

--- a/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useScoresheet } from '../useScoresheet'
 import { useTutorial } from '../useTutorial'
+import { useMeetSession } from '../useMeetSession'
 import { TUTORIAL_STEPS } from '../../tutorial/tutorialSteps'
 import { CellValue } from '../../types/scoresheet'
 import { toTeamIdx, toSeatIdx, toColIdx } from '../../types/indices'
@@ -190,8 +191,7 @@ describe('useTutorial — snapshot safety', () => {
 })
 
 describe('useTutorial — meet link', () => {
-  it('clears the meet link on start and restores it on finish', async () => {
-    const { useMeetSession } = await import('../useMeetSession')
+  it('clears the meet link on start and restores it on finish', () => {
     const meet = useMeetSession()
     // Plant a session directly so we don't depend on a network roundtrip.
     meet.restoreSession({
@@ -225,8 +225,7 @@ describe('useTutorial — meet link', () => {
     t.finish()
   })
 
-  it('recoverFromCrash restores both quiz and meet snapshots', async () => {
-    const { useMeetSession } = await import('../useMeetSession')
+  it('recoverFromCrash restores both quiz and meet snapshots', () => {
     const meet = useMeetSession()
     meet.restoreSession({
       meetId: 7,

--- a/apps/scoresheet/src/composables/useMeetSession.ts
+++ b/apps/scoresheet/src/composables/useMeetSession.ts
@@ -132,6 +132,22 @@ export function useMeetSession() {
     persist()
   }
 
+  /**
+   * Capture the current session as a deep-cloned plain object — used by the
+   * tutorial to stash the meet link before clearing it, so the user's
+   * pre-tutorial linkage can be restored on tutorial exit.
+   */
+  function snapshotSession(): MeetSessionData | null {
+    if (!session.value) return null
+    return JSON.parse(JSON.stringify(session.value)) as MeetSessionData
+  }
+
+  /** Restore a previously-snapshotted session (or clear if null). */
+  function restoreSession(data: MeetSessionData | null): void {
+    session.value = data
+    persist()
+  }
+
   /** Re-fetch the team list (e.g. after a page restore, to pick up roster changes) */
   async function refresh(): Promise<void> {
     if (!session.value) return
@@ -160,6 +176,8 @@ export function useMeetSession() {
     isQuizzerDiverged,
     getDbName,
     clearSession,
+    snapshotSession,
+    restoreSession,
     refresh,
   }
 }

--- a/apps/scoresheet/src/composables/useMeetSession.ts
+++ b/apps/scoresheet/src/composables/useMeetSession.ts
@@ -133,9 +133,10 @@ export function useMeetSession() {
   }
 
   /**
-   * Capture the current session as a deep-cloned plain object — used by the
-   * tutorial to stash the meet link before clearing it, so the user's
-   * pre-tutorial linkage can be restored on tutorial exit.
+   * Deep-clone the current session — used by the tutorial to stash the meet
+   * link before clearing it. JSON round-trip rather than structuredClone
+   * because session.value is a Vue reactive proxy and structuredClone rejects
+   * it; the existing localStorage persistence does the same coercion anyway.
    */
   function snapshotSession(): MeetSessionData | null {
     if (!session.value) return null

--- a/apps/scoresheet/src/composables/useTutorial.ts
+++ b/apps/scoresheet/src/composables/useTutorial.ts
@@ -3,9 +3,11 @@ import { CellValue, QUIZZERS_PER_TEAM, type Timeout } from '../types/scoresheet'
 import { serializeStore, parseQuizFile, type DeserializeResult } from '../persistence/quizFile'
 import type { QuizStore } from '../stores/quizStore'
 import { TUTORIAL_STEPS, type TutorialStep } from '../tutorial/tutorialSteps'
+import { useMeetSession, type MeetSessionData } from './useMeetSession'
 import type { TeamIdx, SeatIdx, ColIdx } from '../types/indices'
 
 const SNAPSHOT_KEY = 'qzr-sheet:tutorial-snapshot'
+const MEET_SNAPSHOT_KEY = 'qzr-sheet:tutorial-meet-snapshot'
 
 export interface ScoresheetAPI {
   store: QuizStore
@@ -29,6 +31,7 @@ export interface ScoresheetAPI {
 }
 
 export function useTutorial(scoresheet: ScoresheetAPI) {
+  const meetSession = useMeetSession()
   const active = ref(false)
   const currentStepIndex = ref(0)
   const targetEls = ref<HTMLElement[]>([])
@@ -37,6 +40,12 @@ export function useTutorial(scoresheet: ScoresheetAPI) {
   // from this, not from the serialized string, so a parse failure at finish time
   // can't destroy the user's pre-tutorial state.
   let snapshotData: DeserializeResult | null = null
+  // Pre-tutorial meet link, captured so we can re-attach on finish. The
+  // tutorial UI assumes the team-name input and quizzer rows are editable;
+  // when a meet is linked those become a team-picker instead, breaking the
+  // walkthrough. Unlinking for the duration of the tutorial keeps the UI in
+  // its standalone shape.
+  let meetSnapshot: MeetSessionData | null = null
   let cleanupFns: (() => void)[] = []
 
   const currentStep = computed<TutorialStep | null>(() =>
@@ -64,6 +73,19 @@ export function useTutorial(scoresheet: ScoresheetAPI) {
       localStorage.setItem(SNAPSHOT_KEY, serialized)
     } catch {
       // localStorage full — proceed without crash recovery
+    }
+
+    // Snapshot and clear the meet link so the team/quizzer inputs stay
+    // editable during the tutorial. Persist a copy too so a mid-tutorial
+    // crash recovery can restore the link along with the quiz state.
+    meetSnapshot = meetSession.snapshotSession()
+    if (meetSnapshot) {
+      try {
+        localStorage.setItem(MEET_SNAPSHOT_KEY, JSON.stringify(meetSnapshot))
+      } catch {
+        // localStorage full — proceed; the in-memory snapshot still restores on finish
+      }
+      meetSession.clearSession()
     }
 
     scoresheet.pauseAutoSave.value = true
@@ -300,6 +322,17 @@ export function useTutorial(scoresheet: ScoresheetAPI) {
       }
     }
 
+    // Restore the meet link if the user had one before starting.
+    if (meetSnapshot) {
+      meetSession.restoreSession(meetSnapshot)
+      meetSnapshot = null
+    }
+    try {
+      localStorage.removeItem(MEET_SNAPSHOT_KEY)
+    } catch {
+      // ignore
+    }
+
     scoresheet.pauseAutoSave.value = false
     active.value = false
     snapshotData = null
@@ -322,11 +355,22 @@ export function useTutorial(scoresheet: ScoresheetAPI) {
       const data = parseQuizFile(saved)
       scoresheet.loadFile(data)
       localStorage.removeItem(SNAPSHOT_KEY)
-      return true
     } catch {
       localStorage.removeItem(SNAPSHOT_KEY)
       return false
     }
+    // Re-link the meet if a snapshot was persisted. Best-effort: if the
+    // payload is malformed we drop it and the user re-picks via the dialog.
+    const savedMeet = localStorage.getItem(MEET_SNAPSHOT_KEY)
+    if (savedMeet) {
+      try {
+        meetSession.restoreSession(JSON.parse(savedMeet) as MeetSessionData)
+      } catch {
+        // ignore — meet just stays unlinked
+      }
+      localStorage.removeItem(MEET_SNAPSHOT_KEY)
+    }
+    return true
   }
 
   return {

--- a/apps/scoresheet/src/composables/useTutorial.ts
+++ b/apps/scoresheet/src/composables/useTutorial.ts
@@ -40,11 +40,8 @@ export function useTutorial(scoresheet: ScoresheetAPI) {
   // from this, not from the serialized string, so a parse failure at finish time
   // can't destroy the user's pre-tutorial state.
   let snapshotData: DeserializeResult | null = null
-  // Pre-tutorial meet link, captured so we can re-attach on finish. The
-  // tutorial UI assumes the team-name input and quizzer rows are editable;
-  // when a meet is linked those become a team-picker instead, breaking the
-  // walkthrough. Unlinking for the duration of the tutorial keeps the UI in
-  // its standalone shape.
+  // Pre-tutorial meet link. Linked meets replace the team-name input with a
+  // team-picker, so we unlink for the walkthrough and re-link on finish.
   let meetSnapshot: MeetSessionData | null = null
   let cleanupFns: (() => void)[] = []
 
@@ -356,7 +353,9 @@ export function useTutorial(scoresheet: ScoresheetAPI) {
       scoresheet.loadFile(data)
       localStorage.removeItem(SNAPSHOT_KEY)
     } catch {
+      // Quiz parse failed — clean up both keys so we don't leak stale state.
       localStorage.removeItem(SNAPSHOT_KEY)
+      localStorage.removeItem(MEET_SNAPSHOT_KEY)
       return false
     }
     // Re-link the meet if a snapshot was persisted. Best-effort: if the


### PR DESCRIPTION
## Bug

When the scoresheet was linked to a meet (via `?meet=` URL or the picker dialog) and the user started the interactive tutorial, team and quizzer name editing didn't work as the tutorial expects:

- The team-name input is replaced by a team-picker dropdown when a meet is linked (only registered DB teams are selectable; free-text input is hidden).
- Quizzer-name divergence detection flags every tutorial-set name against the DB roster, causing odd UI states.

The tutorial reset the in-memory quiz store but never touched the meet session, so these meet-mode UI affordances stayed active during the walkthrough.

## Fix

`useTutorial.start()` now snapshots and clears the meet session; `finish()` restores it. A copy of the meet snapshot is also persisted to `localStorage` (`qzr-sheet:tutorial-meet-snapshot`) so a mid-tutorial crash recovery brings both the quiz state and the meet link back.

## Changes

- `apps/scoresheet/src/composables/useMeetSession.ts` — exports new `snapshotSession()` and `restoreSession(data)` data-layer helpers.
- `apps/scoresheet/src/composables/useTutorial.ts` — captures + restores the meet link around the tutorial; persists for crash recovery.
- `apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts` — 3 new tests:
  - clears link on start, restores on finish
  - no-op for users with no meet linked
  - `recoverFromCrash` restores both quiz and meet snapshots

## Test plan

- [x] `pnpm test:unit` (676 scoresheet + 206 API)
- [x] `pnpm type-check` clean
- [ ] Manual: link a meet via `?meet=<viewerCode>`, start the tutorial, confirm team-name + quizzer-name inputs are editable for the walkthrough, confirm the meet link restores when the tutorial finishes
- [ ] Manual: crash-recovery — link meet → start tutorial → reload page mid-tutorial → confirm both quiz state and meet link are restored

_Created by Claude Code_