### PR TITLE
chore(deps): drop Node 20, require Node >=22.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript-eslint": "^8.0.0"
   },
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": ">=22.12.0"
   },
   "packageManager": "pnpm@10.7.0+sha512.6b865ad4b62a1d9842b61d674a393903b871d9244954f652b8842c2b553c72176b278f64c463e52d40fff8aba385c235c8c9ecf5cc7de4fd78b8bb6d49633ab6"
 }


### PR DESCRIPTION
## Summary

Node 20 LTS ended April 2026. Tighten the root `engines.node` field from
`^20.19.0 || >=22.12.0` to `>=22.12.0` so CI (which uses `node-version-file: package.json`)
installs Node 22.x instead of 20.x.

No code changes needed — all dependencies already support Node 22+. Local `pnpm test:unit`
passes on Node 22.14.0; all 212 tests green.

## Out of scope

The other Node deprecation warning visible on recent CI runs (`actions/checkout@v4` etc.
running on Node 20 inside the GitHub runner) is the action's bundled runtime, not ours.
That's fixed by action authors releasing new majors (`actions/checkout@v5` etc.) and waits
on them. Deadline is June 2, 2026 — plenty of runway.

## Test plan

- [ ] CI passes (qzr-sheet `check` job installs Node 22.x and runs through clean).
- [ ] Confirm `pnpm test:unit`, `pnpm lint`, `pnpm type-check` all stay green on Node 22.

_Created by Claude Code_