### PR TITLE
chore: first per-package release (api+web 0.10.0, scoresheet+shared 0.9.2)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -74,17 +74,15 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      # Tag both the consumer (api) and the contract package (shared).
+      # The shared tag is idempotent across the three deploy workflows —
+      # whichever consumer deploy runs first wins, the others no-op.
       - name: Tag release
         working-directory: .
         run: |
-          version=$(jq -r .version packages/api/package.json)
-          tag="api@${version}"
-          if git rev-parse "$tag" >/dev/null 2>&1; then
-            echo "Tag $tag already exists; skipping"
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git tag -a "$tag" -m "Deployed @qzr/api $version to Cloudflare Workers"
-            git push origin "$tag"
-            echo "Tagged $tag at $(git rev-parse HEAD)"
-          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          api_v=$(jq -r .version packages/api/package.json)
+          shared_v=$(jq -r .version packages/shared/package.json)
+          tools/tag-if-missing.sh "api@${api_v}" "Deployed @qzr/api ${api_v} to Cloudflare Workers"
+          tools/tag-if-missing.sh "shared@${shared_v}" "Bundled @qzr/shared ${shared_v} (shipped with api@${api_v})"

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -77,16 +77,14 @@ jobs:
           pnpm dlx wrangler pages deploy apps/web/dist \
             --project-name=versevault-www --branch=master
 
+      # Tag both the consumer (web) and the contract package (shared).
+      # The shared tag is idempotent across the three deploy workflows —
+      # whichever consumer deploy runs first wins, the others no-op.
       - name: Tag release
         run: |
-          version=$(jq -r .version apps/web/package.json)
-          tag="web@${version}"
-          if git rev-parse "$tag" >/dev/null 2>&1; then
-            echo "Tag $tag already exists; skipping"
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git tag -a "$tag" -m "Deployed @qzr/web $version to Cloudflare Pages"
-            git push origin "$tag"
-            echo "Tagged $tag at $(git rev-parse HEAD)"
-          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          web_v=$(jq -r .version apps/web/package.json)
+          shared_v=$(jq -r .version packages/shared/package.json)
+          tools/tag-if-missing.sh "web@${web_v}" "Deployed @qzr/web ${web_v} to Cloudflare Pages"
+          tools/tag-if-missing.sh "shared@${shared_v}" "Bundled @qzr/shared ${shared_v} (shipped with web@${web_v})"

--- a/.github/workflows/release-scoresheet.yml
+++ b/.github/workflows/release-scoresheet.yml
@@ -86,6 +86,16 @@ jobs:
           draft: true
           body: 'See [apps/scoresheet/CHANGELOG.md](https://github.com/${{ github.repository }}/blob/master/apps/scoresheet/CHANGELOG.md) for details.'
 
+      # Tag the contract package alongside the scoresheet release tag.
+      # Idempotent across the three deploy workflows — whichever
+      # consumer deploy runs first wins, the others no-op.
+      - name: Tag shared contract
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          shared_v=$(jq -r .version packages/shared/package.json)
+          tools/tag-if-missing.sh "shared@${shared_v}" "Bundled @qzr/shared ${shared_v} (shipped with scoresheet@${{ steps.ver.outputs.v }})"
+
   pwa:
     needs: [filter, verify-contract]
     if: needs.filter.outputs.bumped == 'true'

--- a/apps/scoresheet/CHANGELOG.md
+++ b/apps/scoresheet/CHANGELOG.md
@@ -14,6 +14,16 @@ portal/API/infra work shipped on that tag.
 
 ## [Unreleased]
 
+## [0.9.2] — 2026-05-21
+
+First per-package scoresheet release. No source changes since 0.9.1 — bumping to establish the
+per-package baseline so future releases ship as `scoresheet@x.y.z` independently of the web portal
+and API.
+
+### Bundled contract
+
+* `@qzr/shared@0.9.2` — unchanged from 0.9.1
+
 ## [0.9.1]
 
 Completes the guest-via-URL feature shipped in 0.9.0 — the API rejected guest reads on the path the

--- a/apps/scoresheet/package.json
+++ b/apps/scoresheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scoresheet",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/scoresheet/src-tauri/tauri.conf.json
+++ b/apps/scoresheet/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "qzr-sheet",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "identifier": "com.quizmeet.sheet",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -14,3 +14,41 @@ The portal shipped as part of the unified monorepo versioning era under tags `v0
 portal. This per-package changelog starts fresh from 0.9.1 as the baseline.
 
 ## [Unreleased]
+
+## [0.10.0] — 2026-05-21
+
+First per-package web release. Covers everything shipped on master since unified tag `v0.9.1`.
+
+### Added
+
+* **Draft-and-save schedule editor** — `ScheduleEditView` now accumulates slot/quiz/seat edits,
+  prelim assignments, and team lateness locally; **Save** commits the whole draft via the bulk
+  `POST /schedule/sync` endpoint; **Discard** reverts to the last-saved snapshot. Mirrors the roster
+  editor pattern in `MeetTeamsView`. Populate, Roll Teams, and Sort by Lateness now run instantly
+  with no network round-trips
+* **Unified Populate pipeline** — 4-layer pipeline (grid cell allocator → rule-book row sort by
+  lateness → flexible per-slot division ownership → disjointness-aware row placement) replaces the
+  ad-hoc populate logic. Drives the Populate button + the per-slot configuration
+* **Per-team Late toggle in Prelim setup** — admins flag late teams; the populate pipeline pushes
+  them to the back of the row order
+* **Roll Teams** — generates letter→teamId prelim assignments locally as part of the draft
+* **Stats break separator** — required slot kind that marks the prelim/elim boundary; Populate uses
+  it to know where prelim quizzes end and elim quizzes begin
+* **Per-division team counts in Prelim setup** — surfaces the new API field
+
+### Changed
+
+* `runPopulate` now mutates draft state only — no per-quiz API round-trips during
+  populate/sort/roll; one bulk POST on Save
+* Schedule grid splits view by day
+* Prelim round-robin shape validation
+* `d{div}-q{n|letter}` quiz label format for stable references across draft state
+
+### Removed
+
+* **Push-late button** — superseded by the per-slot Late toggle + populate pipeline. Bipartite
+  matching and k-room push-late logic gone
+
+### Bundled contract
+
+* `@qzr/shared@0.9.2` — unchanged from 0.9.1

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qzr/web",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -16,3 +16,36 @@ Each release section must include a `### Bundled contract` subsection naming the
 wire/state compatibility signal — see CLAUDE.md "Contract package versioning".
 
 ## [Unreleased]
+
+## [0.10.0] — 2026-05-21
+
+First per-package API release. Covers everything shipped on master since unified tag `v0.9.1`.
+
+### Added
+
+* **Bulk `POST /api/meets/:id/schedule/sync` endpoint** — replaces the per-row schedule CRUD with a
+  single full-state-replace request. Server diffs payload against current state, resolves tempId
+  references between new slots and quizzes, full-replaces seats per editable quiz, full-replaces
+  prelim assignments per division in payload, and per-team lateness diff. Rejects with 409 on
+  attempts to delete or mutate completed quizzes. Mirrors the roster-sync pattern in
+  `POST /api/churches/:churchId/roster/sync`
+* **Team lateness flag** — `PATCH /api/teams/:teamId` accepts `lateness: boolean`; surfaces in the
+  joined `GET /api/meets/:id/teams` rows
+* **Roll Teams binding in prelim assignments** — server-side letter→teamId binding when populating
+  prelim assignments
+* **Per-division team counts** — `GET /api/meets/:id/teams` response includes per-division totals
+  for the prelim setup UI
+
+### Changed (breaking)
+
+* **Removed per-row schedule endpoints** — `POST /meets/:id/slots`,
+  `PATCH/DELETE /meets/:id/slots/:slotId`, `POST /meets/:id/quizzes`,
+  `PATCH/DELETE /meets/:id/quizzes/:quizId`, `PATCH /meets/:id/quizzes/:quizId/seats`, and the
+  standalone `POST /meets/:id/prelim-assignments` are gone. Clients must migrate to the bulk
+  `POST /schedule/sync` endpoint. The web portal landed the migration in `@qzr/web@0.10.0`; any
+  out-of-tree consumer needs the same change
+
+### Bundled contract
+
+* `@qzr/shared@0.9.2` — unchanged from 0.9.1 (no wire/schema changes; bump is the per-package
+  baseline)

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qzr/api",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -21,3 +21,9 @@ When consumers bump their own version, they must update their CHANGELOG's `### B
 subsection to name the current `@qzr/shared` version. CI verifies this in each deploy workflow.
 
 ## [Unreleased]
+
+## [0.9.2] — 2026-05-21
+
+First per-package release after the per-package deploys cutover. No source changes since v0.9.1
+(unified tag) — bumping to establish the per-package baseline so consumer changelogs have a contract
+version to reference under `### Bundled contract`. Future entries here document wire/state changes.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qzr/shared",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "main": "src/index.ts",

--- a/tools/tag-if-missing.sh
+++ b/tools/tag-if-missing.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Tag the current HEAD with the given annotated tag if it doesn't already
+# exist. Designed to be called from multiple concurrent workflow runs
+# against the same tag (e.g. shared@<v> tagged by deploy-api, deploy-web,
+# and release-scoresheet in parallel) — fetch tags first to detect
+# remote-already-exists, and tolerate a lost race on push.
+#
+# Usage: tools/tag-if-missing.sh <tag> <subject>
+#
+# Requires: origin remote configured, contents:write perms, and either
+# git config user.{name,email} pre-set or this script invoked with them
+# available in the environment.
+
+set -euo pipefail
+
+tag=$1
+subject=$2
+
+git fetch origin --tags --quiet || true
+
+if git rev-parse --quiet --verify "refs/tags/${tag}" >/dev/null; then
+	echo "Tag ${tag} already exists; skipping"
+	exit 0
+fi
+
+git tag -a "${tag}" -m "${subject}"
+
+if git push origin "${tag}"; then
+	echo "Tagged ${tag} at $(git rev-parse HEAD)"
+else
+	echo "Push of ${tag} failed — likely lost the race to another workflow"
+fi


### PR DESCRIPTION
## Summary

First release under the per-package deploy model that landed in #66. Four bump commits — one
per package — each with its own CHANGELOG entry and `### Bundled contract` reference.

| Package | Bump | Driver |
|---|---|---|
| `@qzr/shared` | 0.9.1 → 0.9.2 | No src changes. Baseline for the contract version that consumers reference. |
| `@qzr/api` | 0.9.1 → 0.10.0 | Bulk `POST /schedule/sync` + lateness + per-division team counts + breaking removal of per-row schedule endpoints. |
| `@qzr/web` | 0.9.1 → 0.10.0 | Draft-and-save schedule editor + unified populate pipeline + Roll Teams + per-team Late toggle + stats break separator. |
| scoresheet | 0.9.1 → 0.9.2 | No src changes. Baseline so future scoresheet releases tag independently. |

## What fires when this merges

The merge commit modifies three watched `package.json` files (api, web, scoresheet) plus
shared (not watched), triggering three workflows in parallel against the same SHA:

* `deploy-api.yml` — verify contract (`@qzr/api@0.10.0` CHANGELOG references
  `@qzr/shared@0.9.2`) → D1 migrations → `wrangler deploy` → tag `api@0.10.0`.
* `deploy-web.yml` — verify contract → `pnpm build:all` → `wrangler pages deploy
  apps/web/dist` → tag `web@0.10.0`.
* `release-scoresheet.yml` — verify contract → `create-release` (pre-creates the
  `scoresheet@0.9.2` draft) → fan out to `pwa` (Pages deploy) + `android` (signed APK upload)
  + `desktop` matrix (linux/windows/macos Tauri builds) → all uploads land in the existing
  draft release.

**Known concurrency event:** both `deploy-web.yml` and `release-scoresheet.yml`'s `pwa` job
deploy to the same Cloudflare Pages project (`versevault-www`) in parallel. For this bump
they produce byte-identical scoresheet PWA contents (scoresheet src didn't change), so the
race is harmless. Documented in the per-package-deploys plan as a low-impact follow-up.

**`shared@0.9.2` won't be tagged by CI** — no workflow watches `packages/shared/package.json`.
I'll tag it manually after merge: `git tag shared@0.9.2 <merge-sha> && git push origin
shared@0.9.2`. (verse-vault's pattern tags contract crates as part of consumer deploys; we
could add that to `deploy-api.yml` in a follow-up.)

## Test plan

- [ ] CI passes (`pnpm type-check`, `pnpm lint`, `pnpm test:unit`) — already locally green.
- [ ] Branch protection's "up to date" check passes (no commits to master since branch).
- [ ] After merge, three workflows fire and finish green:
  - [ ] `api@0.10.0` tag pushed; Worker deployed; D1 migrations applied (none pending — confirmed).
  - [ ] `web@0.10.0` tag pushed; Cloudflare Pages serves new portal.
  - [ ] `scoresheet@0.9.2` draft release created with linux/windows/macos installers + Android APK attached.
- [ ] Manually `git tag shared@0.9.2 <sha> && git push origin shared@0.9.2`.
- [ ] Spot-check `www.versevault.ca/scoresheet/` still serves the scoresheet PWA correctly.

_Created by Claude Code_