### PR TITLE
docs(ci): note scoresheet release auto-publish

### DIFF
--- a/.github/workflows/release-scoresheet.yml
+++ b/.github/workflows/release-scoresheet.yml
@@ -6,19 +6,25 @@ name: Release scoresheet
 #
 # A scoresheet release ships through two channels:
 #   1. Native desktop (Tauri matrix: linux/windows/macos) + Android APK
-#      → drafts a GitHub release
+#      → GitHub release with installers attached
 #   2. PWA bundle inside the web Pages site (apps/web/dist/scoresheet/)
 #      → redeploys Cloudflare Pages so the live scoring tool at
 #        www.versevault.ca/scoresheet/ matches the desktop version
 #
 # A `create-release` job runs serially before the artefact jobs to
-# pre-create the draft GitHub release + `scoresheet@x.y.z` tag.
+# pre-create the GitHub release + `scoresheet@x.y.z` tag as a draft.
 # Without it, the desktop matrix (3 jobs) and android (1 job) would
 # all race to be the first to create the release via tauri-action /
 # softprops/action-gh-release, producing duplicate drafts or 422s.
-# Once the draft exists, the desktop matrix uploads by `releaseId`
+# Once the release exists, the desktop matrix uploads by `releaseId`
 # and android uploads by `tag_name` — both idempotent against the
 # existing release.
+#
+# Auto-publish: tauri-action flips the release from draft to
+# published at the end of a successful desktop matrix run. The
+# release goes live as soon as all three platforms upload cleanly.
+# No manual smoke-test gate — fix any installer regression by
+# bumping a patch and re-cutting the release.
 on:
   push:
     branches: [master]
@@ -77,7 +83,10 @@ jobs:
       - id: ver
         run: echo "v=$(jq -r .version apps/scoresheet/package.json)" >> "$GITHUB_OUTPUT"
 
-      - name: Create draft release
+      # Pre-create as draft so artefact jobs upload into a known
+      # release ID; tauri-action publishes it at the end of a
+      # successful desktop matrix.
+      - name: Create release
         id: create
         uses: softprops/action-gh-release@v2
         with:
@@ -170,7 +179,7 @@ jobs:
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: pnpm android:build
 
-      # Upload into the draft release created by `create-release`. No
+      # Upload into the release created by `create-release`. No
       # `name` / `draft` / `body` here — those come from the existing
       # release so they aren't fought over.
       - name: Upload APK to release
@@ -219,9 +228,11 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Upload into the draft release created by `create-release` via
+      # Upload into the release created by `create-release` via
       # releaseId — sidesteps tauri-action's "create if missing" path
       # so the three matrix legs don't race on release creation.
+      # tauri-action publishes the release (draft → live) at the end
+      # of a successful matrix run.
       - name: Build and upload
         uses: tauri-apps/tauri-action@v0
         env:

--- a/apps/scoresheet/CHANGELOG.md
+++ b/apps/scoresheet/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to the scoresheet (Tauri desktop, Android APK, browser PWA) 
 following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Released via `.github/workflows/release-scoresheet.yml` (Tauri matrix + Android APK draft) plus
-`.github/workflows/deploy-web.yml` (PWA bundled into the web Pages deploy) on every `version` bump
-in `apps/scoresheet/package.json` that lands on `master`.
+Released via `.github/workflows/release-scoresheet.yml` (Tauri matrix linux/windows/macos + signed
+Android APK, auto-published as a GitHub release on a green matrix) plus the same workflow's `pwa`
+job (PWA bundled into the web Pages deploy) on every `version` bump in
+`apps/scoresheet/package.json` that lands on `master`.
 
 Entries prior to 0.9.2 are from the era of unified monorepo versioning — every release tag
 (`v0.x.y`) bumped scoresheet + portal + API in lockstep, so the same version section also documents


### PR DESCRIPTION
## Summary

Pure documentation update — the workflow's actual behaviour is unchanged.

When PR #66's race-fix landed, the desktop matrix switched from `tagName` to `releaseId` and
dropped `releaseDraft: true`. The original `release.yml` used `releaseDraft: true` so every
scoresheet release went to drafts, requiring manual click-to-publish. With the new shape,
`tauri-action` flips the release from draft to published at the end of a successful desktop
matrix run.

This was an unintentional behavioural change that I missed at the time — confirmed live on
the `scoresheet@0.9.2` cut, where the release shipped published instead of drafted. The
user accepted the new behaviour ("auto-publish on successful matrix") as the policy going
forward.

Update the workflow header comment + the scoresheet CHANGELOG.md header to describe
auto-publish as the documented policy. No YAML behaviour change; no rollback of
scoresheet@0.9.2.

## Test plan

- [ ] CI passes (text-only docs change; nothing functional to break).
- [ ] On the next scoresheet release, confirm the release ships straight to "Latest" — no
      draft step.

_Created by Claude Code_