### PR TITLE
chore: sync dev process with verse-vault (process bits)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,48 +1,97 @@
 name: Claude Code Review
 
+# Pure opt-in. Tokens aren't free, so nothing fires by default — not on PR
+# open, not on push. To get a review:
+#
+#   Comment `@claude review` (or any `@claude ...`) on the PR.
+#
+# That fires the review immediately and adds a `claude-watch` label, after
+# which every push to the PR also fires. Remove the label in the PR UI to
+# unsubscribe.
+
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # `synchronize` only — gated on the `claude-watch` label in the `if:`.
+    # No `opened` / `ready_for_review` because opening a PR shouldn't burn
+    # a review unless explicitly requested.
+    types: [synchronize]
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    # Skip PRs from non-trusted authors (forks, external contributors).
-    # Secrets aren't passed to forked PRs anyway, but this avoids the failed run.
     if: |
-      github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.author_association == 'COLLABORATOR'
+      (
+        (
+          github.event_name == 'pull_request' &&
+          (
+            github.event.pull_request.author_association == 'OWNER' ||
+            github.event.pull_request.author_association == 'MEMBER' ||
+            github.event.pull_request.author_association == 'COLLABORATOR'
+          ) &&
+          contains(github.event.pull_request.labels.*.name, 'claude-watch')
+        ) || (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request != null &&
+          contains(github.event.comment.body, '@claude') &&
+          (
+            github.event.comment.author_association == 'OWNER' ||
+            github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'COLLABORATOR'
+          )
+        )
+      )
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # write so the action can post review comments + check runs
+      # write so we can add the `claude-watch` label on first @claude mention
       pull-requests: write
       issues: write
       id-token: write
 
     steps:
+      - name: Resolve PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # First @claude comment subscribes the PR to per-push reviews by adding
+      # a label. Creating the label first is idempotent (`|| true`).
+      - name: Subscribe PR to per-push reviews
+        if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create claude-watch \
+            --color ededed \
+            --description "Run claude-review on every push (remove label to unsubscribe)" \
+            --repo ${{ github.repository }} || true
+          gh pr edit ${{ steps.pr.outputs.number }} \
+            --add-label claude-watch \
+            --repo ${{ github.repository }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # need full history for git blame / log lookups during review
+          # issue_comment workflows checkout the default branch by default;
+          # point at the PR head so the review sees the actual diff.
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Allow the Claude bot's pushes to trigger reviews (the whole flow depends on it)
           allowed_bots: 'claude'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}'
           # Tools the /code-review:code-review skill needs to inspect the PR + post results.
           # Narrow allowlist: read-only gh subcommands + the comment/review POSTs we want,
           # plus history-only git subcommands. Avoids granting blanket Bash(gh:*) / Bash(git:*).
@@ -52,4 +101,3 @@ jobs:
             pr checks:*),Bash(gh api repos/*/pulls/*:*),Bash(gh api repos/*/issues/*:*),Bash(gh
             issue view:*),Bash(gh issue list:*),Bash(gh label list:*),Bash(git log:*),Bash(git
             blame:*),Bash(git diff:*),Bash(git show:*)"
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,21 @@
 
 Bible Quiz scoresheet app. Tauri 2 + Vue 3 + Vite + TypeScript. Monorepo with pnpm workspaces.
 
-See `README.md` for setup, project structure, and deployment. See `ROADMAP.md` for feature status.
+See `README.md` for setup and deployment. See `ROADMAP.md` for feature status.
+
+## Project layout
+
+```
+apps/
+  scoresheet/   # Vue 3 + Tauri 2 — offline-first scoring tool
+  web/          # Portal — coach roster mgmt, admin dashboard
+packages/
+  shared/       # QuizFile schema, role enums, shared API types
+  ui/           # Workspace-internal Vue components
+  api/          # Hono + D1 + Drizzle (Cloudflare Workers)
+```
+
+See `docs/architecture.md` for full detail on internals, data flow, and design decisions.
 
 ## Commands
 
@@ -35,6 +49,72 @@ These commands are wired up as project commands and should be used proactively a
 
 Dev servers (`pnpm dev`, `pnpm dev:all`, etc.) are long-running and should not be started from here.
 
+## Pre-commit checks
+
+Hooks are wired via `simple-git-hooks` + `lint-staged` and installed by `pnpm install` (see the
+`postinstall` script in `package.json`). The `pre-commit` hook runs `lint-staged` — which formats
+TS/Vue/CSS with Prettier, fixes lint with ESLint, and runs `dprint` on markdown / Dockerfiles. The
+`commit-msg` hook runs `commitlint` against the conventional-commits config (see
+`commitlint.config.js` for the scope-enum and length rules below).
+
+## Git conventions
+
+* Commits must be atomic and single-responsibility — one logical change per commit.
+* Commit as you go: after each logical chunk compiles and tests pass, commit it — don't batch at the
+  end.
+* Do not add `Co-Authored-By` lines.
+* Work on feature branches, not directly on master.
+* Always run pnpm commands from the repo root using root-level aliases (e.g. `pnpm test:unit`, not
+  `pnpm --filter scoresheet test:unit`) — keeps commands predictable for auto-approval.
+
+### Merging PRs
+
+* Always use a merge commit, never squash: `gh pr merge <N> --merge --delete-branch`. The individual
+  branch commits must land on master so `git log` shows the actual progression.
+* Merge-commit subjects follow conventional-commits, same as regular commits — typically
+  `chore: merge <branch-name>`. For local merges, set this via `git merge --no-ff -m "..."`. For
+  PRs, pass `--subject "chore: merge <branch>"` to `gh pr merge` (or edit before confirming) —
+  GitHub's default `Merge pull request #N from …` template doesn't conform to commitlint.
+
+### Rewriting history
+
+* **Feature branches:** rewriting is fine and often encouraged (rebase, amend, reorder, squash
+  fixups, `git push --force-with-lease`) when it produces a cleaner, more readable series _before_
+  merging.
+* **Master:** never rewrite history. Once a commit is on master, it stays.
+* **What to squash:** "changed my mind from X to Y" iterations where the intermediate state never
+  ships. Keep small atomic commits that each did meaningful incremental work — the goal is that
+  `git blame` on any given line lands on a commit whose message explains the change.
+* **`git rebase -i` is unavailable in Claude Code** (no interactive input). For targeted squashes,
+  `git cherry-pick --no-commit <a> <b> <c>` followed by a single `git commit` collapses a contiguous
+  group; for wider restructures, `git reset --soft <base>` then re-stage and re-commit in groups.
+
+### Commit message format ([Conventional Commits](https://www.conventionalcommits.org/))
+
+```
+<type>(<scope>): <short subject in lowercase>
+
+<wrapped body explaining why, not what (the diff shows what)>
+```
+
+Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `style`, `revert`, `perf`, `build`.
+
+Scopes: `scoresheet`, `web`, `api`, `shared`, `ui`, `tauri`, `ci`, `deps`. Omit the scope for
+cross-cutting changes (e.g. `chore: bump version to 0.9.2`).
+
+Subject in lowercase, no trailing period, imperative mood ("add X", not "added X"), and **≤ 50
+characters** including the type/scope prefix. Body wrapped at ~72 cols, focuses on the why. Mark
+breaking changes with `!` after the type/scope (`feat(api)!: …`) — wire format, file format, or
+public-type changes.
+
+## Contract package versioning
+
+`packages/shared` (QuizFile schema, role enums, shared API types) is a contract across consumers —
+the API today, the scoresheet PWA + Tauri client, and the web portal. Same `@qzr/shared` version
+across consumers means same observable wire/state behaviour. Discipline for when this matters lives
+in `docs/release-process.md` once per-package deploys ship (PR pending) — until then, this section
+is a stub.
+
 ## Releasing
 
 1. Update `CHANGELOG.md` with a new version section
@@ -50,19 +130,6 @@ git push origin master --tags
 
 CI deploys on `v*` tags.
 
-## Project Structure
-
-See `docs/architecture.md` for full detail on internals, data flow, and design decisions.
-
-```
-apps/
-  scoresheet/   # Vue 3 + Tauri 2 — offline-first scoring tool
-  web/          # Portal — coach roster mgmt, admin dashboard
-packages/
-  shared/       # QuizFile schema, role enums, shared API types
-  api/          # Hono + D1 + Drizzle (Cloudflare Workers)
-```
-
 ## Key Conventions
 
 * Scoring functions are **pure** — `cells[teamIdx][seatIdx][colIdx]` in, result out. No Vue.
@@ -73,19 +140,6 @@ packages/
   code is obvious should be brief or perhaps even omitted. Prefer comments that explain "why" or
   clarify complex logic. Docstrings should be brief and focused on info that is not obvious from the
   signature and would be useful to consumers. (but don't be too picky about removing comments)
-* Commits should be atomic and self-contained, with conventional commit messages. Commits should not
-  be too large or too small. Use branches for larger features or refactors.
-* Work on feature branches, not directly on master. Merge when ready.
-* Commit history should be clean and readable — it's the primary record of why each change happened,
-  so favor history that's easy to follow and easy to bisect.
-* Use merge commits, not squash. When merging a PR, use `gh pr merge <N> --merge --delete-branch`
-  (not `--squash`) — the individual branch commits should land on master so `git log` shows the
-  actual progression.
-* Rewriting history on feature branches is fine and often encouraged (rebase, amend, reorder, squash
-  fixups, force-push with `--force-with-lease`) when it produces a cleaner, more readable series
-  before merging. Never rewrite history on master — once a commit is on master, it stays.
-* Always run pnpm commands from the repo root using root-level aliases (e.g. `pnpm test:unit`, not
-  `pnpm --filter scoresheet test:unit`) — keeps commands predictable for auto-approval.
 
 ## Gotchas
 

--- a/typos.toml
+++ b/typos.toml
@@ -1,2 +1,11 @@
+[files]
+extend-exclude = [
+    "dist/",
+    "apps/*/dist/",
+    "packages/api/.wrangler/",
+    "apps/scoresheet/src-tauri/target/",
+    "apps/scoresheet/src-tauri/gen/",
+]
+
 [default.extend-identifiers]
 OT = "OT"


### PR DESCRIPTION
## Summary

Pulls three dev-process improvements from verse-vault. Process-only — no app behaviour
changes, no deploy plumbing changes. The bigger per-package-deploys cut-over ships in a
follow-up PR.

### 1. Restructured `CLAUDE.md`

* Project layout at top so the repo map doesn't require a README fetch.
* New **Pre-commit checks** section naming what `lint-staged` and `commitlint` actually
  enforce — was previously buried in `package.json`.
* New **Git conventions** section wrapping three subsections:
  * **Merging PRs** — adds the merge-commit subject convention
    `gh pr merge … --subject "chore: merge <branch>"`. Today PRs land with GitHub's
    default `Merge pull request #N from …` which fails commitlint's 50-char header rule.
  * **Rewriting history** — documents the `git rebase -i` Claude Code limitation and the
    `git cherry-pick --no-commit` / `git reset --soft` workarounds.
  * **Commit message format** — formal conventional-commits spec promoted from a bullet
    in "Key Conventions" into a labelled section with the template + scope-enum + length
    rules in one place. Adds the `!` breaking-change marker note.
* New **Contract package versioning** stub — filled in by the follow-up PR when
  `@qzr/shared` gets the verse-vault-style contract-version discipline.

### 2. Opt-in `claude-code-review.yml`

Today the review fires on every PR open + every push, burning tokens. New pattern (direct
port of verse-vault's):

* Triggers on `pull_request: [synchronize]` **only when** the PR has the `claude-watch`
  label. No fire on `opened` / `reopened` / `ready_for_review`.
* Triggers on `issue_comment` when the comment contains `@claude` from a trusted author.
  First `@claude` comment auto-creates and applies the `claude-watch` label (subscribes
  the PR to per-push reviews). Remove the label to unsubscribe.
* Kept qzr's narrow `claude_args` allowlist (verse-vault dropped it) — defence in depth
  against a malicious `@claude` comment escalating beyond read-only gh subcommands.

### 3. `typos.toml` build-artefact excludes

Wraps `dist/`, `.wrangler/`, `src-tauri/target/`, `src-tauri/gen/` so when typos gets
wired into the pre-commit hook in the follow-up PR, it doesn't drown in generated-code
noise. No behaviour today — typos isn't currently invoked anywhere in qzr.

## Test plan

- [ ] Open a junk PR with no changes against this branch's CI — confirm no Claude review
      fires (was: review on open).
- [ ] Comment `@claude review` on the junk PR — confirm the `claude-watch` label appears
      and the review runs.
- [ ] Push to the junk PR — confirm the review re-fires.
- [ ] Remove the `claude-watch` label, push again — confirm no review fires.
- [ ] Merge this PR with `gh pr merge <N> --merge --delete-branch --subject "chore: merge chore/sync-dev-process"`
      and confirm the merge-commit subject passes commitlint.

_Created by Claude Code_