### PR TITLE
feat: guest joins more meets by code

### DIFF
--- a/apps/scoresheet/src/components/MeetPickerDialog.vue
+++ b/apps/scoresheet/src/components/MeetPickerDialog.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { ApiError, MeetRole } from '@qzr/shared'
+import { ApiError } from '@qzr/shared'
 import { ref } from 'vue'
 
 import { getMyMeets, joinMeet, type MeetSummary } from '../api'
 import { useMeetSession } from '../composables/useMeetSession'
-import { useGuestSession, initGuestSession } from '../composables/useGuestSession'
+import { useGuestSession, initGuestSession, joinByCode } from '../composables/useGuestSession'
 
 const emit = defineEmits<{ loaded: [] }>()
 
@@ -19,33 +19,33 @@ const submitting = ref(false)
 const joinCode = ref('')
 const joinError = ref('')
 const joining = ref(false)
+/** Tracks whether the last getMyMeets() saw a signed-in cookie session. Drives
+ * the "Have a code?" form: signed-in users add a real membership via /api/join,
+ * anonymous viewers add a guest token via /api/join/guest. */
+const signedIn = ref(false)
 
 async function fetchMeets() {
   loading.value = true
   error.value = ''
-  // Seed the list with the URL-shared meet (if any) so anonymous guests have
-  // something to click. Signed-in memberships are layered on top below.
   const seen = new Set<number>()
   const list: MeetSummary[] = []
-  if (guest.isActive.value && guest.meetId.value !== null && guest.meetName.value !== null) {
-    list.push({
-      meetId: guest.meetId.value,
-      meetName: guest.meetName.value,
-      role: MeetRole.Viewer,
-    })
-    seen.add(guest.meetId.value)
+  for (const j of guest.joinedMeets.value) {
+    list.push({ meetId: j.meetId, meetName: j.meetName, role: j.role })
+    seen.add(j.meetId)
   }
   try {
     const res = await getMyMeets()
+    signedIn.value = true
     for (const m of res.memberships) {
       if (seen.has(m.meetId)) continue
       seen.add(m.meetId)
       list.push(m)
     }
   } catch (e) {
-    // 401 is expected for anonymous guests — suppress if we already have
-    // the URL meet to show; otherwise surface "Not signed in."
+    // 401 just means anonymous guest — suppress the error if we already have
+    // joined meets to show. Other errors still surface.
     if (e instanceof ApiError && e.status === 401) {
+      signedIn.value = false
       if (list.length === 0) error.value = 'Not signed in.'
     } else {
       error.value = (e as Error).message
@@ -60,6 +60,10 @@ async function selectMeet(meet: MeetSummary) {
   submitting.value = true
   error.value = ''
   try {
+    // If this meet is one the user joined as a guest, switch the active
+    // session so loadMeet's request uses that meet's JWT. setActive is a
+    // no-op for non-guest rows (signed-in memberships).
+    guest.setActive(meet.meetId)
     await loadMeet(meet.meetId, meet.meetName)
     dialogRef.value?.close()
     emit('loaded')
@@ -76,7 +80,12 @@ async function handleJoinCode() {
   joining.value = true
   joinError.value = ''
   try {
-    await joinMeet(code)
+    if (signedIn.value) {
+      await joinMeet(code)
+    } else {
+      const data = await joinByCode(code)
+      if (!data) throw new Error('Invalid code.')
+    }
     joinCode.value = ''
     await fetchMeets()
   } catch (e) {

--- a/apps/scoresheet/src/composables/__tests__/guestSession.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/guestSession.spec.ts
@@ -8,9 +8,12 @@ vi.mock('../../api', () => ({
 import { joinMeetGuest } from '../../api'
 import {
   initGuestSession,
-  setGuestSession,
-  guestSessionRef,
+  joinByCode,
+  setGuestState,
+  setActiveSession,
+  guestStateRef,
   getGuestToken,
+  getActiveSession,
   STORAGE_KEY,
 } from '../guestSession'
 
@@ -28,13 +31,13 @@ function setSearch(search: string): void {
 
 beforeEach(() => {
   localStorage.clear()
-  setGuestSession(null)
+  setGuestState(null)
   vi.clearAllMocks()
   setSearch('')
 })
 
 afterEach(() => {
-  setGuestSession(null)
+  setGuestState(null)
 })
 
 describe('initGuestSession — URL parsing', () => {
@@ -43,10 +46,11 @@ describe('initGuestSession — URL parsing', () => {
     const result = await initGuestSession()
     expect(result).toBeNull()
     expect(joinMeetGuest).not.toHaveBeenCalled()
-    expect(guestSessionRef.value).toBeNull()
+    expect(guestStateRef.value.joined).toEqual([])
+    expect(guestStateRef.value.active).toBeNull()
   })
 
-  it('parses ?meet=<slug> and posts to /api/join/guest', async () => {
+  it('parses ?meet=<slug>, joins, and makes the new session active', async () => {
     setSearch('?meet=fall-2025')
     vi.mocked(joinMeetGuest).mockResolvedValue({
       token: 'tok-abc',
@@ -59,10 +63,23 @@ describe('initGuestSession — URL parsing', () => {
       token: 'tok-abc',
       meetId: 7,
       meetName: 'Fall 2025',
-      slug: 'fall-2025',
+      role: MeetRole.Viewer,
+      code: 'fall-2025',
     })
-    expect(guestSessionRef.value?.token).toBe('tok-abc')
+    expect(getActiveSession()?.meetId).toBe(7)
     expect(getGuestToken()).toBe('tok-abc')
+  })
+
+  it('rejects non-viewer roles via URL (security: shareable links → viewers only)', async () => {
+    setSearch('?meet=room-code')
+    vi.mocked(joinMeetGuest).mockResolvedValue({
+      token: 'tok-x',
+      meet: { id: 1, name: 'X' },
+      role: MeetRole.Official,
+    })
+    const result = await initGuestSession()
+    expect(result).toBeNull()
+    expect(guestStateRef.value.joined).toEqual([])
   })
 })
 
@@ -84,7 +101,6 @@ describe('initGuestSession — idempotency / race', () => {
     const a = initGuestSession()
     const b = initGuestSession()
     const c = initGuestSession()
-
     expect(joinMeetGuest).toHaveBeenCalledTimes(1)
 
     resolveJoin({
@@ -97,21 +113,7 @@ describe('initGuestSession — idempotency / race', () => {
     expect(ra).toEqual(rb)
     expect(rb).toEqual(rc)
     expect(ra?.meetId).toBe(11)
-    // Still just the one call after all three settled.
     expect(joinMeetGuest).toHaveBeenCalledTimes(1)
-  })
-
-  it('ignores a non-viewer response (security gate)', async () => {
-    setSearch('?meet=fall-2025')
-    vi.mocked(joinMeetGuest).mockResolvedValue({
-      token: 'tok-x',
-      meet: { id: 1, name: 'X' },
-      role: 'admin',
-    })
-    const result = await initGuestSession()
-    expect(result).toBeNull()
-    expect(guestSessionRef.value).toBeNull()
-    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
   })
 
   it('returns null when the join request fails', async () => {
@@ -119,6 +121,124 @@ describe('initGuestSession — idempotency / race', () => {
     vi.mocked(joinMeetGuest).mockResolvedValue(null)
     const result = await initGuestSession()
     expect(result).toBeNull()
-    expect(guestSessionRef.value).toBeNull()
+    expect(guestStateRef.value.joined).toEqual([])
+  })
+})
+
+describe('joinByCode — typed-in form', () => {
+  it('adds a viewer-code session without making it active', async () => {
+    // Plant an existing active session so we can verify joinByCode doesn't change it.
+    setGuestState({
+      active: 7,
+      joined: [
+        {
+          token: 'old',
+          meetId: 7,
+          meetName: 'Old Meet',
+          role: MeetRole.Viewer,
+          code: 'old-code',
+        },
+      ],
+    })
+    vi.mocked(joinMeetGuest).mockResolvedValue({
+      token: 'tok-new',
+      meet: { id: 8, name: 'New Meet' },
+      role: MeetRole.Viewer,
+    })
+    const result = await joinByCode('new-code')
+    expect(result?.meetId).toBe(8)
+    expect(guestStateRef.value.joined).toHaveLength(2)
+    expect(guestStateRef.value.active).toBe(7)
+    expect(getGuestToken()).toBe('old')
+  })
+
+  it('accepts an official-code session', async () => {
+    vi.mocked(joinMeetGuest).mockResolvedValue({
+      token: 'tok-off',
+      meet: { id: 5, name: 'Room 1' },
+      role: MeetRole.Official,
+    })
+    const result = await joinByCode('OFFICIAL-CODE-123')
+    expect(result?.role).toBe(MeetRole.Official)
+    expect(guestStateRef.value.joined[0]?.role).toBe(MeetRole.Official)
+  })
+
+  it('returns null on invalid code (404 path)', async () => {
+    vi.mocked(joinMeetGuest).mockResolvedValue(null)
+    const result = await joinByCode('nope')
+    expect(result).toBeNull()
+    expect(guestStateRef.value.joined).toEqual([])
+  })
+
+  it('replaces a duplicate by meetId rather than adding a second entry', async () => {
+    vi.mocked(joinMeetGuest).mockResolvedValueOnce({
+      token: 'tok-a',
+      meet: { id: 3, name: 'M' },
+      role: MeetRole.Viewer,
+    })
+    await joinByCode('code-a')
+    vi.mocked(joinMeetGuest).mockResolvedValueOnce({
+      token: 'tok-b',
+      meet: { id: 3, name: 'M' },
+      role: MeetRole.Viewer,
+    })
+    await joinByCode('code-a')
+    expect(guestStateRef.value.joined).toHaveLength(1)
+    expect(guestStateRef.value.joined[0]?.token).toBe('tok-b')
+  })
+
+  it('trims whitespace before joining', async () => {
+    vi.mocked(joinMeetGuest).mockResolvedValue({
+      token: 't',
+      meet: { id: 1, name: 'M' },
+      role: MeetRole.Viewer,
+    })
+    await joinByCode('  spaced  ')
+    expect(joinMeetGuest).toHaveBeenCalledWith('spaced')
+  })
+})
+
+describe('setActiveSession', () => {
+  it('switches the active session among joined meets', () => {
+    setGuestState({
+      active: 1,
+      joined: [
+        { token: 't1', meetId: 1, meetName: 'A', role: MeetRole.Viewer, code: 'a' },
+        { token: 't2', meetId: 2, meetName: 'B', role: MeetRole.Viewer, code: 'b' },
+      ],
+    })
+    expect(getGuestToken()).toBe('t1')
+    setActiveSession(2)
+    expect(getGuestToken()).toBe('t2')
+  })
+
+  it('is a no-op when meetId is not in the joined list', () => {
+    setGuestState({
+      active: 1,
+      joined: [{ token: 't1', meetId: 1, meetName: 'A', role: MeetRole.Viewer, code: 'a' }],
+    })
+    setActiveSession(99)
+    expect(guestStateRef.value.active).toBe(1)
+  })
+
+  it('clears the active marker when called with null', () => {
+    setGuestState({
+      active: 1,
+      joined: [{ token: 't1', meetId: 1, meetName: 'A', role: MeetRole.Viewer, code: 'a' }],
+    })
+    setActiveSession(null)
+    expect(getGuestToken()).toBeNull()
+  })
+})
+
+describe('persistence', () => {
+  it('removes the storage key entirely once cleared', () => {
+    setGuestState({
+      active: 1,
+      joined: [{ token: 't', meetId: 1, meetName: 'M', role: MeetRole.Viewer, code: 'c' }],
+    })
+    expect(localStorage.getItem(STORAGE_KEY)).toBeTruthy()
+    setGuestState(null)
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
   })
 })

--- a/apps/scoresheet/src/composables/guestSession.ts
+++ b/apps/scoresheet/src/composables/guestSession.ts
@@ -3,11 +3,20 @@ import { MeetRole } from '@qzr/shared'
 import { joinMeetGuest } from '../api'
 
 /**
- * Guest session state for visitors hitting the scoresheet via a shareable
- * URL like `/scoresheet/?meet=fall-2025`. The slug matches a meet's public
- * `viewerCode`. The state lives in this non-`use*` module so the API client
- * (`api.ts`) can read the token synchronously without going through Vue's
- * composable contract.
+ * Guest session state for visitors who don't have an account. Two entry points:
+ *
+ * 1. Shareable URL — `/scoresheet/?meet=<viewerCode>` auto-joins as viewer on
+ *    page load. Restricted to viewer codes only (the URL is shareable, so we
+ *    can't trust the recipient with an official code).
+ * 2. "Have a code?" form in the meet picker — accepts viewer or official
+ *    codes, the user is typing them in directly.
+ *
+ * The session keeps a list of every meet the user has joined this way and
+ * tracks which one is currently active. The API client's `request()` wrapper
+ * reads the active token via `getGuestToken()` and attaches it as
+ * `Authorization: Bearer`. This module is a non-`use*` module so the API
+ * client can read state synchronously without going through Vue's composable
+ * contract.
  */
 
 export const STORAGE_KEY = 'qzr-guest-session'
@@ -19,24 +28,66 @@ export interface GuestSessionData {
   token: string
   meetId: number
   meetName: string
-  /** Viewer code used to obtain this token; lets us refresh against the same meet. */
-  slug: string
+  role: MeetRole.Viewer | MeetRole.Official
+  /** Code used to obtain this token (URL slug or typed-in code). */
+  code: string
 }
 
-export const guestSessionRef = ref<GuestSessionData | null>(loadFromStorage())
+interface GuestState {
+  /** meetId of the active session whose token is sent on requests. */
+  active: number | null
+  joined: GuestSessionData[]
+}
+
+const EMPTY_STATE: GuestState = { active: null, joined: [] }
+
+export const guestStateRef = ref<GuestState>(loadFromStorage())
 
 /** Synchronous accessor used by the API client wrapper. */
 export function getGuestToken(): string | null {
-  return guestSessionRef.value?.token ?? null
+  const s = guestStateRef.value
+  if (s.active === null) return null
+  return s.joined.find((j) => j.meetId === s.active)?.token ?? null
 }
 
-export function setGuestSession(data: GuestSessionData | null): void {
-  guestSessionRef.value = data
+/** Active session (whose token would be attached to outgoing requests). */
+export function getActiveSession(): GuestSessionData | null {
+  const s = guestStateRef.value
+  if (s.active === null) return null
+  return s.joined.find((j) => j.meetId === s.active) ?? null
+}
+
+/** Replace the entire state. Pass null to clear everything (also drops the cached init promise). */
+export function setGuestState(state: GuestState | null): void {
+  guestStateRef.value = state ?? EMPTY_STATE
   persist()
-  // Clearing also drops the cached init promise, so the next
-  // initGuestSession() call refetches a fresh token instead of resolving
-  // to the stale "previously cleared" result.
-  if (data === null) initPromise = null
+  // Clearing also drops the cached init promise so the next initGuestSession()
+  // call refetches a fresh token instead of resolving to the stale "previously
+  // cleared" result.
+  if (state === null) initPromise = null
+}
+
+/** Make a particular joined meet active. No-op if meetId isn't in the list (or null clears). */
+export function setActiveSession(meetId: number | null): void {
+  const state = guestStateRef.value
+  if (meetId !== null && !state.joined.some((j) => j.meetId === meetId)) return
+  guestStateRef.value = { ...state, active: meetId }
+  persist()
+}
+
+/**
+ * Add (or replace by meetId) a guest session in the joined list. The new
+ * session is also made active when `makeActive` is true; the URL `?meet=` flow
+ * passes true, the "Have a code?" form passes false.
+ */
+export function addJoinedSession(data: GuestSessionData, makeActive: boolean): void {
+  const state = guestStateRef.value
+  const filtered = state.joined.filter((j) => j.meetId !== data.meetId)
+  guestStateRef.value = {
+    active: makeActive ? data.meetId : state.active,
+    joined: [...filtered, data],
+  }
+  persist()
 }
 
 /**
@@ -48,9 +99,11 @@ export function setGuestSession(data: GuestSessionData | null): void {
 let initPromise: Promise<GuestSessionData | null> | null = null
 
 /**
- * Bootstrap: read `?meet=<slug>` from the URL and either reuse a fresh stored
- * token or obtain a new one. Safe and cheap to call multiple times — the
- * first call caches the in-flight promise and later calls await the same one.
+ * Bootstrap from the URL: read `?meet=<slug>` and either reuse a fresh stored
+ * session for that slug or call POST /api/join/guest. URL flow is restricted
+ * to viewer codes — the link is shareable and we can't trust the recipient
+ * with an official code. Safe and cheap to call multiple times — the first
+ * call caches the in-flight promise and later calls await the same one.
  */
 export function initGuestSession(): Promise<GuestSessionData | null> {
   if (!initPromise) initPromise = doInitGuestSession()
@@ -63,8 +116,9 @@ async function doInitGuestSession(): Promise<GuestSessionData | null> {
   const slug = params.get(URL_PARAM)?.trim()
   if (!slug) return null
 
-  const existing = guestSessionRef.value
-  if (existing && existing.slug === slug && tokenIsFresh(existing.token)) {
+  const existing = guestStateRef.value.joined.find((j) => j.code === slug)
+  if (existing && tokenIsFresh(existing.token)) {
+    setActiveSession(existing.meetId)
     return existing
   }
 
@@ -74,16 +128,40 @@ async function doInitGuestSession(): Promise<GuestSessionData | null> {
     token: res.token,
     meetId: res.meet.id,
     meetName: res.meet.name,
-    slug,
+    role: MeetRole.Viewer,
+    code: slug,
   }
-  setGuestSession(data)
+  addJoinedSession(data, true)
   return data
 }
 
 /**
- * Return true if the JWT is more than REFRESH_SKEW_MS away from expiring.
- * We never trust the exp claim for security (the server re-verifies), only
- * to decide when to skip a refresh round-trip.
+ * Join a meet via a typed-in code (called from the "Have a code?" form).
+ * Accepts viewer and official codes — the user is typing them in directly so
+ * passing an official code is informed consent. Adds to the joined list but
+ * does NOT switch the active session; the user picks the row to load it.
+ */
+export async function joinByCode(code: string): Promise<GuestSessionData | null> {
+  const trimmed = code.trim()
+  if (!trimmed) return null
+  const res = await joinMeetGuest(trimmed)
+  if (!res) return null
+  if (res.role !== MeetRole.Viewer && res.role !== MeetRole.Official) return null
+  const data: GuestSessionData = {
+    token: res.token,
+    meetId: res.meet.id,
+    meetName: res.meet.name,
+    role: res.role,
+    code: trimmed,
+  }
+  addJoinedSession(data, false)
+  return data
+}
+
+/**
+ * Return true if the JWT is more than REFRESH_SKEW_MS away from expiring. We
+ * never trust the exp claim for security (the server re-verifies), only to
+ * decide when to skip a refresh round-trip.
  */
 function tokenIsFresh(token: string): boolean {
   try {
@@ -102,23 +180,58 @@ function tokenIsFresh(token: string): boolean {
 }
 
 function persist(): void {
-  if (guestSessionRef.value === null) {
+  const s = guestStateRef.value
+  if (s.active === null && s.joined.length === 0) {
     localStorage.removeItem(STORAGE_KEY)
   } else {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(guestSessionRef.value))
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(s))
   }
 }
 
-function loadFromStorage(): GuestSessionData | null {
+function loadFromStorage(): GuestState {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return null
-    const data = JSON.parse(raw) as Partial<GuestSessionData>
-    // `slug` was added later — older sessions without it are treated as stale
-    // so the next initGuestSession() refreshes them with a slug-keyed entry.
-    if (!data.token || !data.meetId || !data.meetName || !data.slug) return null
-    return data as GuestSessionData
+    if (!raw) return { active: null, joined: [] }
+    const data = JSON.parse(raw) as unknown
+    if (!data || typeof data !== 'object') return { active: null, joined: [] }
+
+    // New shape: { active, joined[] }
+    if ('joined' in data && Array.isArray((data as GuestState).joined)) {
+      const s = data as GuestState
+      const joined = s.joined.filter(isValidSession)
+      const active = s.active && joined.some((j) => j.meetId === s.active) ? s.active : null
+      return { active, joined }
+    }
+
+    // Legacy shape: a single session at the top level. Wrap it as the only
+    // joined entry. Pre-multi-meet sessions only ever held viewer tokens.
+    const legacy = data as Partial<GuestSessionData & { slug?: string }>
+    if (legacy.token && legacy.meetId && legacy.meetName) {
+      return {
+        active: legacy.meetId,
+        joined: [
+          {
+            token: legacy.token,
+            meetId: legacy.meetId,
+            meetName: legacy.meetName,
+            role: MeetRole.Viewer,
+            code: legacy.code ?? legacy.slug ?? '',
+          },
+        ],
+      }
+    }
+    return { active: null, joined: [] }
   } catch {
-    return null
+    return { active: null, joined: [] }
   }
+}
+
+function isValidSession(j: unknown): j is GuestSessionData {
+  return (
+    !!j &&
+    typeof j === 'object' &&
+    typeof (j as GuestSessionData).token === 'string' &&
+    typeof (j as GuestSessionData).meetId === 'number' &&
+    typeof (j as GuestSessionData).meetName === 'string'
+  )
 }

--- a/apps/scoresheet/src/composables/useGuestSession.ts
+++ b/apps/scoresheet/src/composables/useGuestSession.ts
@@ -1,16 +1,29 @@
 import { computed } from 'vue'
-import { guestSessionRef, setGuestSession } from './guestSession'
+import {
+  guestStateRef,
+  setGuestState,
+  setActiveSession,
+  getActiveSession,
+  type GuestSessionData,
+} from './guestSession'
 
-export { initGuestSession, getGuestToken } from './guestSession'
+export { initGuestSession, getGuestToken, joinByCode } from './guestSession'
+export type { GuestSessionData } from './guestSession'
 
 export function useGuestSession() {
-  const isActive = computed(() => guestSessionRef.value !== null)
-  const meetId = computed(() => guestSessionRef.value?.meetId ?? null)
-  const meetName = computed(() => guestSessionRef.value?.meetName ?? null)
+  const isActive = computed(() => guestStateRef.value.active !== null)
+  const meetId = computed(() => getActiveSession()?.meetId ?? null)
+  const meetName = computed(() => getActiveSession()?.meetName ?? null)
+  /** Every meet the user has joined as a guest, oldest first. */
+  const joinedMeets = computed<GuestSessionData[]>(() => guestStateRef.value.joined)
 
-  function clear(): void {
-    setGuestSession(null)
+  function setActive(meetIdToActivate: number | null): void {
+    setActiveSession(meetIdToActivate)
   }
 
-  return { isActive, meetId, meetName, clear }
+  function clear(): void {
+    setGuestState(null)
+  }
+
+  return { isActive, meetId, meetName, joinedMeets, setActive, clear }
 }


### PR DESCRIPTION
## Summary

Extends the guest flow (shipped fully working in PR #53) so an anonymous
viewer can keep adding meets to their picker list. Previously the guest
could only see the single meet from `?meet=<viewerCode>` — the
"Have a code?" form on the picker required a signed-in account.

Now: typing a viewer or official code in that form calls
`POST /api/join/guest`, gets a token scoped to that meet, and adds it
to the picker as another row. URL `?meet=` stays viewer-only because
the link is shareable; the form accepts both roles since the user is
typing the code directly.

## Implementation

- **`guestSession.ts`** — storage shape changes from a single
  `GuestSessionData` to `{ active: meetId | null, joined: GuestSessionData[] }`.
  Legacy shape auto-migrates on load.
  - `getGuestToken()` returns the active session's token (unchanged contract).
  - New: `setActiveSession(meetId)`, `addJoinedSession(data, makeActive)`,
    `joinByCode(code)`.
  - `initGuestSession()` (URL flow) still viewer-only, makes itself active.
  - `joinByCode()` (form flow) accepts viewer + official, does NOT auto-activate.
- **`useGuestSession()`** — exposes `joinedMeets`, `setActive(meetId)`.
- **`MeetPickerDialog.vue`**
  - `fetchMeets()` seeds the list with all joined sessions, layers
    `getMyMeets()` memberships on top.
  - `handleJoinCode()` dispatches: signed-in → existing `joinMeet`
    (membership), anonymous → `joinByCode` (guest). Tracked via
    `signedIn` ref set by `fetchMeets`'s response.
  - `selectMeet()` calls `guest.setActive(meet.meetId)` before
    `loadMeet()` so the request is signed by the right meet's JWT.

## Test plan

- [x] `pnpm test:unit` — 690 scoresheet (was 681 → +9) + 209 API pass
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean on changed files
- [ ] Manual smoke (`pnpm dev:all`):
  - [ ] Sign out / private window
  - [ ] Visit `/scoresheet/?meet=<viewer-code-A>`
  - [ ] Click "Load teams from meet" → see meet A as a row
  - [ ] In "Have a code?", paste viewer-code-B → meet B appears as a second row
  - [ ] Click meet B → loads B's teams
  - [ ] Click meet A → loads A's teams (active session switches)
  - [ ] Try an official code → joins as Official, displays correctly
  - [ ] Try an invalid code → "Invalid code." error in form
  - [ ] As a signed-in user: form still uses /api/join (membership) path
  - [ ] Reload page → joined list survives, active meet is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)