### PR TITLE
feat(web): denser schedule cells matching winkler

### DIFF
--- a/apps/web/src/components/ScheduleGrid.vue
+++ b/apps/web/src/components/ScheduleGrid.vue
@@ -16,12 +16,17 @@ const grid = computed(() =>
 )
 const isEmpty = computed(() => !hasAnyQuiz(grid.value))
 
-/**
- * Single render path for a seat chip. Future "follow team" highlighting hooks
- * in here once seats start carrying teamIds (see #39 Roll Teams).
- */
-function seatLabel(seat: ScheduledQuizSeat): string {
-  return seat.letter ?? seat.seedRef ?? '?'
+/** Letter slot for prelims, seedRef for elims, blank otherwise.
+ *  Single render path so future "follow team" highlighting hooks in here
+ *  once seats start carrying teamIds (see #39 Roll Teams). */
+function seatRef(seat: ScheduledQuizSeat): string {
+  return seat.letter ?? seat.seedRef ?? ''
+}
+
+/** Resolved team name for a seat. Always '—' until #39 ships the
+ *  prelim_assignments / seed_resolutions resolution layer. */
+function seatTeam(_seat: ScheduledQuizSeat): string {
+  return '—'
 }
 </script>
 
@@ -60,16 +65,19 @@ function seatLabel(seat: ScheduledQuizSeat): string {
             <td v-for="(quiz, i) in row.cells" :key="grid.rooms[i]!.id" class="quiz-cell">
               <div v-if="quiz" class="quiz-card" :data-quiz-id="quiz.id">
                 <div class="quiz-label">{{ quiz.label }}</div>
-                <ul class="seat-list">
-                  <li
-                    v-for="seat in quiz.seats"
-                    :key="seat.id"
-                    class="seat-chip"
-                    :data-seat-letter="seat.letter || undefined"
-                  >
-                    {{ seatLabel(seat) }}
-                  </li>
-                </ul>
+                <table class="seat-table">
+                  <tbody>
+                    <tr
+                      v-for="seat in quiz.seats"
+                      :key="seat.id"
+                      class="seat-row"
+                      :data-seat-letter="seat.letter || undefined"
+                    >
+                      <td class="seat-ref">{{ seatRef(seat) }}</td>
+                      <td class="seat-team">{{ seatTeam(seat) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </td>
           </template>
@@ -94,73 +102,95 @@ function seatLabel(seat: ScheduledQuizSeat): string {
   overflow-x: auto;
 }
 
+/* Datasheet aesthetic — tight cells, hairline borders, monospace numbers.
+   Mirrors the dense per-quiz layout from docs/example-winkler-2026.md. */
 .schedule-grid {
   border-collapse: collapse;
   width: 100%;
-  font-size: 0.85rem;
+  font-size: 0.78rem;
+  table-layout: fixed;
 }
 
 .schedule-grid th,
 .schedule-grid td {
   border: 1px solid var(--color-border-alt);
-  padding: 0.4rem 0.6rem;
+  padding: 0;
   vertical-align: top;
   text-align: left;
 }
 
 .time-col {
-  width: 5rem;
+  width: 4.5rem;
   font-weight: 600;
   white-space: nowrap;
   background: var(--color-bg-raised);
+  padding: 0.35rem 0.5rem;
+  vertical-align: top;
+  color: var(--color-text-muted);
 }
 
 .room-col {
   font-weight: 600;
   background: var(--color-bg-raised);
   text-align: center;
+  padding: 0.35rem 0.5rem;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
 }
 
 .event-row .event-cell {
   background: var(--color-bg-warm);
   font-style: italic;
-  text-align: center;
+  text-align: left;
   color: var(--color-text-muted);
+  padding: 0.4rem 0.6rem;
+  letter-spacing: 0.02em;
 }
 
 .quiz-cell {
-  min-width: 8rem;
+  min-width: 7rem;
 }
 
 .quiz-card {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
 }
 
 .quiz-label {
   font-weight: 600;
-  font-size: 0.8rem;
+  text-align: center;
+  padding: 0.3rem 0.4rem 0.2rem;
+  border-bottom: 1px solid var(--color-border-alt);
+  color: var(--color-text);
 }
 
-.seat-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  gap: 0.25rem;
-  flex-wrap: wrap;
+.seat-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.72rem;
 }
 
-.seat-chip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 1.6rem;
-  padding: 0.1rem 0.35rem;
-  border: 1px solid var(--color-border);
-  border-radius: 4px;
-  font-size: 0.75rem;
-  background: var(--color-bg);
+.seat-table .seat-row td {
+  border: none;
+  border-top: 1px dotted var(--color-border-alt);
+  padding: 0.18rem 0.4rem;
+}
+.seat-table .seat-row:first-child td {
+  border-top: none;
+}
+
+.seat-ref {
+  width: 2.6rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.seat-team {
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>

--- a/packages/api/seed-schedule.sql
+++ b/packages/api/seed-schedule.sql
@@ -1,0 +1,116 @@
+-- Seed a representative schedule slice for the local Test meet (id=1).
+-- Idempotent: clears any existing schedule rows for this meet first.
+-- Times are stored as Unix seconds; UTC strings here = America/Winnipeg
+-- wall time + 6h (CST). Adjust if testing in another zone.
+
+DELETE FROM scheduled_quiz_seats WHERE quiz_id IN (SELECT id FROM scheduled_quizzes WHERE meet_id = 1);
+DELETE FROM scheduled_quizzes WHERE meet_id = 1;
+DELETE FROM meet_slots WHERE meet_id = 1;
+DELETE FROM meet_rooms WHERE meet_id = 1;
+
+-- ---- Rooms ----
+INSERT INTO meet_rooms (meet_id, name, sort_order) VALUES
+  (1, 'Room 1', 1),
+  (1, 'Room 2', 2),
+  (1, 'Room 3', 3),
+  (1, 'Room 4', 4),
+  (1, 'Room 5', 5);
+
+-- ---- Slots ----
+-- Friday 2026-05-15 morning: assembly + 3 prelim rounds
+-- Saturday 2026-05-16: stats break, intermediates, finals, awards
+INSERT INTO meet_slots (meet_id, start_at, duration_minutes, kind, event_label, sort_order) VALUES
+  (1, CAST(strftime('%s', '2026-05-15 13:30:00') AS INTEGER), 30, 'event', 'Opening Assembly',    1),
+  (1, CAST(strftime('%s', '2026-05-15 14:00:00') AS INTEGER), 25, 'quiz',  NULL,                  2),
+  (1, CAST(strftime('%s', '2026-05-15 14:25:00') AS INTEGER), 25, 'quiz',  NULL,                  3),
+  (1, CAST(strftime('%s', '2026-05-15 14:50:00') AS INTEGER), 25, 'quiz',  NULL,                  4),
+  (1, CAST(strftime('%s', '2026-05-16 15:00:00') AS INTEGER), 60, 'event', 'Stats Break',         5),
+  (1, CAST(strftime('%s', '2026-05-16 16:00:00') AS INTEGER), 30, 'quiz',  NULL,                  6),
+  (1, CAST(strftime('%s', '2026-05-16 17:00:00') AS INTEGER), 30, 'quiz',  NULL,                  7),
+  (1, CAST(strftime('%s', '2026-05-16 22:00:00') AS INTEGER), 60, 'event', 'Awards & Worship',    8);
+
+-- ---- Quizzes ----
+-- Helper: slots and rooms looked up by sort_order / name within meet.
+-- Round 1 (sort_order=2): full row
+INSERT INTO scheduled_quizzes (meet_id, slot_id, room_id, division, phase, label) VALUES
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=2), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 1'), '1', 'prelim', 'Div 1 Quiz 1'),
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=2), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 2'), '1', 'prelim', 'Div 1 Quiz 2'),
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=2), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 3'), '1', 'prelim', 'Div 1 Quiz 3'),
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=2), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 4'), '2', 'prelim', 'Div 2 Quiz 1');
+-- Round 2 (sort_order=3)
+INSERT INTO scheduled_quizzes (meet_id, slot_id, room_id, division, phase, label) VALUES
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=3), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 1'), '1', 'prelim', 'Div 1 Quiz 4'),
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=3), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 2'), '1', 'prelim', 'Div 1 Quiz 5'),
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=3), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 3'), '1', 'prelim', 'Div 1 Quiz 6'),
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=3), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 4'), '2', 'prelim', 'Div 2 Quiz 2');
+-- Round 3 (sort_order=4) — sparse: rooms 4 and 5 empty
+INSERT INTO scheduled_quizzes (meet_id, slot_id, room_id, division, phase, label) VALUES
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=4), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 1'), '1', 'prelim', 'Div 1 Quiz 7'),
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=4), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 2'), '1', 'prelim', 'Div 1 Quiz 8'),
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=4), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 3'), '1', 'prelim', 'Div 1 Quiz 9');
+-- Intermediates (sort_order=6) — elim with seedRefs
+INSERT INTO scheduled_quizzes (meet_id, slot_id, room_id, division, phase, lane, label, bracket_label) VALUES
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=6), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 1'), '1', 'elim', 'intermediate', 'Div 1 Quiz X', 'X'),
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=6), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 2'), '1', 'elim', 'intermediate', 'Div 1 Quiz Y', 'Y'),
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=6), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 3'), '2', 'elim', 'intermediate', 'Div 2 Quiz X', 'X');
+-- Finals (sort_order=7) — elim main
+INSERT INTO scheduled_quizzes (meet_id, slot_id, room_id, division, phase, lane, label, bracket_label) VALUES
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=7), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 1'), '1', 'elim', 'main', 'Div 1 Final', 'Final'),
+  (1, (SELECT id FROM meet_slots WHERE meet_id=1 AND sort_order=7), (SELECT id FROM meet_rooms WHERE meet_id=1 AND name='Room 2'), '2', 'elim', 'main', 'Div 2 Final', 'Final');
+
+-- ---- Seats ----
+-- Prelim seats: letter codes A–I across the 9 div-1 prelim quizzes per
+-- rules.md "Preliminary Round Brackets" 9-team table.
+-- Div 2 uses a 4-team table (A–F across 2 quizzes shown here).
+INSERT INTO scheduled_quiz_seats (quiz_id, seat_number, letter) VALUES
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 1'), 1, 'A'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 1'), 2, 'B'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 1'), 3, 'C'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 2'), 1, 'D'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 2'), 2, 'E'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 2'), 3, 'F'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 3'), 1, 'G'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 3'), 2, 'H'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 3'), 3, 'I'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 4'), 1, 'A'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 4'), 2, 'D'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 4'), 3, 'G'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 5'), 1, 'B'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 5'), 2, 'E'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 5'), 3, 'H'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 6'), 1, 'C'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 6'), 2, 'F'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 6'), 3, 'I'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 7'), 1, 'A'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 7'), 2, 'E'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 7'), 3, 'I'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 8'), 1, 'B'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 8'), 2, 'F'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 8'), 3, 'G'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 9'), 1, 'C'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 9'), 2, 'D'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz 9'), 3, 'H'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Quiz 1'), 1, 'A'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Quiz 1'), 2, 'B'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Quiz 1'), 3, 'C'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Quiz 2'), 1, 'D'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Quiz 2'), 2, 'E'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Quiz 2'), 3, 'F');
+
+-- Elim seats: seedRefs reference prior quizzes (X/Y) or prelim ranks.
+INSERT INTO scheduled_quiz_seats (quiz_id, seat_number, seed_ref) VALUES
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz X'), 1, '7th place'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz X'), 2, '8th place'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz X'), 3, '9th place'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz Y'), 1, '10th place'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz Y'), 2, '11th place'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Quiz Y'), 3, '12th place'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Quiz X'), 1, '4th place'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Quiz X'), 2, '5th place'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Quiz X'), 3, '6th place'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Final'),  1, '1st Quiz X'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Final'),  2, '1st Quiz Y'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 1 Final'),  3, '1st of prelims'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Final'),  1, '1st Quiz X'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Final'),  2, '2nd Quiz X'),
+  ((SELECT id FROM scheduled_quizzes WHERE meet_id=1 AND label='Div 2 Final'),  3, '3rd Quiz X');


### PR DESCRIPTION
## Summary

The schedule view shipped with horizontal seat chips per quiz. Compared against `docs/example-winkler-2026.md` ([§5.1 Time grid](https://github.com/TommyAmberson/qzr-sheet/blob/master/docs/example-winkler-2026.md#51-time-grid)), real meet schedules are denser: each cell is a stacked mini-table with one row per seat, two columns per row (seedRef + team name).

This PR moves the cell rendering toward that datasheet aesthetic without yet wiring up team-name resolution:

- Each quiz cell is now a 3-row mini-table (`<table class="seat-table">`).
- Per row: `seat-ref` (letter for prelims, seedRef for elims) + `seat-team` (placeholder `—` until the resolution layer ships).
- Quiz label is centered, with a hairline separator above the seat rows.
- Time / room headers de-emphasised (smaller, muted) so the quiz cells dominate.
- Switched the table to `table-layout: fixed` with `min-width` per quiz cell — many-room meets overflow horizontally inside the existing `overflow-x: auto` wrapper.

## Out of scope

- **Team-name resolution.** No API yet for `prelim_assignments` / `seed_resolutions`; `seat-team` is a `—` placeholder. Wiring that up is the natural next slice (#39 Roll Teams).
- **Bracket / lane visual grouping** (Winkler tints A vs K vs B vs C). Worth doing once team names land — colour without context is noise.

## Test plan

- [x] `pnpm test:unit` (9 grid tests still green; 690 total)
- [x] `pnpm type-check` clean
- [ ] Browser smoke-test: sign in, open `/TestQuizMeet2026/schedule`. The seeded fixture (5 rooms, 8 slots, 16 quizzes — see `packages/api/seed-schedule.sql` on master if you want to reseed) covers prelims, elims, sparse rounds, event rows, and the division filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)