### PR TITLE
feat(web): read-only schedule view

### DIFF
--- a/apps/web/src/__tests__/scheduleGrid.spec.ts
+++ b/apps/web/src/__tests__/scheduleGrid.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+
+import { buildGrid, hasAnyQuiz } from '../scheduleGrid'
+import type { MeetRoom, MeetSlot, ScheduledQuiz } from '../api'
+
+function room(id: number, name: string, sortOrder: number): MeetRoom {
+  return { id, name, sortOrder, hasCode: false }
+}
+
+function slot(id: number, sortOrder: number, kind: 'quiz' | 'event' = 'quiz'): MeetSlot {
+  return {
+    id,
+    meetId: 1,
+    startAt: '2026-05-08T13:00:00.000Z',
+    durationMinutes: 25,
+    kind,
+    eventLabel: kind === 'event' ? 'Breakfast' : null,
+    sortOrder,
+  }
+}
+
+function quiz(
+  id: number,
+  slotId: number,
+  roomId: number,
+  division = 'Div 1',
+  overrides: Partial<ScheduledQuiz> = {},
+): ScheduledQuiz {
+  return {
+    id,
+    meetId: 1,
+    slotId,
+    roomId,
+    division,
+    phase: 'prelim',
+    lane: null,
+    label: `Q${id}`,
+    bracketLabel: null,
+    publishedAt: null,
+    completedAt: null,
+    seats: [],
+    ...overrides,
+  }
+}
+
+describe('buildGrid', () => {
+  it('orders rooms by sortOrder then id', () => {
+    const grid = buildGrid([room(2, 'B', 2), room(1, 'A', 1), room(3, 'C', 1)], [], [], null)
+    expect(grid.rooms.map((r) => r.id)).toEqual([1, 3, 2])
+  })
+
+  it('orders rows by slot sortOrder then id', () => {
+    const grid = buildGrid([room(1, 'A', 0)], [slot(2, 2), slot(1, 1)], [], null)
+    expect(grid.rows.map((r) => r.slot.id)).toEqual([1, 2])
+  })
+
+  it('places quizzes into their (slot, room) cells; missing cells are null', () => {
+    const rooms = [room(1, 'A', 0), room(2, 'B', 1)]
+    const slots = [slot(1, 0)]
+    const quizzes = [quiz(10, 1, 1)]
+    const grid = buildGrid(rooms, slots, quizzes, null)
+    expect(grid.rows).toHaveLength(1)
+    expect(grid.rows[0]!.cells.map((c) => c?.id ?? null)).toEqual([10, null])
+  })
+
+  it('event rows have no cells (spanned by the renderer)', () => {
+    const grid = buildGrid([room(1, 'A', 0)], [slot(1, 0, 'event')], [], null)
+    expect(grid.rows[0]!.cells).toEqual([])
+  })
+
+  it('division filter hides off-division quizzes but keeps the slot row', () => {
+    const rooms = [room(1, 'A', 0), room(2, 'B', 1)]
+    const slots = [slot(1, 0)]
+    const quizzes = [quiz(10, 1, 1, 'Div 1'), quiz(11, 1, 2, 'Div 2')]
+    const grid = buildGrid(rooms, slots, quizzes, 'Div 1')
+    expect(grid.rows[0]!.cells.map((c) => c?.id ?? null)).toEqual([10, null])
+  })
+
+  it('null divisionFilter passes all quizzes through', () => {
+    const rooms = [room(1, 'A', 0), room(2, 'B', 1)]
+    const slots = [slot(1, 0)]
+    const quizzes = [quiz(10, 1, 1, 'Div 1'), quiz(11, 1, 2, 'Div 2')]
+    const grid = buildGrid(rooms, slots, quizzes, null)
+    expect(grid.rows[0]!.cells.map((c) => c?.id ?? null)).toEqual([10, 11])
+  })
+})
+
+describe('hasAnyQuiz', () => {
+  it('is false for an empty grid', () => {
+    const grid = buildGrid([room(1, 'A', 0)], [slot(1, 0)], [], null)
+    expect(hasAnyQuiz(grid)).toBe(false)
+  })
+
+  it('is true when at least one cell holds a quiz', () => {
+    const grid = buildGrid([room(1, 'A', 0)], [slot(1, 0)], [quiz(10, 1, 1)], null)
+    expect(hasAnyQuiz(grid)).toBe(true)
+  })
+
+  it('is false when all quizzes are filtered out by division', () => {
+    const grid = buildGrid([room(1, 'A', 0)], [slot(1, 0)], [quiz(10, 1, 1, 'Div 2')], 'Div 1')
+    expect(hasAnyQuiz(grid)).toBe(false)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -390,3 +390,57 @@ export interface RosterExportEntry {
 export function exportRoster(meetId: number): Promise<{ entries: RosterExportEntry[] }> {
   return request(`/api/meets/${meetId}/roster/export`)
 }
+
+// ---- Schedule (read-only, see issue #13) ----
+
+export interface MeetRoom {
+  id: number
+  name: string
+  sortOrder: number
+  hasCode: boolean
+}
+
+export interface MeetSlot {
+  id: number
+  meetId: number
+  startAt: string
+  durationMinutes: number
+  kind: 'quiz' | 'event'
+  eventLabel: string | null
+  sortOrder: number
+}
+
+export interface ScheduledQuizSeat {
+  id: number
+  quizId: number
+  seatNumber: number
+  letter: string | null
+  seedRef: string | null
+}
+
+export interface ScheduledQuiz {
+  id: number
+  meetId: number
+  slotId: number
+  roomId: number
+  division: string
+  phase: 'prelim' | 'elim'
+  lane: 'main' | 'consolation' | 'intermediate' | null
+  label: string
+  bracketLabel: string | null
+  publishedAt: string | null
+  completedAt: string | null
+  seats: ScheduledQuizSeat[]
+}
+
+export function listMeetRooms(meetId: number): Promise<{ rooms: MeetRoom[] }> {
+  return request(`/api/meets/${meetId}/rooms`)
+}
+
+export function listMeetSlots(meetId: number): Promise<{ slots: MeetSlot[] }> {
+  return request(`/api/meets/${meetId}/slots`)
+}
+
+export function listScheduledQuizzes(meetId: number): Promise<{ quizzes: ScheduledQuiz[] }> {
+  return request(`/api/meets/${meetId}/quizzes`)
+}

--- a/apps/web/src/components/ScheduleGrid.vue
+++ b/apps/web/src/components/ScheduleGrid.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type { MeetRoom, MeetSlot, ScheduledQuiz, ScheduledQuizSeat } from '../api'
+import { buildGrid, formatSlotTime, hasAnyQuiz } from '../scheduleGrid'
+
+const props = defineProps<{
+  rooms: MeetRoom[]
+  slots: MeetSlot[]
+  quizzes: ScheduledQuiz[]
+  divisionFilter: string | null
+}>()
+
+const grid = computed(() =>
+  buildGrid(props.rooms, props.slots, props.quizzes, props.divisionFilter),
+)
+const isEmpty = computed(() => !hasAnyQuiz(grid.value))
+
+/**
+ * Single render path for a seat chip. Future "follow team" highlighting hooks
+ * in here once seats start carrying teamIds (see #39 Roll Teams).
+ */
+function seatLabel(seat: ScheduledQuizSeat): string {
+  return seat.letter ?? seat.seedRef ?? '?'
+}
+</script>
+
+<template>
+  <div v-if="grid.rooms.length === 0" class="schedule-empty">
+    No rooms have been added to this meet yet.
+  </div>
+
+  <div v-else class="schedule-scroll">
+    <table class="schedule-grid">
+      <thead>
+        <tr>
+          <th class="time-col" scope="col">Time</th>
+          <th
+            v-for="room in grid.rooms"
+            :key="room.id"
+            :data-room-id="room.id"
+            class="room-col"
+            scope="col"
+          >
+            {{ room.name }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="row in grid.rows"
+          :key="row.slot.id"
+          :class="{ 'event-row': row.slot.kind === 'event' }"
+        >
+          <th class="time-col" scope="row">{{ formatSlotTime(row.slot.startAt) }}</th>
+          <td v-if="row.slot.kind === 'event'" class="event-cell" :colspan="grid.rooms.length">
+            {{ row.slot.eventLabel || 'Event' }}
+          </td>
+          <template v-else>
+            <td v-for="(quiz, i) in row.cells" :key="grid.rooms[i]!.id" class="quiz-cell">
+              <div v-if="quiz" class="quiz-card" :data-quiz-id="quiz.id">
+                <div class="quiz-label">{{ quiz.label }}</div>
+                <ul class="seat-list">
+                  <li
+                    v-for="seat in quiz.seats"
+                    :key="seat.id"
+                    class="seat-chip"
+                    :data-seat-letter="seat.letter || undefined"
+                  >
+                    {{ seatLabel(seat) }}
+                  </li>
+                </ul>
+              </div>
+            </td>
+          </template>
+        </tr>
+      </tbody>
+    </table>
+
+    <p v-if="isEmpty" class="schedule-state">No quizzes scheduled in this view.</p>
+  </div>
+</template>
+
+<style scoped>
+.schedule-empty,
+.schedule-state {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  padding: 1rem 0;
+  text-align: center;
+}
+
+.schedule-scroll {
+  overflow-x: auto;
+}
+
+.schedule-grid {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.85rem;
+}
+
+.schedule-grid th,
+.schedule-grid td {
+  border: 1px solid var(--color-border-alt);
+  padding: 0.4rem 0.6rem;
+  vertical-align: top;
+  text-align: left;
+}
+
+.time-col {
+  width: 5rem;
+  font-weight: 600;
+  white-space: nowrap;
+  background: var(--color-bg-raised);
+}
+
+.room-col {
+  font-weight: 600;
+  background: var(--color-bg-raised);
+  text-align: center;
+}
+
+.event-row .event-cell {
+  background: var(--color-bg-warm);
+  font-style: italic;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.quiz-cell {
+  min-width: 8rem;
+}
+
+.quiz-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.quiz-label {
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.seat-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.seat-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.6rem;
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  background: var(--color-bg);
+}
+</style>

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -26,6 +26,12 @@ const router = createRouter({
             churchId: Number(route.params.churchId),
           }),
         },
+        {
+          path: 'schedule',
+          name: 'meet-schedule',
+          component: () => import('../views/ScheduleView.vue'),
+          props: (route) => ({ slug: route.params.slug as string }),
+        },
       ],
     },
   ],

--- a/apps/web/src/scheduleGrid.ts
+++ b/apps/web/src/scheduleGrid.ts
@@ -1,0 +1,62 @@
+import type { MeetRoom, MeetSlot, ScheduledQuiz } from './api'
+
+export interface GridRow {
+  slot: MeetSlot
+  /** Quiz at each room column (same order as `Grid.rooms`). null = empty cell.
+   *  Always empty for event slots — the renderer spans those across columns. */
+  cells: (ScheduledQuiz | null)[]
+}
+
+export interface Grid {
+  rooms: MeetRoom[]
+  rows: GridRow[]
+}
+
+/**
+ * Build the schedule grid: rooms sorted by sortOrder then id (column order),
+ * slots sorted by sortOrder then id (row order), each quiz placed at its
+ * (slot, room) cell. `divisionFilter` drops off-division quizzes to null
+ * cells but keeps every slot row so empty rooms are still visible.
+ */
+export function buildGrid(
+  rooms: MeetRoom[],
+  slots: MeetSlot[],
+  quizzes: ScheduledQuiz[],
+  divisionFilter: string | null,
+): Grid {
+  const sortedRooms = [...rooms].sort((a, b) => a.sortOrder - b.sortOrder || a.id - b.id)
+  const sortedSlots = [...slots].sort((a, b) => a.sortOrder - b.sortOrder || a.id - b.id)
+
+  const byCell = new Map<number, Map<number, ScheduledQuiz>>()
+  for (const q of quizzes) {
+    if (divisionFilter !== null && q.division !== divisionFilter) continue
+    let perSlot = byCell.get(q.slotId)
+    if (!perSlot) {
+      perSlot = new Map()
+      byCell.set(q.slotId, perSlot)
+    }
+    perSlot.set(q.roomId, q)
+  }
+
+  const rows: GridRow[] = sortedSlots.map((slot) => {
+    if (slot.kind === 'event') return { slot, cells: [] }
+    const perSlot = byCell.get(slot.id)
+    return {
+      slot,
+      cells: sortedRooms.map((r) => perSlot?.get(r.id) ?? null),
+    }
+  })
+
+  return { rooms: sortedRooms, rows }
+}
+
+export function hasAnyQuiz(grid: Grid): boolean {
+  return grid.rows.some((r) => r.cells.some((c) => c !== null))
+}
+
+/** "8:00 AM" — local-time hh:mm; `startAt` is an ISO string from the API. */
+export function formatSlotTime(startAt: string): string {
+  const d = new Date(startAt)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+}

--- a/apps/web/src/views/QuizMeetView.vue
+++ b/apps/web/src/views/QuizMeetView.vue
@@ -717,6 +717,21 @@ onMounted(load)
         </div>
       </div>
 
+      <!-- Schedule -->
+      <div class="section">
+        <div class="section-header">
+          <h3 class="section-title">Schedule</h3>
+          <div class="section-actions">
+            <button
+              class="btn btn--secondary btn--sm"
+              @click="router.push({ name: 'meet-schedule', params: { slug } })"
+            >
+              Open schedule →
+            </button>
+          </div>
+        </div>
+      </div>
+
       <!-- Churches -->
       <div class="section">
         <div class="section-header">

--- a/apps/web/src/views/ScheduleView.vue
+++ b/apps/web/src/views/ScheduleView.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import {
+  getMeet,
+  listMeetRooms,
+  listMeetSlots,
+  listScheduledQuizzes,
+  type MeetDetail,
+  type MeetRoom,
+  type MeetSlot,
+  type ScheduledQuiz,
+} from '../api'
+import ScheduleGrid from '../components/ScheduleGrid.vue'
+
+const props = defineProps<{ slug: string }>()
+const router = useRouter()
+
+const detail = ref<MeetDetail | null>(null)
+const rooms = ref<MeetRoom[]>([])
+const slots = ref<MeetSlot[]>([])
+const quizzes = ref<ScheduledQuiz[]>([])
+const loading = ref(true)
+const error = ref('')
+const divisionFilter = ref<string | null>(null)
+
+const meet = computed(() => detail.value?.meet ?? null)
+const divisions = computed(() => meet.value?.divisions ?? [])
+
+async function load() {
+  loading.value = true
+  error.value = ''
+  try {
+    const meetDetail = await getMeet(props.slug)
+    detail.value = meetDetail
+    const meetId = meetDetail.meet.id
+    const [r, s, q] = await Promise.all([
+      listMeetRooms(meetId),
+      listMeetSlots(meetId),
+      listScheduledQuizzes(meetId),
+    ])
+    rooms.value = r.rooms
+    slots.value = s.slots
+    quizzes.value = q.quizzes
+  } catch (e) {
+    error.value = (e as Error).message
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="container">
+    <button class="back-link" @click="router.push({ name: 'meet', params: { slug } })">
+      ← {{ meet?.name || 'QuizMeet' }}
+    </button>
+
+    <p v-if="loading" class="state-msg">Loading…</p>
+    <p v-else-if="error" class="state-msg state-msg--error">{{ error }}</p>
+
+    <template v-else-if="meet">
+      <div class="page-header">
+        <h2 class="page-title">Schedule</h2>
+        <span class="meet-name">{{ meet.name }}</span>
+      </div>
+
+      <div v-if="divisions.length > 1" class="filter-row">
+        <label class="filter-label" for="division-filter">Division</label>
+        <select id="division-filter" v-model="divisionFilter" class="filter-select">
+          <option :value="null">All</option>
+          <option v-for="d in divisions" :key="d" :value="d">{{ d }}</option>
+        </select>
+      </div>
+
+      <ScheduleGrid
+        :rooms="rooms"
+        :slots="slots"
+        :quizzes="quizzes"
+        :division-filter="divisionFilter"
+      />
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.container {
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.back-link {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font: inherit;
+  cursor: pointer;
+  padding: 0.25rem 0;
+  margin-bottom: 0.5rem;
+}
+
+.back-link:hover {
+  color: var(--color-text);
+}
+
+.state-msg {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  padding: 1rem 0;
+}
+
+.state-msg--error {
+  color: var(--color-invalid, #c00);
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  margin-bottom: 1rem;
+}
+
+.page-title {
+  font-size: 1.4rem;
+  margin: 0;
+}
+
+.meet-name {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.filter-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.filter-label {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.filter-select {
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--color-border-alt);
+  border-radius: 4px;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+</style>


### PR DESCRIPTION
## Summary

Closes #13. Adds the first portal UI for the schedule data spine that landed in #12.

A read-only `ScheduleView.vue` mounted at `/:slug/schedule`:

- Slots × rooms grid, oldest-slot-first, lowest-sortOrder room first
- Event slots span all room columns
- Quiz cards show their label and seat chips (letters for prelims, seedRefs for elims — see "Out of scope" below)
- Division filter dropdown when the meet has more than one division
- "Open schedule →" entry point added to `QuizMeetView.vue`

## Future-proofing

User flagged plans for "follow this team" / "follow this room" personalization in later PRs. To avoid revisiting the rendering layer:

- Room headers carry `data-room-id`; quiz cards carry `data-quiz-id`; seat chips carry `data-seat-letter`. Easy targets for highlight passes.
- `ScheduleGrid` is pure-presentational with `divisionFilter` already as a prop — adding `followedTeamIds: Set<number>` slots in next to it without refactor.
- One render path per chip (`seatLabel(seat)`) so future highlight state has one place to live.

No new composable or storage code in this PR.

## Out of scope (deferred)

- **Team-name resolution.** Seats currently show letter (`A`, `B`, `C`) for prelim quizzes and seedRef JSON for elim quizzes. Resolving `teamId` → team name is naturally part of #39 Roll Teams.
- Edit/drag interactions — that's #14.
- Server-side phase-aware visibility — `schedule.use('*', requireAuth())` lets any authenticated user fetch every quiz today. Pre-existing; will file a follow-up.
- Per-division state badges, mobile-first layout, draft/published distinction.

## Test plan

- [x] `pnpm test:unit` — 9 new tests in `apps/web/src/__tests__/scheduleGrid.spec.ts` cover grid ordering, event-row pass-through, empty cells, division filter, `hasAnyQuiz`. All 690 unit tests pass.
- [x] `pnpm type-check` clean.
- [ ] Browser smoke-test: not run by me. Worth a manual pass on `pnpm dev:web` against a meet with seeded slots/quizzes (and one with none, for the empty state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)