### PR TITLE
feat: load scoresheet from scheduled quiz (#6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,23 @@ TS/Vue/CSS with Prettier, fixes lint with ESLint, and runs `dprint` on markdown 
 * **`git rebase -i` is unavailable in Claude Code** (no interactive input). For targeted squashes,
   `git cherry-pick --no-commit <a> <b> <c>` followed by a single `git commit` collapses a contiguous
   group; for wider restructures, `git reset --soft <base>` then re-stage and re-commit in groups.
+* **Fixup + autosquash for review fixes.** When a later commit corrects something an earlier commit
+  on the same branch got wrong (typo, missed branch, /simplify finding, code-review reply), consider
+  `git commit --fixup=<orig-sha>` instead of a fresh `fix(...): ...` commit. That produces a commit
+  named `fixup! <orig-subject>` paired with the target. Before merging, collapse with
+  `git -c sequence.editor=: rebase -i --autosquash master` — `-i` is required (autosquash only
+  activates in interactive mode) and the no-op sequence editor accepts the auto-prepared todo list.
+  Fixup-marked commits discard their own message and keep the original's verbatim, so no editor
+  prompts fire. End state: `git blame` lands on the original commit (whose message explains the
+  change), not a follow-up "fix" commit that re-states the same scope. Works best when the target is
+  recent and no intermediate commits touch the same lines — long-lived branches with interleaved
+  refactors will produce conflicts on autosquash, in which case keep the fresh `fix(...)` commit.
+  Before squashing, check whether the fixup's content changes what the target commit's subject
+  claims: a typo or off-by-one fix slots in invisibly, but a fixup that meaningfully expands scope
+  or reverses a stated intent leaves the original subject misleading. In that case, use
+  `git commit --fixup=amend:<orig-sha>` instead — autosquash will prompt for a new subject when
+  collapsing — or just `git commit --amend` directly if the target is HEAD. Otherwise the squashed
+  commit will lie about what it does.
 
 ### Commit message format ([Conventional Commits](https://www.conventionalcommits.org/))
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,18 @@ git push origin master
 CI fires the matching `.github/workflows/deploy-<pkg>.yml` (or `release-scoresheet.yml`), runs the
 contract check, deploys, and tags `<pkg>@<semver>` on success. **Don't tag locally** — CI does it.
 
+## Scope discipline
+
+When working on a feature and you notice something nearby that's bad, awkward, or should be
+changed/fixed — **stop and check with the user before acting**. Offer options:
+
+* address it now as a separate change (commit it before continuing the feature), or
+* leave it and document it (TODO comment, issue, or ROADMAP entry) and continue.
+
+Don't silently fix it as part of the current feature — it muddies the diff, and the user may have
+context (deliberate choice, planned rework, scope concerns) you don't. And don't just ignore it —
+surface it so the user can decide.
+
 ## Key Conventions
 
 * Scoring functions are **pure** — `cells[teamIdx][seatIdx][colIdx]` in, result out. No Vue.

--- a/apps/scoresheet/src/__tests__/quizMeta.spec.ts
+++ b/apps/scoresheet/src/__tests__/quizMeta.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { quizNumberFromScheduledQuiz, consolationFromScheduledQuiz } from '../quizMeta'
+
+describe('quizNumberFromScheduledQuiz', () => {
+  it('returns bracketLabel for elim quizzes', () => {
+    expect(
+      quizNumberFromScheduledQuiz({
+        phase: 'elim',
+        lane: 'main',
+        label: 'D1-QA',
+        bracketLabel: 'A',
+      }),
+    ).toBe('A')
+  })
+
+  it('strips the D{div}-Q prefix for prelim labels', () => {
+    expect(
+      quizNumberFromScheduledQuiz({
+        phase: 'prelim',
+        lane: null,
+        label: 'D1-Q1',
+        bracketLabel: null,
+      }),
+    ).toBe('1')
+    expect(
+      quizNumberFromScheduledQuiz({
+        phase: 'prelim',
+        lane: null,
+        label: 'D2-Q14',
+        bracketLabel: null,
+      }),
+    ).toBe('14')
+  })
+
+  it('falls back to the raw label when the format is unrecognised', () => {
+    expect(
+      quizNumberFromScheduledQuiz({
+        phase: 'prelim',
+        lane: null,
+        label: 'Final Round Showcase',
+        bracketLabel: null,
+      }),
+    ).toBe('Final Round Showcase')
+  })
+})
+
+describe('consolationFromScheduledQuiz', () => {
+  it('returns true only for consolation lanes', () => {
+    expect(consolationFromScheduledQuiz({ lane: 'consolation' })).toBe(true)
+    expect(consolationFromScheduledQuiz({ lane: 'main' })).toBe(false)
+    expect(consolationFromScheduledQuiz({ lane: 'intermediate' })).toBe(false)
+    expect(consolationFromScheduledQuiz({ lane: null })).toBe(false)
+  })
+})

--- a/apps/scoresheet/src/api.ts
+++ b/apps/scoresheet/src/api.ts
@@ -58,6 +58,45 @@ export function getTeamQuizzers(teamId: number): Promise<{ quizzers: MeetTeamQui
   return request(`/api/teams/${teamId}/quizzers`)
 }
 
+export interface ScheduledQuizSummary {
+  id: number
+  meetId: number
+  slotId: number
+  roomId: number
+  division: string
+  phase: 'prelim' | 'elim'
+  lane: 'main' | 'consolation' | 'intermediate' | null
+  label: string
+  bracketLabel: string | null
+  slotStartAt: string
+  roomName: string
+}
+
+export interface ScheduledQuizSeat {
+  seatNumber: number
+  letter: string | null
+  seedRef: string | null
+  team: {
+    id: number
+    churchId: number
+    churchName: string
+    churchShortName: string
+    division: string
+    number: number
+    consolation: boolean
+  } | null
+  quizzers: MeetTeamQuizzer[]
+}
+
+export interface ScheduledQuizDetails {
+  quiz: ScheduledQuizSummary
+  seats: ScheduledQuizSeat[]
+}
+
+export function getScheduledQuiz(meetId: number, quizId: number): Promise<ScheduledQuizDetails> {
+  return request(`/api/meets/${meetId}/quizzes/${quizId}/teams`)
+}
+
 export function joinMeet(
   code: string,
 ): Promise<{ meet: { id: number; name: string }; role: string }> {

--- a/apps/scoresheet/src/api.ts
+++ b/apps/scoresheet/src/api.ts
@@ -61,6 +61,7 @@ export function getTeamQuizzers(teamId: number): Promise<{ quizzers: MeetTeamQui
 export interface ScheduledQuizSummary {
   id: number
   meetId: number
+  meetName: string
   slotId: number
   roomId: number
   division: string
@@ -76,15 +77,7 @@ export interface ScheduledQuizSeat {
   seatNumber: number
   letter: string | null
   seedRef: string | null
-  team: {
-    id: number
-    churchId: number
-    churchName: string
-    churchShortName: string
-    division: string
-    number: number
-    consolation: boolean
-  } | null
+  team: MeetTeam | null
   quizzers: MeetTeamQuizzer[]
 }
 

--- a/apps/scoresheet/src/api.ts
+++ b/apps/scoresheet/src/api.ts
@@ -97,6 +97,75 @@ export function getScheduledQuiz(meetId: number, quizId: number): Promise<Schedu
   return request(`/api/meets/${meetId}/quizzes/${quizId}/teams`)
 }
 
+// ---- Picker bulk reads (used by SchedulePickerDialog) ----
+
+export interface MeetRoomSummary {
+  id: number
+  name: string
+  sortOrder: number
+  hasCode: boolean
+}
+
+export interface MeetSlotSummary {
+  id: number
+  meetId: number
+  startAt: string
+  durationMinutes: number
+  kind: 'quiz' | 'event'
+  eventLabel: string | null
+  sortOrder: number
+}
+
+export interface ScheduledQuizSummaryRow {
+  id: number
+  meetId: number
+  slotId: number
+  roomId: number
+  division: string
+  phase: 'prelim' | 'elim'
+  lane: 'main' | 'consolation' | 'intermediate' | null
+  label: string
+  bracketLabel: string | null
+  publishedAt: string | null
+  completedAt: string | null
+  seats: Array<{
+    id: number
+    quizId: number
+    seatNumber: number
+    letter: string | null
+    seedRef: string | null
+  }>
+}
+
+export interface PrelimAssignmentRow {
+  id: number
+  meetId: number
+  division: string
+  letter: string
+  teamId: number
+  assignedAt: string | number
+}
+
+export function listMeetRooms(meetId: number): Promise<{ rooms: MeetRoomSummary[] }> {
+  return request(`/api/meets/${meetId}/rooms`)
+}
+
+export function listMeetSlots(meetId: number): Promise<{ slots: MeetSlotSummary[] }> {
+  return request(`/api/meets/${meetId}/slots`)
+}
+
+export function listScheduledQuizzes(
+  meetId: number,
+): Promise<{ quizzes: ScheduledQuizSummaryRow[] }> {
+  return request(`/api/meets/${meetId}/quizzes`)
+}
+
+export function listPrelimAssignments(
+  meetId: number,
+): Promise<{ assignments: PrelimAssignmentRow[] }> {
+  return request(`/api/meets/${meetId}/prelim-assignments`)
+}
+
 export function joinMeet(
   code: string,
 ): Promise<{ meet: { id: number; name: string }; role: string }> {

--- a/apps/scoresheet/src/components/MeetPickerDialog.vue
+++ b/apps/scoresheet/src/components/MeetPickerDialog.vue
@@ -1,69 +1,33 @@
 <script setup lang="ts">
-import { ApiError } from '@qzr/shared'
 import { ref } from 'vue'
 
-import { getMyMeets, joinMeet, type MeetSummary } from '../api'
+import { type MeetSummary } from '../api'
+import { useMeetList } from '../composables/useMeetList'
 import { useMeetSession } from '../composables/useMeetSession'
-import { useGuestSession, initGuestSession, joinByCode } from '../composables/useGuestSession'
 
 const emit = defineEmits<{ loaded: [] }>()
 
 const { loadMeet } = useMeetSession()
-const guest = useGuestSession()
+const {
+  meets,
+  loading,
+  error,
+  joinCode,
+  joinError,
+  joining,
+  init,
+  handleJoinCode,
+  setActiveGuest,
+} = useMeetList()
 
 const dialogRef = ref<HTMLDialogElement | null>(null)
-const meets = ref<MeetSummary[]>([])
-const loading = ref(false)
-const error = ref('')
 const submitting = ref(false)
-const joinCode = ref('')
-const joinError = ref('')
-const joining = ref(false)
-/** Tracks whether the last getMyMeets() saw a signed-in cookie session. Drives
- * the "Have a code?" form: signed-in users add a real membership via /api/join,
- * anonymous viewers add a guest token via /api/join/guest. */
-const signedIn = ref(false)
-
-async function fetchMeets() {
-  loading.value = true
-  error.value = ''
-  const seen = new Set<number>()
-  const list: MeetSummary[] = []
-  for (const j of guest.joinedMeets.value) {
-    list.push({ meetId: j.meetId, meetName: j.meetName, role: j.role })
-    seen.add(j.meetId)
-  }
-  try {
-    const res = await getMyMeets()
-    signedIn.value = true
-    for (const m of res.memberships) {
-      if (seen.has(m.meetId)) continue
-      seen.add(m.meetId)
-      list.push(m)
-    }
-  } catch (e) {
-    // 401 just means anonymous guest — suppress the error if we already have
-    // joined meets to show. Other errors still surface.
-    if (e instanceof ApiError && e.status === 401) {
-      signedIn.value = false
-      if (list.length === 0) error.value = 'Not signed in.'
-    } else {
-      error.value = (e as Error).message
-    }
-  } finally {
-    meets.value = list
-    loading.value = false
-  }
-}
 
 async function selectMeet(meet: MeetSummary) {
   submitting.value = true
   error.value = ''
   try {
-    // If this meet is one the user joined as a guest, switch the active
-    // session so loadMeet's request uses that meet's JWT. setActive is a
-    // no-op for non-guest rows (signed-in memberships).
-    guest.setActive(meet.meetId)
+    setActiveGuest(meet.meetId)
     await loadMeet(meet.meetId, meet.meetName)
     dialogRef.value?.close()
     emit('loaded')
@@ -74,38 +38,13 @@ async function selectMeet(meet: MeetSummary) {
   }
 }
 
-async function handleJoinCode() {
-  const code = joinCode.value.trim()
-  if (!code) return
-  joining.value = true
-  joinError.value = ''
-  try {
-    if (signedIn.value) {
-      await joinMeet(code)
-    } else {
-      const data = await joinByCode(code)
-      if (!data) throw new Error('Invalid code.')
-    }
-    joinCode.value = ''
-    await fetchMeets()
-  } catch (e) {
-    joinError.value = (e as Error).message
-  } finally {
-    joining.value = false
-  }
-}
-
 function close() {
   dialogRef.value?.close()
 }
 
 async function open() {
   dialogRef.value?.showModal()
-  // Wait for the URL-shared guest session before populating the list so the
-  // shared meet shows up as a clickable row even for anonymous viewers.
-  loading.value = true
-  await initGuestSession()
-  await fetchMeets()
+  await init()
 }
 
 defineExpose({ open })

--- a/apps/scoresheet/src/components/SchedulePickerDialog.vue
+++ b/apps/scoresheet/src/components/SchedulePickerDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, shallowRef } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 
 import { ScheduleGrid } from '@qzr/ui'
 
@@ -8,6 +8,7 @@ import {
   type MeetSlotSummary,
   type MeetSummary,
   type PrelimAssignmentRow,
+  type ScheduledQuizDetails,
   type ScheduledQuizSummaryRow,
   listMeetRooms,
   listMeetSlots,
@@ -17,9 +18,8 @@ import {
 import { initGuestSession } from '../composables/useGuestSession'
 import { useMeetList } from '../composables/useMeetList'
 import { useMeetSession } from '../composables/useMeetSession'
-import { QUIZZERS_PER_TEAM } from '../types/scoresheet'
 
-const emit = defineEmits<{ loaded: [{ quizId: number }] }>()
+const emit = defineEmits<{ loaded: [ScheduledQuizDetails] }>()
 
 const meetSession = useMeetSession()
 const {
@@ -39,7 +39,7 @@ type Step = 'meet' | 'quiz'
 const dialogRef = ref<HTMLDialogElement | null>(null)
 const step = ref<Step>('meet')
 const activeMeetId = ref<number | null>(null)
-const activeMeetName = ref<string>('')
+const headerMeetName = computed(() => meetSession.meetName.value ?? '')
 const submitting = ref(false)
 
 const quizzes = shallowRef<ScheduledQuizSummaryRow[]>([])
@@ -72,15 +72,14 @@ async function loadQuizzesForMeet(meetId: number) {
 
 async function selectMeet(meet: MeetSummary) {
   submitting.value = true
-  meetsError.value = ''
+  quizError.value = ''
   try {
     setActiveGuest(meet.meetId)
     activeMeetId.value = meet.meetId
-    activeMeetName.value = meet.meetName
     step.value = 'quiz'
     await loadQuizzesForMeet(meet.meetId)
   } catch (e) {
-    meetsError.value = (e as Error).message
+    quizError.value = (e as Error).message
   } finally {
     submitting.value = false
   }
@@ -91,14 +90,9 @@ async function pickQuiz(quizId: number) {
   submitting.value = true
   quizError.value = ''
   try {
-    await meetSession.loadFromQuiz(
-      activeMeetId.value,
-      quizId,
-      activeMeetName.value,
-      [0, 1, 2].map(() => Array<string>(QUIZZERS_PER_TEAM).fill('')),
-    )
+    const details = await meetSession.loadFromQuiz(activeMeetId.value, quizId)
     dialogRef.value?.close()
-    emit('loaded', { quizId })
+    emit('loaded', details)
   } catch (e) {
     quizError.value = (e as Error).message
   } finally {
@@ -109,7 +103,6 @@ async function pickQuiz(quizId: number) {
 function backToMeetStep() {
   step.value = 'meet'
   activeMeetId.value = null
-  activeMeetName.value = ''
   quizzes.value = []
   rooms.value = []
   slots.value = []
@@ -127,16 +120,11 @@ async function open() {
   // calls before the guest JWT is attached (initMeetList() awaits it
   // for the meet-picker step). Cached promise — no extra round-trip.
   await initGuestSession()
-  // If a meet is already loaded, jump straight to the quiz step for it.
-  if (meetSession.isActive.value) {
-    const session = meetSession.snapshotSession()
-    if (session) {
-      activeMeetId.value = session.meetId
-      activeMeetName.value = session.meetName
-      step.value = 'quiz'
-      await loadQuizzesForMeet(session.meetId)
-      return
-    }
+  if (meetSession.isActive.value && meetSession.meetId.value !== null) {
+    activeMeetId.value = meetSession.meetId.value
+    step.value = 'quiz'
+    await loadQuizzesForMeet(meetSession.meetId.value)
+    return
   }
   step.value = 'meet'
   await initMeetList()
@@ -150,12 +138,11 @@ defineExpose({ open })
     <div class="schedule-picker-inner">
       <div class="schedule-picker-header">
         <span class="schedule-picker-title">
-          {{ step === 'meet' ? 'Load from schedule' : `Load from schedule — ${activeMeetName}` }}
+          {{ step === 'meet' ? 'Load from schedule' : `Load from schedule — ${headerMeetName}` }}
         </span>
         <button class="schedule-picker-close" @click="close">×</button>
       </div>
 
-      <!-- Step 1: pick a meet (skipped when a meet is already active) -->
       <template v-if="step === 'meet'">
         <p v-if="meetsLoading" class="schedule-picker-state">Loading…</p>
         <p v-else-if="meetsError" class="schedule-picker-state schedule-picker-state--error">
@@ -191,7 +178,6 @@ defineExpose({ open })
         </form>
       </template>
 
-      <!-- Step 2: pick a scheduled quiz -->
       <template v-else>
         <p v-if="quizLoading" class="schedule-picker-state">Loading schedule…</p>
         <p v-else-if="quizError" class="schedule-picker-state schedule-picker-state--error">

--- a/apps/scoresheet/src/components/SchedulePickerDialog.vue
+++ b/apps/scoresheet/src/components/SchedulePickerDialog.vue
@@ -9,7 +9,6 @@ import {
   type MeetSummary,
   type MeetTeam,
   type PrelimAssignmentRow,
-  type ScheduledQuizDetails,
   type ScheduledQuizSummaryRow,
   getMeetTeams,
   listMeetRooms,
@@ -21,7 +20,12 @@ import { initGuestSession } from '../composables/useGuestSession'
 import { useMeetList } from '../composables/useMeetList'
 import { useMeetSession } from '../composables/useMeetSession'
 
-const emit = defineEmits<{ loaded: [ScheduledQuizDetails] }>()
+const props = defineProps<{
+  /** Parent-controlled commit: returns true when the quiz has been
+   *  loaded and the dialog should close. Returning false (e.g. user
+   *  cancelled an overwrite confirm) keeps the dialog open. */
+  onPick: (meetId: number, quizId: number) => Promise<boolean>
+}>()
 
 const meetSession = useMeetSession()
 const {
@@ -95,9 +99,8 @@ async function pickQuiz(quizId: number) {
   submitting.value = true
   quizError.value = ''
   try {
-    const details = await meetSession.loadFromQuiz(activeMeetId.value, quizId)
-    dialogRef.value?.close()
-    emit('loaded', details)
+    const ok = await props.onPick(activeMeetId.value, quizId)
+    if (ok) dialogRef.value?.close()
   } catch (e) {
     quizError.value = (e as Error).message
   } finally {

--- a/apps/scoresheet/src/components/SchedulePickerDialog.vue
+++ b/apps/scoresheet/src/components/SchedulePickerDialog.vue
@@ -1,0 +1,468 @@
+<script setup lang="ts">
+import { ref, shallowRef } from 'vue'
+
+import { ScheduleGrid } from '@qzr/ui'
+
+import {
+  type MeetRoomSummary,
+  type MeetSlotSummary,
+  type MeetSummary,
+  type PrelimAssignmentRow,
+  type ScheduledQuizSummaryRow,
+  listMeetRooms,
+  listMeetSlots,
+  listPrelimAssignments,
+  listScheduledQuizzes,
+} from '../api'
+import { initGuestSession } from '../composables/useGuestSession'
+import { useMeetList } from '../composables/useMeetList'
+import { useMeetSession } from '../composables/useMeetSession'
+import { QUIZZERS_PER_TEAM } from '../types/scoresheet'
+
+const emit = defineEmits<{ loaded: [{ quizId: number }] }>()
+
+const meetSession = useMeetSession()
+const {
+  meets,
+  loading: meetsLoading,
+  error: meetsError,
+  joinCode,
+  joinError,
+  joining,
+  init: initMeetList,
+  handleJoinCode,
+  setActiveGuest,
+} = useMeetList()
+
+type Step = 'meet' | 'quiz'
+
+const dialogRef = ref<HTMLDialogElement | null>(null)
+const step = ref<Step>('meet')
+const activeMeetId = ref<number | null>(null)
+const activeMeetName = ref<string>('')
+const submitting = ref(false)
+
+const quizzes = shallowRef<ScheduledQuizSummaryRow[]>([])
+const rooms = shallowRef<MeetRoomSummary[]>([])
+const slots = shallowRef<MeetSlotSummary[]>([])
+const prelimAssignments = shallowRef<PrelimAssignmentRow[]>([])
+const quizLoading = ref(false)
+const quizError = ref('')
+
+async function loadQuizzesForMeet(meetId: number) {
+  quizLoading.value = true
+  quizError.value = ''
+  try {
+    const [q, r, s, p] = await Promise.all([
+      listScheduledQuizzes(meetId),
+      listMeetRooms(meetId),
+      listMeetSlots(meetId),
+      listPrelimAssignments(meetId),
+    ])
+    quizzes.value = q.quizzes
+    rooms.value = r.rooms
+    slots.value = s.slots
+    prelimAssignments.value = p.assignments
+  } catch (e) {
+    quizError.value = (e as Error).message
+  } finally {
+    quizLoading.value = false
+  }
+}
+
+async function selectMeet(meet: MeetSummary) {
+  submitting.value = true
+  meetsError.value = ''
+  try {
+    setActiveGuest(meet.meetId)
+    activeMeetId.value = meet.meetId
+    activeMeetName.value = meet.meetName
+    step.value = 'quiz'
+    await loadQuizzesForMeet(meet.meetId)
+  } catch (e) {
+    meetsError.value = (e as Error).message
+  } finally {
+    submitting.value = false
+  }
+}
+
+async function pickQuiz(quizId: number) {
+  if (activeMeetId.value === null) return
+  submitting.value = true
+  quizError.value = ''
+  try {
+    await meetSession.loadFromQuiz(
+      activeMeetId.value,
+      quizId,
+      activeMeetName.value,
+      [0, 1, 2].map(() => Array<string>(QUIZZERS_PER_TEAM).fill('')),
+    )
+    dialogRef.value?.close()
+    emit('loaded', { quizId })
+  } catch (e) {
+    quizError.value = (e as Error).message
+  } finally {
+    submitting.value = false
+  }
+}
+
+function backToMeetStep() {
+  step.value = 'meet'
+  activeMeetId.value = null
+  activeMeetName.value = ''
+  quizzes.value = []
+  rooms.value = []
+  slots.value = []
+  prelimAssignments.value = []
+}
+
+function close() {
+  dialogRef.value?.close()
+}
+
+async function open() {
+  dialogRef.value?.showModal()
+  // initGuestSession() runs fire-and-forget at app start; await it here
+  // so the early-return path's loadQuizzesForMeet doesn't fire its API
+  // calls before the guest JWT is attached (initMeetList() awaits it
+  // for the meet-picker step). Cached promise — no extra round-trip.
+  await initGuestSession()
+  // If a meet is already loaded, jump straight to the quiz step for it.
+  if (meetSession.isActive.value) {
+    const session = meetSession.snapshotSession()
+    if (session) {
+      activeMeetId.value = session.meetId
+      activeMeetName.value = session.meetName
+      step.value = 'quiz'
+      await loadQuizzesForMeet(session.meetId)
+      return
+    }
+  }
+  step.value = 'meet'
+  await initMeetList()
+}
+
+defineExpose({ open })
+</script>
+
+<template>
+  <dialog ref="dialogRef" class="schedule-picker-dialog" @click.self="close">
+    <div class="schedule-picker-inner">
+      <div class="schedule-picker-header">
+        <span class="schedule-picker-title">
+          {{ step === 'meet' ? 'Load from schedule' : `Load from schedule — ${activeMeetName}` }}
+        </span>
+        <button class="schedule-picker-close" @click="close">×</button>
+      </div>
+
+      <!-- Step 1: pick a meet (skipped when a meet is already active) -->
+      <template v-if="step === 'meet'">
+        <p v-if="meetsLoading" class="schedule-picker-state">Loading…</p>
+        <p v-else-if="meetsError" class="schedule-picker-state schedule-picker-state--error">
+          {{ meetsError }}
+        </p>
+        <p v-else-if="meets.length === 0" class="schedule-picker-state">No meets found.</p>
+
+        <ul v-else class="meet-list">
+          <li v-for="meet in meets" :key="meet.meetId">
+            <button class="meet-row" :disabled="submitting" @click="selectMeet(meet)">
+              <span class="meet-row-name">{{ meet.meetName }}</span>
+              <span class="meet-row-role">{{ meet.role }}</span>
+            </button>
+          </li>
+        </ul>
+
+        <hr class="schedule-picker-divider" />
+
+        <form class="join-form" @submit.prevent="handleJoinCode">
+          <p class="join-label">Have a code?</p>
+          <div class="join-row">
+            <input
+              v-model="joinCode"
+              class="join-input"
+              placeholder="Enter a code to join a meet"
+              :disabled="joining"
+            />
+            <button type="submit" class="join-btn" :disabled="joining || !joinCode.trim()">
+              {{ joining ? '…' : 'Join' }}
+            </button>
+          </div>
+          <p v-if="joinError" class="join-error">{{ joinError }}</p>
+        </form>
+      </template>
+
+      <!-- Step 2: pick a scheduled quiz -->
+      <template v-else>
+        <p v-if="quizLoading" class="schedule-picker-state">Loading schedule…</p>
+        <p v-else-if="quizError" class="schedule-picker-state schedule-picker-state--error">
+          {{ quizError }}
+        </p>
+        <ScheduleGrid
+          v-else
+          :rooms="rooms"
+          :slots="slots"
+          :quizzes="quizzes"
+          :prelim-assignments="prelimAssignments"
+          empty-message="This meet has no scheduled quizzes yet."
+        >
+          <template #quiz-label="{ quiz }">
+            <button
+              type="button"
+              class="picker-quiz-btn"
+              :disabled="submitting"
+              :title="`Load ${quiz.label} into the scoresheet`"
+              @click="pickQuiz(quiz.id)"
+            >
+              {{ quiz.label }}
+            </button>
+          </template>
+        </ScheduleGrid>
+
+        <div class="schedule-picker-actions">
+          <button
+            v-if="!meetSession.isActive.value"
+            type="button"
+            class="schedule-picker-back"
+            @click="backToMeetStep"
+          >
+            ← Pick a different meet
+          </button>
+          <span class="schedule-picker-actions-spacer" />
+        </div>
+      </template>
+    </div>
+  </dialog>
+</template>
+
+<style scoped>
+.schedule-picker-dialog {
+  border: 1px solid var(--color-border-alt);
+  border-radius: 10px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  padding: 0;
+  width: min(60rem, 95vw);
+  max-height: 90vh;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  inset: 0;
+  margin: auto;
+}
+
+.schedule-picker-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.schedule-picker-inner {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.schedule-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.schedule-picker-title {
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.schedule-picker-close {
+  background: none;
+  border: none;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--color-text-faint);
+  cursor: pointer;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+}
+
+.schedule-picker-close:hover {
+  color: var(--color-text);
+  background: var(--color-border-alt);
+}
+
+.schedule-picker-state {
+  font-size: 0.8rem;
+  color: var(--color-text-faint);
+  text-align: center;
+  padding: 1.5rem 0;
+}
+
+.schedule-picker-state--error {
+  color: var(--color-invalid);
+}
+
+.meet-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+}
+
+.meet-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  background: none;
+  border: 1px solid var(--color-border-alt);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  font-family: inherit;
+  color: var(--color-text);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+}
+
+.meet-row:hover:not(:disabled) {
+  background: var(--color-border-alt);
+  border-color: var(--color-accent);
+}
+
+.meet-row:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.meet-row-name {
+  font-weight: 600;
+}
+
+.meet-row-role {
+  font-size: 0.7rem;
+  color: var(--color-text-faint);
+  text-transform: capitalize;
+  flex-shrink: 0;
+}
+
+.schedule-picker-divider {
+  border: none;
+  border-top: 1px solid var(--color-border-alt);
+  margin: 0;
+}
+
+.join-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.join-label {
+  font-size: 0.75rem;
+  color: var(--color-text-faint);
+  margin: 0;
+}
+
+.join-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.join-input {
+  flex: 1;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-alt);
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.8rem;
+  font-family: inherit;
+  color: var(--color-text);
+}
+
+.join-input:focus {
+  outline: 1px solid var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.join-btn {
+  background: var(--color-accent);
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.8rem;
+  font-family: inherit;
+  color: #fff;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.join-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.join-btn:not(:disabled):hover {
+  filter: brightness(1.1);
+}
+
+.join-error {
+  font-size: 0.75rem;
+  color: var(--color-invalid);
+  margin: 0;
+}
+
+.picker-quiz-btn {
+  background: none;
+  border: 0;
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.78rem;
+  color: var(--color-text);
+  cursor: pointer;
+  padding: 0;
+  border-radius: 3px;
+}
+
+.picker-quiz-btn:hover:not(:disabled) {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
+.picker-quiz-btn:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.schedule-picker-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-top: 1px solid var(--color-border-alt);
+  padding-top: 0.75rem;
+}
+
+.schedule-picker-back {
+  background: none;
+  border: 1px solid var(--color-border-alt);
+  border-radius: 6px;
+  padding: 0.4rem 0.8rem;
+  font: inherit;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.schedule-picker-back:hover {
+  background: var(--color-border-alt);
+  color: var(--color-text);
+}
+
+.schedule-picker-actions-spacer {
+  flex: 1;
+}
+</style>

--- a/apps/scoresheet/src/components/SchedulePickerDialog.vue
+++ b/apps/scoresheet/src/components/SchedulePickerDialog.vue
@@ -7,9 +7,11 @@ import {
   type MeetRoomSummary,
   type MeetSlotSummary,
   type MeetSummary,
+  type MeetTeam,
   type PrelimAssignmentRow,
   type ScheduledQuizDetails,
   type ScheduledQuizSummaryRow,
+  getMeetTeams,
   listMeetRooms,
   listMeetSlots,
   listPrelimAssignments,
@@ -46,6 +48,7 @@ const quizzes = shallowRef<ScheduledQuizSummaryRow[]>([])
 const rooms = shallowRef<MeetRoomSummary[]>([])
 const slots = shallowRef<MeetSlotSummary[]>([])
 const prelimAssignments = shallowRef<PrelimAssignmentRow[]>([])
+const teams = shallowRef<MeetTeam[]>([])
 const quizLoading = ref(false)
 const quizError = ref('')
 
@@ -53,16 +56,18 @@ async function loadQuizzesForMeet(meetId: number) {
   quizLoading.value = true
   quizError.value = ''
   try {
-    const [q, r, s, p] = await Promise.all([
+    const [q, r, s, p, t] = await Promise.all([
       listScheduledQuizzes(meetId),
       listMeetRooms(meetId),
       listMeetSlots(meetId),
       listPrelimAssignments(meetId),
+      getMeetTeams(meetId),
     ])
     quizzes.value = q.quizzes
     rooms.value = r.rooms
     slots.value = s.slots
     prelimAssignments.value = p.assignments
+    teams.value = t.teams
   } catch (e) {
     quizError.value = (e as Error).message
   } finally {
@@ -107,6 +112,7 @@ function backToMeetStep() {
   rooms.value = []
   slots.value = []
   prelimAssignments.value = []
+  teams.value = []
 }
 
 function close() {
@@ -189,6 +195,7 @@ defineExpose({ open })
           :slots="slots"
           :quizzes="quizzes"
           :prelim-assignments="prelimAssignments"
+          :meet-teams="teams"
           empty-message="This meet has no scheduled quizzes yet."
         >
           <template #quiz-label="{ quiz }">

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -20,6 +20,7 @@ import { anyTeamHasAnswer } from '../scoring/helpers'
 import { ValidationCode, validationMessage } from '../scoring/validation'
 import { useMeetSession } from '../composables/useMeetSession'
 import { useTutorial } from '../composables/useTutorial'
+import { quizNumberFromScheduledQuiz, consolationFromScheduledQuiz } from '../quizMeta'
 import MeetPickerDialog from './MeetPickerDialog.vue'
 import SignInWidget from './SignInWidget.vue'
 import TutorialOverlay from './TutorialOverlay.vue'
@@ -80,7 +81,62 @@ function pickFromOpenPicker(teamId: number) {
   if (openPickerSlot.value !== null) pickTeam(openPickerSlot.value, teamId)
 }
 
-onMounted(() => meetSession.refresh())
+onMounted(() => {
+  void meetSession.refresh()
+  void loadFromUrlParams()
+})
+
+/**
+ * If the page was opened with `?meet=X&quiz=Y` (e.g. from the
+ * portal's schedule view → quiz cell), prefill the meet session
+ * with that scheduled quiz and populate the scoresheet meta
+ * (division / quiz # / consolation) + the 3 team slots.
+ * After loading, strip the params from the URL so a refresh
+ * doesn't re-trigger and clobber edits.
+ */
+async function loadFromUrlParams() {
+  const params = new URLSearchParams(window.location.search)
+  const meetId = Number(params.get('meet'))
+  const quizId = Number(params.get('quiz'))
+  if (!meetId || !quizId || Number.isNaN(meetId) || Number.isNaN(quizId)) return
+
+  const storeNamesByTeamIdx = [0, 1, 2].map((teamIdx) => {
+    const storeTeamId = store.teams[teamIdx]?.id
+    if (storeTeamId === undefined) return Array<string>(QUIZZERS_PER_TEAM).fill('')
+    // Cleared default names get sent as empty so the matcher fills them
+    // with the resolved DB names; edited names pass through and try to
+    // bind to roster entries.
+    return store
+      .quizzersByTeam(storeTeamId)
+      .map((q) => (isDefaultQuizzerName(q.name) ? '' : q.name))
+  })
+
+  try {
+    const details = await meetSession.loadFromQuiz(meetId, quizId, '', storeNamesByTeamIdx)
+
+    quiz.value.division = details.quiz.division
+    quiz.value.quizNumber = quizNumberFromScheduledQuiz(details.quiz)
+    quiz.value.consolation = consolationFromScheduledQuiz(details.quiz)
+
+    for (let teamIdx = 0; teamIdx < 3; teamIdx++) {
+      const slot = meetSession.getSlot(teamIdx)
+      if (!slot) continue
+      const storeTeamId = store.teams[teamIdx]!.id
+      setTeamName(teamIdx, slot.dbLabelFull)
+      for (let seatIdx = 0; seatIdx < QUIZZERS_PER_TEAM; seatIdx++) {
+        if (!store.quizzersByTeam(storeTeamId)[seatIdx]?.name.trim()) {
+          setQuizzerName(teamIdx, seatIdx, slot.quizzers[seatIdx]!.dbName)
+        }
+      }
+    }
+  } catch (err) {
+    alert(`Could not load scheduled quiz: ${(err as Error).message}`)
+  } finally {
+    // Always strip the params so they don't re-fire on refresh, even
+    // when the load failed (the user can manually retry via the picker).
+    history.replaceState(null, '', window.location.pathname)
+  }
+}
 
 async function openMeetPicker() {
   closeMenus()

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -22,6 +22,7 @@ import { useMeetSession } from '../composables/useMeetSession'
 import { useTutorial } from '../composables/useTutorial'
 import { quizNumberFromScheduledQuiz, consolationFromScheduledQuiz } from '../quizMeta'
 import MeetPickerDialog from './MeetPickerDialog.vue'
+import SchedulePickerDialog from './SchedulePickerDialog.vue'
 import SignInWidget from './SignInWidget.vue'
 import TutorialOverlay from './TutorialOverlay.vue'
 
@@ -64,6 +65,7 @@ const vFitName = {
 
 const meetSession = useMeetSession()
 const meetPickerRef = ref<InstanceType<typeof MeetPickerDialog> | null>(null)
+const schedulePickerRef = ref<InstanceType<typeof SchedulePickerDialog> | null>(null)
 const openPickerSlot = ref<number | null>(null)
 const pickerPos = ref({ top: 0, left: 0 })
 
@@ -141,6 +143,29 @@ async function loadFromUrlParams() {
 async function openMeetPicker() {
   closeMenus()
   meetPickerRef.value?.open()
+}
+
+async function openSchedulePicker() {
+  closeMenus()
+  schedulePickerRef.value?.open()
+}
+
+async function onSchedulePicked() {
+  // loadFromQuiz inside the dialog already populated the meet session,
+  // assigned the 3 team slots, and stamped quizId. We mirror the URL
+  // entry point's post-assign bookkeeping so the scoresheet's team
+  // labels + empty quizzer seats fill from the resolved DB data.
+  for (let teamIdx = 0; teamIdx < 3; teamIdx++) {
+    const slot = meetSession.getSlot(teamIdx)
+    if (!slot) continue
+    const storeTeamId = store.teams[teamIdx]!.id
+    setTeamName(teamIdx, slot.dbLabelFull)
+    for (let seatIdx = 0; seatIdx < QUIZZERS_PER_TEAM; seatIdx++) {
+      if (!store.quizzersByTeam(storeTeamId)[seatIdx]?.name.trim()) {
+        setQuizzerName(teamIdx, seatIdx, slot.quizzers[seatIdx]!.dbName)
+      }
+    }
+  }
 }
 
 function isDefaultQuizzerName(name: string): boolean {
@@ -864,6 +889,7 @@ const appVersion: string = __APP_VERSION__
                     <button v-else @click="doClearNames">✕ Clear names</button>
                     <hr class="file-menu__divider" />
                     <button @click="openMeetPicker">🔗 Load teams from meet…</button>
+                    <button @click="openSchedulePicker">📅 Load from schedule…</button>
                   </div>
                 </div>
                 <button class="help-toggle" title="Interactive tutorial" @click="tutorial.start()">
@@ -1454,6 +1480,7 @@ const appVersion: string = __APP_VERSION__
       <!-- Cell selector popup -->
       <Teleport to="body">
         <MeetPickerDialog ref="meetPickerRef" @loaded="onMeetLoaded" />
+        <SchedulePickerDialog ref="schedulePickerRef" @loaded="onSchedulePicked" />
         <div
           v-if="selector"
           :class="[

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -2568,6 +2568,9 @@ thead tr th.sticky-col {
   outline: 2px solid var(--color-border);
   outline-offset: -2px;
 }
+/* Drop the grey hover outline during drag — the drop-target's blue
+   indicator is a box-shadow on every td (see .row--drop-target rules
+   below), so suppressing the col--name outline here doesn't fight it. */
 .is-dragging .row--quizzer:hover > .col--name {
   outline: none;
 }
@@ -2804,9 +2807,29 @@ thead tr th.sticky-col {
 .row--dragging > td {
   opacity: 0.4;
 }
-.row--drop-target > .col--name {
-  outline: 2px solid var(--color-accent);
-  outline-offset: -2px;
+/* Drop target: outline the entire row in accent. Inset box-shadow
+   on every cell stitches a continuous border across the whole row;
+   the first/last cells add the left/right ends. Outline doesn't work
+   here because adjacent cells' outlines leave a visible gap pattern
+   (outline-offset: -2px puts each cell's edge 2px inside).
+   Note: this temporarily overrides .sticky-col's right-edge shadow
+   on .col--name during drag — fine, the blue ring is what matters. */
+.row--drop-target > td {
+  box-shadow:
+    inset 0 2px 0 0 var(--color-accent),
+    inset 0 -2px 0 0 var(--color-accent);
+}
+.row--drop-target > td:first-child {
+  box-shadow:
+    inset 0 2px 0 0 var(--color-accent),
+    inset 0 -2px 0 0 var(--color-accent),
+    inset 2px 0 0 0 var(--color-accent);
+}
+.row--drop-target > td:last-child {
+  box-shadow:
+    inset 0 2px 0 0 var(--color-accent),
+    inset 0 -2px 0 0 var(--color-accent),
+    inset -2px 0 0 0 var(--color-accent);
 }
 
 /* Editable name inputs */

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -18,7 +18,8 @@ import { fillOts } from '../export/fillOts'
 import { readOds } from '../export/readOds'
 import { anyTeamHasAnswer } from '../scoring/helpers'
 import { ValidationCode, validationMessage } from '../scoring/validation'
-import { useMeetSession } from '../composables/useMeetSession'
+import type { ScheduledQuizSeat } from '../api'
+import { useMeetSession, type SlotSession } from '../composables/useMeetSession'
 import { useTutorial } from '../composables/useTutorial'
 import { quizNumberFromScheduledQuiz, consolationFromScheduledQuiz } from '../quizMeta'
 import MeetPickerDialog from './MeetPickerDialog.vue'
@@ -103,53 +104,104 @@ function hasNonDefaultNames(): boolean {
 }
 
 /** Single entry point for loading a scheduled quiz into the
- *  scoresheet — shared by the URL ?meet&quiz prefill and the in-app
- *  picker. Mirrors pickTeam's clear-defaults-then-fill flow so
- *  "Quizzer 1..4" placeholders get replaced by DB names just like
- *  picking a team from the dropdown does. Warns first if the user
- *  has typed real names. Returns true on success so the picker
- *  dialog can decide whether to close. */
+ *  scoresheet — shared by the URL ?meet&quiz prefill and the
+ *  in-app picker. Warns first if the user has typed real names,
+ *  then per seat decides what to do via `computeSeatChange`, and
+ *  commits all slot updates in one atomic write. Returns true on
+ *  success so the picker dialog can decide whether to close. */
 async function loadScheduledQuiz(meetId: number, quizId: number): Promise<boolean> {
   if (hasNonDefaultNames()) {
     if (!(await confirmAction('Loading this quiz will overwrite your current names. Continue?'))) {
       return false
     }
   }
-  // Clear default names → empty seats so the matcher can fill them.
-  for (let teamIdx = 0; teamIdx < 3; teamIdx++) {
-    const storeTeamId = store.teams[teamIdx]?.id
-    if (storeTeamId === undefined) continue
-    for (let seatIdx = 0; seatIdx < QUIZZERS_PER_TEAM; seatIdx++) {
-      if (isDefaultQuizzerName(store.quizzersByTeam(storeTeamId)[seatIdx]?.name ?? '')) {
-        setQuizzerName(teamIdx, seatIdx, '')
-      }
-    }
-  }
-  const storeNamesByTeamIdx = [0, 1, 2].map((teamIdx) => {
-    const storeTeamId = store.teams[teamIdx]?.id
-    if (storeTeamId === undefined) return Array<string>(QUIZZERS_PER_TEAM).fill('')
-    return store.quizzersByTeam(storeTeamId).map((q) => q.name)
-  })
+  let details
   try {
-    const details = await meetSession.loadFromQuiz(meetId, quizId, storeNamesByTeamIdx)
-    quiz.value.division = details.quiz.division
-    quiz.value.quizNumber = quizNumberFromScheduledQuiz(details.quiz)
-    quiz.value.consolation = consolationFromScheduledQuiz(details.quiz)
-    for (let teamIdx = 0; teamIdx < 3; teamIdx++) {
-      const slot = meetSession.getSlot(teamIdx)
-      if (!slot) continue
-      const storeTeamId = store.teams[teamIdx]!.id
-      setTeamName(teamIdx, slot.dbLabelFull)
-      for (let seatIdx = 0; seatIdx < QUIZZERS_PER_TEAM; seatIdx++) {
-        if (!store.quizzersByTeam(storeTeamId)[seatIdx]?.name.trim()) {
-          setQuizzerName(teamIdx, seatIdx, slot.quizzers[seatIdx]!.dbName)
-        }
-      }
-    }
-    return true
+    details = await meetSession.loadFromQuiz(meetId, quizId)
   } catch (err) {
     alert(`Could not load scheduled quiz: ${(err as Error).message}`)
     return false
+  }
+  quiz.value.division = details.quiz.division
+  quiz.value.quizNumber = quizNumberFromScheduledQuiz(details.quiz)
+  quiz.value.consolation = consolationFromScheduledQuiz(details.quiz)
+
+  const slots = [0, 1, 2].map((i) => meetSession.getSlot(i))
+  const storeMirrors: (() => void)[] = []
+  for (const seat of details.seats) {
+    const slotIdx = seat.seatNumber - 1
+    if (slotIdx < 0 || slotIdx > 2) continue
+    const change = computeSeatChange(slotIdx, seat)
+    if (!change) continue
+    slots[slotIdx] = change.slot
+    storeMirrors.push(change.mirrorToStore)
+  }
+  meetSession.applyLoadedQuiz(slots, quizId)
+  for (const mirror of storeMirrors) mirror()
+  return true
+}
+
+/** Decide what to do for one seat. Three branches, in order:
+ *  - Same team as before — refresh team display, leave quizzer
+ *    names alone.
+ *  - Different team but every non-default typed name appears in
+ *    the incoming roster (case-insensitive, any order) — keep
+ *    the user's name positions, fill any default seats with the
+ *    unused roster names.
+ *  - Otherwise — clear all 5 quizzer seats and fill with the DB
+ *    roster in seat order. No fuzzy "Bobby ≈ Robert" rescue.
+ *
+ *  Returns the new SlotSession + a deferred store-mirror callback
+ *  so the caller can commit all slots atomically before any store
+ *  side-effects. Returns null when the seat is unresolved. */
+function computeSeatChange(
+  slotIdx: number,
+  seat: ScheduledQuizSeat,
+): { slot: SlotSession; mirrorToStore: () => void } | null {
+  if (!seat.team) return null
+  const currentSlot = meetSession.getSlot(slotIdx)
+  const storeTeamId = store.teams[slotIdx]!.id
+  const currentNames = store.quizzersByTeam(storeTeamId).map((q) => q.name)
+
+  if (currentSlot?.teamId === seat.team.id) {
+    const slot = meetSession.buildSlotFromSeat(seat, currentNames)!
+    return {
+      slot,
+      mirrorToStore: () => setTeamName(slotIdx, slot.dbLabelFull),
+    }
+  }
+
+  const currentNonDefault = currentNames.filter((n) => !isDefaultQuizzerName(n))
+  const rosterSet = new Set(seat.quizzers.map((q) => q.name.trim().toLowerCase()))
+  const allMatch =
+    currentNonDefault.length > 0 &&
+    currentNonDefault.every((n) => rosterSet.has(n.trim().toLowerCase()))
+
+  if (allMatch) {
+    const namesForMatch = currentNames.map((n) => (isDefaultQuizzerName(n) ? '' : n))
+    const slot = meetSession.buildSlotFromSeat(seat, namesForMatch)!
+    return {
+      slot,
+      mirrorToStore: () => {
+        setTeamName(slotIdx, slot.dbLabelFull)
+        for (let seatIdx = 0; seatIdx < QUIZZERS_PER_TEAM; seatIdx++) {
+          if (isDefaultQuizzerName(currentNames[seatIdx] ?? '')) {
+            setQuizzerName(slotIdx, seatIdx, slot.quizzers[seatIdx]!.dbName)
+          }
+        }
+      },
+    }
+  }
+
+  const slot = meetSession.buildSlotFromSeat(seat, [])!
+  return {
+    slot,
+    mirrorToStore: () => {
+      setTeamName(slotIdx, slot.dbLabelFull)
+      for (let seatIdx = 0; seatIdx < QUIZZERS_PER_TEAM; seatIdx++) {
+        setQuizzerName(slotIdx, seatIdx, slot.quizzers[seatIdx]!.dbName)
+      }
+    },
   }
 }
 

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -18,6 +18,7 @@ import { fillOts } from '../export/fillOts'
 import { readOds } from '../export/readOds'
 import { anyTeamHasAnswer } from '../scoring/helpers'
 import { ValidationCode, validationMessage } from '../scoring/validation'
+import type { ScheduledQuizDetails } from '../api'
 import { useMeetSession } from '../composables/useMeetSession'
 import { useTutorial } from '../composables/useTutorial'
 import { quizNumberFromScheduledQuiz, consolationFromScheduledQuiz } from '../quizMeta'
@@ -88,14 +89,28 @@ onMounted(() => {
   void loadFromUrlParams()
 })
 
-/**
- * If the page was opened with `?meet=X&quiz=Y` (e.g. from the
- * portal's schedule view → quiz cell), prefill the meet session
- * with that scheduled quiz and populate the scoresheet meta
- * (division / quiz # / consolation) + the 3 team slots.
- * After loading, strip the params from the URL so a refresh
- * doesn't re-trigger and clobber edits.
- */
+/** Apply the resolved per-slot dbLabelFull + roster names from the
+ *  meet session into the scoresheet store. Used by both the URL
+ *  prefill path and the in-app picker callback — the store and the
+ *  meetSession are eventually-consistent after loadFromQuiz, this
+ *  is the function that bridges them. */
+function fillSlotsFromMeetSession() {
+  for (let teamIdx = 0; teamIdx < 3; teamIdx++) {
+    const slot = meetSession.getSlot(teamIdx)
+    if (!slot) continue
+    const storeTeamId = store.teams[teamIdx]!.id
+    setTeamName(teamIdx, slot.dbLabelFull)
+    for (let seatIdx = 0; seatIdx < QUIZZERS_PER_TEAM; seatIdx++) {
+      if (!store.quizzersByTeam(storeTeamId)[seatIdx]?.name.trim()) {
+        setQuizzerName(teamIdx, seatIdx, slot.quizzers[seatIdx]!.dbName)
+      }
+    }
+  }
+}
+
+/** Prefill from `?meet=&quiz=` (set by the portal's schedule view
+ *  when the user clicks a quiz cell). Always strips the params from
+ *  the URL afterward so a refresh doesn't re-clobber edits. */
 async function loadFromUrlParams() {
   const params = new URLSearchParams(window.location.search)
   const meetId = Number(params.get('meet'))
@@ -105,37 +120,20 @@ async function loadFromUrlParams() {
   const storeNamesByTeamIdx = [0, 1, 2].map((teamIdx) => {
     const storeTeamId = store.teams[teamIdx]?.id
     if (storeTeamId === undefined) return Array<string>(QUIZZERS_PER_TEAM).fill('')
-    // Cleared default names get sent as empty so the matcher fills them
-    // with the resolved DB names; edited names pass through and try to
-    // bind to roster entries.
     return store
       .quizzersByTeam(storeTeamId)
       .map((q) => (isDefaultQuizzerName(q.name) ? '' : q.name))
   })
 
   try {
-    const details = await meetSession.loadFromQuiz(meetId, quizId, '', storeNamesByTeamIdx)
-
+    const details = await meetSession.loadFromQuiz(meetId, quizId, storeNamesByTeamIdx)
     quiz.value.division = details.quiz.division
     quiz.value.quizNumber = quizNumberFromScheduledQuiz(details.quiz)
     quiz.value.consolation = consolationFromScheduledQuiz(details.quiz)
-
-    for (let teamIdx = 0; teamIdx < 3; teamIdx++) {
-      const slot = meetSession.getSlot(teamIdx)
-      if (!slot) continue
-      const storeTeamId = store.teams[teamIdx]!.id
-      setTeamName(teamIdx, slot.dbLabelFull)
-      for (let seatIdx = 0; seatIdx < QUIZZERS_PER_TEAM; seatIdx++) {
-        if (!store.quizzersByTeam(storeTeamId)[seatIdx]?.name.trim()) {
-          setQuizzerName(teamIdx, seatIdx, slot.quizzers[seatIdx]!.dbName)
-        }
-      }
-    }
+    fillSlotsFromMeetSession()
   } catch (err) {
     alert(`Could not load scheduled quiz: ${(err as Error).message}`)
   } finally {
-    // Always strip the params so they don't re-fire on refresh, even
-    // when the load failed (the user can manually retry via the picker).
     history.replaceState(null, '', window.location.pathname)
   }
 }
@@ -150,22 +148,11 @@ async function openSchedulePicker() {
   schedulePickerRef.value?.open()
 }
 
-async function onSchedulePicked() {
-  // loadFromQuiz inside the dialog already populated the meet session,
-  // assigned the 3 team slots, and stamped quizId. We mirror the URL
-  // entry point's post-assign bookkeeping so the scoresheet's team
-  // labels + empty quizzer seats fill from the resolved DB data.
-  for (let teamIdx = 0; teamIdx < 3; teamIdx++) {
-    const slot = meetSession.getSlot(teamIdx)
-    if (!slot) continue
-    const storeTeamId = store.teams[teamIdx]!.id
-    setTeamName(teamIdx, slot.dbLabelFull)
-    for (let seatIdx = 0; seatIdx < QUIZZERS_PER_TEAM; seatIdx++) {
-      if (!store.quizzersByTeam(storeTeamId)[seatIdx]?.name.trim()) {
-        setQuizzerName(teamIdx, seatIdx, slot.quizzers[seatIdx]!.dbName)
-      }
-    }
-  }
+function onSchedulePicked(details: ScheduledQuizDetails) {
+  quiz.value.division = details.quiz.division
+  quiz.value.quizNumber = quizNumberFromScheduledQuiz(details.quiz)
+  quiz.value.consolation = consolationFromScheduledQuiz(details.quiz)
+  fillSlotsFromMeetSession()
 }
 
 function isDefaultQuizzerName(name: string): boolean {

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -2831,6 +2831,17 @@ thead tr th.sticky-col {
     inset 0 -2px 0 0 var(--color-accent),
     inset -2px 0 0 0 var(--color-accent);
 }
+/* col--name keeps its own 1px border-top to bridge the sticky-layer
+   gap, which pushes the padding box (where inset box-shadow paints)
+   1px lower than its neighbours. Recolour that border to accent and
+   shrink the top box-shadow to 1px so the visible blue stays 2px
+   tall and aligns continuously with the rest of the row's top edge. */
+.row--drop-target > .col--name {
+  border-top-color: var(--color-accent);
+  box-shadow:
+    inset 0 1px 0 0 var(--color-accent),
+    inset 0 -2px 0 0 var(--color-accent);
+}
 
 /* Editable name inputs */
 .editable-name {

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -18,7 +18,6 @@ import { fillOts } from '../export/fillOts'
 import { readOds } from '../export/readOds'
 import { anyTeamHasAnswer } from '../scoring/helpers'
 import { ValidationCode, validationMessage } from '../scoring/validation'
-import type { ScheduledQuizDetails } from '../api'
 import { useMeetSession } from '../composables/useMeetSession'
 import { useTutorial } from '../composables/useTutorial'
 import { quizNumberFromScheduledQuiz, consolationFromScheduledQuiz } from '../quizMeta'
@@ -89,50 +88,81 @@ onMounted(() => {
   void loadFromUrlParams()
 })
 
-/** Apply the resolved per-slot dbLabelFull + roster names from the
- *  meet session into the scoresheet store. Used by both the URL
- *  prefill path and the in-app picker callback — the store and the
- *  meetSession are eventually-consistent after loadFromQuiz, this
- *  is the function that bridges them. */
-function fillSlotsFromMeetSession() {
+/** True when any team or quizzer name has been edited away from
+ *  the auto-generated defaults. Used to gate the overwrite confirm
+ *  before loading from schedule. */
+function hasNonDefaultNames(): boolean {
   for (let teamIdx = 0; teamIdx < 3; teamIdx++) {
-    const slot = meetSession.getSlot(teamIdx)
-    if (!slot) continue
+    if (!isDefaultTeamName(store.teams[teamIdx]?.name ?? '')) return true
     const storeTeamId = store.teams[teamIdx]!.id
-    setTeamName(teamIdx, slot.dbLabelFull)
+    for (const q of store.quizzersByTeam(storeTeamId)) {
+      if (!isDefaultQuizzerName(q.name)) return true
+    }
+  }
+  return false
+}
+
+/** Single entry point for loading a scheduled quiz into the
+ *  scoresheet — shared by the URL ?meet&quiz prefill and the in-app
+ *  picker. Mirrors pickTeam's clear-defaults-then-fill flow so
+ *  "Quizzer 1..4" placeholders get replaced by DB names just like
+ *  picking a team from the dropdown does. Warns first if the user
+ *  has typed real names. Returns true on success so the picker
+ *  dialog can decide whether to close. */
+async function loadScheduledQuiz(meetId: number, quizId: number): Promise<boolean> {
+  if (hasNonDefaultNames()) {
+    if (!(await confirmAction('Loading this quiz will overwrite your current names. Continue?'))) {
+      return false
+    }
+  }
+  // Clear default names → empty seats so the matcher can fill them.
+  for (let teamIdx = 0; teamIdx < 3; teamIdx++) {
+    const storeTeamId = store.teams[teamIdx]?.id
+    if (storeTeamId === undefined) continue
     for (let seatIdx = 0; seatIdx < QUIZZERS_PER_TEAM; seatIdx++) {
-      if (!store.quizzersByTeam(storeTeamId)[seatIdx]?.name.trim()) {
-        setQuizzerName(teamIdx, seatIdx, slot.quizzers[seatIdx]!.dbName)
+      if (isDefaultQuizzerName(store.quizzersByTeam(storeTeamId)[seatIdx]?.name ?? '')) {
+        setQuizzerName(teamIdx, seatIdx, '')
       }
     }
   }
-}
-
-/** Prefill from `?meet=&quiz=` (set by the portal's schedule view
- *  when the user clicks a quiz cell). Always strips the params from
- *  the URL afterward so a refresh doesn't re-clobber edits. */
-async function loadFromUrlParams() {
-  const params = new URLSearchParams(window.location.search)
-  const meetId = Number(params.get('meet'))
-  const quizId = Number(params.get('quiz'))
-  if (!meetId || !quizId || Number.isNaN(meetId) || Number.isNaN(quizId)) return
-
   const storeNamesByTeamIdx = [0, 1, 2].map((teamIdx) => {
     const storeTeamId = store.teams[teamIdx]?.id
     if (storeTeamId === undefined) return Array<string>(QUIZZERS_PER_TEAM).fill('')
-    return store
-      .quizzersByTeam(storeTeamId)
-      .map((q) => (isDefaultQuizzerName(q.name) ? '' : q.name))
+    return store.quizzersByTeam(storeTeamId).map((q) => q.name)
   })
-
   try {
     const details = await meetSession.loadFromQuiz(meetId, quizId, storeNamesByTeamIdx)
     quiz.value.division = details.quiz.division
     quiz.value.quizNumber = quizNumberFromScheduledQuiz(details.quiz)
     quiz.value.consolation = consolationFromScheduledQuiz(details.quiz)
-    fillSlotsFromMeetSession()
+    for (let teamIdx = 0; teamIdx < 3; teamIdx++) {
+      const slot = meetSession.getSlot(teamIdx)
+      if (!slot) continue
+      const storeTeamId = store.teams[teamIdx]!.id
+      setTeamName(teamIdx, slot.dbLabelFull)
+      for (let seatIdx = 0; seatIdx < QUIZZERS_PER_TEAM; seatIdx++) {
+        if (!store.quizzersByTeam(storeTeamId)[seatIdx]?.name.trim()) {
+          setQuizzerName(teamIdx, seatIdx, slot.quizzers[seatIdx]!.dbName)
+        }
+      }
+    }
+    return true
   } catch (err) {
     alert(`Could not load scheduled quiz: ${(err as Error).message}`)
+    return false
+  }
+}
+
+/** Strip ?meet=&quiz= from the URL after the prefill — set by the
+ *  portal's schedule view when the user clicks a quiz cell. Always
+ *  strips the params so a refresh doesn't re-clobber edits. */
+async function loadFromUrlParams() {
+  const params = new URLSearchParams(window.location.search)
+  const meetId = Number(params.get('meet'))
+  const quizId = Number(params.get('quiz'))
+  if (!meetId || !quizId || Number.isNaN(meetId) || Number.isNaN(quizId)) return
+  try {
+    await loadScheduledQuiz(meetId, quizId)
   } finally {
     history.replaceState(null, '', window.location.pathname)
   }
@@ -146,13 +176,6 @@ async function openMeetPicker() {
 async function openSchedulePicker() {
   closeMenus()
   schedulePickerRef.value?.open()
-}
-
-function onSchedulePicked(details: ScheduledQuizDetails) {
-  quiz.value.division = details.quiz.division
-  quiz.value.quizNumber = quizNumberFromScheduledQuiz(details.quiz)
-  quiz.value.consolation = consolationFromScheduledQuiz(details.quiz)
-  fillSlotsFromMeetSession()
 }
 
 function isDefaultQuizzerName(name: string): boolean {
@@ -1467,7 +1490,7 @@ const appVersion: string = __APP_VERSION__
       <!-- Cell selector popup -->
       <Teleport to="body">
         <MeetPickerDialog ref="meetPickerRef" @loaded="onMeetLoaded" />
-        <SchedulePickerDialog ref="schedulePickerRef" @loaded="onSchedulePicked" />
+        <SchedulePickerDialog ref="schedulePickerRef" :on-pick="loadScheduledQuiz" />
         <div
           v-if="selector"
           :class="[

--- a/apps/scoresheet/src/composables/__tests__/useMeetSession.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useMeetSession.spec.ts
@@ -217,6 +217,7 @@ describe('useMeetSession — loadFromQuiz', () => {
       quiz: {
         id: 777,
         meetId: 42,
+        meetName: 'District Finals',
         slotId: 1,
         roomId: 1,
         division: '1',
@@ -256,7 +257,7 @@ describe('useMeetSession — loadFromQuiz', () => {
       ]),
     )
     const { loadFromQuiz, getSlot, quizId } = useMeetSession()
-    const result = await loadFromQuiz(42, 777, 'Finals', [emptyNames, emptyNames, emptyNames])
+    const result = await loadFromQuiz(42, 777, [emptyNames, emptyNames, emptyNames])
 
     expect(result.quiz.id).toBe(777)
     expect(getSlot(0)?.teamId).toBe(teamA.id)
@@ -275,7 +276,7 @@ describe('useMeetSession — loadFromQuiz', () => {
       ]),
     )
     const { loadFromQuiz, getSlot } = useMeetSession()
-    await loadFromQuiz(42, 778, 'Finals', [emptyNames, emptyNames, emptyNames])
+    await loadFromQuiz(42, 778)
 
     expect(getSlot(0)?.teamId).toBe(teamA.id)
     expect(getSlot(1)).toBeUndefined()
@@ -285,7 +286,7 @@ describe('useMeetSession — loadFromQuiz', () => {
   it('persists quizId to localStorage', async () => {
     vi.mocked(getScheduledQuiz).mockResolvedValueOnce(makeQuizDetails({}, []))
     const { loadFromQuiz } = useMeetSession()
-    await loadFromQuiz(42, 999, 'Finals', [emptyNames, emptyNames, emptyNames])
+    await loadFromQuiz(42, 999)
     const stored = JSON.parse(localStorage.getItem('qzr-meet-session')!)
     expect(stored.quizId).toBe(999)
   })
@@ -295,8 +296,26 @@ describe('useMeetSession — loadFromQuiz', () => {
     const { loadMeet, loadFromQuiz } = useMeetSession()
     await loadMeet(42, 'Finals')
     vi.mocked(getMeetTeams).mockClear()
-    await loadFromQuiz(42, 777, 'Finals', [emptyNames, emptyNames, emptyNames])
+    await loadFromQuiz(42, 777)
     expect(getMeetTeams).not.toHaveBeenCalled()
+  })
+
+  it('uses pre-fetched seat.quizzers — no per-team getTeamQuizzers calls', async () => {
+    const teamA = mockTeams[0]!
+    const teamB = mockTeams[1]!
+    vi.mocked(getScheduledQuiz).mockResolvedValueOnce(
+      makeQuizDetails({}, [
+        { seatNumber: 1, letter: 'A', seedRef: null, team: teamA, quizzers: mockQuizzers },
+        { seatNumber: 2, letter: 'B', seedRef: null, team: teamB, quizzers: mockQuizzers },
+      ]),
+    )
+    const { loadFromQuiz, getSlot } = useMeetSession()
+    await loadFromQuiz(42, 777)
+    // assignTeam path would have called getTeamQuizzers once per team; the
+    // pre-fetched path must not.
+    expect(getTeamQuizzers).not.toHaveBeenCalled()
+    // Verify the roster actually landed in the slot.
+    expect(getSlot(0)?.quizzers[0]!.dbName).toBe('Alice')
   })
 })
 

--- a/apps/scoresheet/src/composables/__tests__/useMeetSession.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useMeetSession.spec.ts
@@ -40,6 +40,11 @@ const mockQuizzers = [
 /** Empty storeNames — simulates all-default (cleared) names */
 const emptyNames = Array<string>(5).fill('')
 
+let setItemSpy: ReturnType<typeof vi.spyOn>
+function localStorageWriteCount() {
+  return setItemSpy.mock.calls.length
+}
+
 beforeEach(() => {
   localStorage.clear()
   // Reset singleton session state between tests
@@ -48,6 +53,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(getMeetTeams).mockResolvedValue({ teams: mockTeams, meetDivisions: ['1', '2'] })
   vi.mocked(getTeamQuizzers).mockResolvedValue({ quizzers: mockQuizzers })
+  setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
 })
 
 describe('useMeetSession — initial state', () => {
@@ -233,62 +239,19 @@ describe('useMeetSession — loadFromQuiz', () => {
     }
   }
 
-  it('assigns all 3 seats from a fully-resolved prelim quiz and stamps quizId', async () => {
+  it('returns details, leaves slot population and quizId stamping to the caller', async () => {
     const teamA = mockTeams[0]!
-    const teamB = mockTeams[1]!
-    const teamC: MeetTeam = {
-      id: 3,
-      churchId: 30,
-      churchName: 'Trinity Church',
-      churchShortName: 'TC',
-      division: '1',
-      number: 1,
-      consolation: false,
-    }
-    vi.mocked(getMeetTeams).mockResolvedValueOnce({
-      teams: [teamA, teamB, teamC],
-      meetDivisions: ['1'],
-    })
     vi.mocked(getScheduledQuiz).mockResolvedValueOnce(
       makeQuizDetails({}, [
         { seatNumber: 1, letter: 'A', seedRef: null, team: teamA, quizzers: mockQuizzers },
-        { seatNumber: 2, letter: 'B', seedRef: null, team: teamB, quizzers: mockQuizzers },
-        { seatNumber: 3, letter: 'C', seedRef: null, team: teamC, quizzers: mockQuizzers },
       ]),
     )
     const { loadFromQuiz, getSlot, quizId } = useMeetSession()
-    const result = await loadFromQuiz(42, 777, [emptyNames, emptyNames, emptyNames])
+    const result = await loadFromQuiz(42, 777)
 
     expect(result.quiz.id).toBe(777)
-    expect(getSlot(0)?.teamId).toBe(teamA.id)
-    expect(getSlot(1)?.teamId).toBe(teamB.id)
-    expect(getSlot(2)?.teamId).toBe(teamC.id)
-    expect(quizId.value).toBe(777)
-  })
-
-  it('leaves unresolved elim seats empty and assigns the rest', async () => {
-    const teamA = mockTeams[0]!
-    vi.mocked(getScheduledQuiz).mockResolvedValueOnce(
-      makeQuizDetails({ phase: 'elim', lane: 'main', bracketLabel: 'A', label: 'D1-QA' }, [
-        { seatNumber: 1, letter: null, seedRef: '1stA', team: teamA, quizzers: mockQuizzers },
-        { seatNumber: 2, letter: null, seedRef: '2ndA', team: null, quizzers: [] },
-        { seatNumber: 3, letter: null, seedRef: '1stB', team: null, quizzers: [] },
-      ]),
-    )
-    const { loadFromQuiz, getSlot } = useMeetSession()
-    await loadFromQuiz(42, 778)
-
-    expect(getSlot(0)?.teamId).toBe(teamA.id)
-    expect(getSlot(1)).toBeUndefined()
-    expect(getSlot(2)).toBeUndefined()
-  })
-
-  it('persists quizId to localStorage', async () => {
-    vi.mocked(getScheduledQuiz).mockResolvedValueOnce(makeQuizDetails({}, []))
-    const { loadFromQuiz } = useMeetSession()
-    await loadFromQuiz(42, 999)
-    const stored = JSON.parse(localStorage.getItem('qzr-meet-session')!)
-    expect(stored.quizId).toBe(999)
+    expect(quizId.value).toBeNull()
+    expect(getSlot(0)).toBeUndefined()
   })
 
   it('reuses an existing meet session without reloading the team list', async () => {
@@ -299,23 +262,73 @@ describe('useMeetSession — loadFromQuiz', () => {
     await loadFromQuiz(42, 777)
     expect(getMeetTeams).not.toHaveBeenCalled()
   })
+})
 
-  it('uses pre-fetched seat.quizzers — no per-team getTeamQuizzers calls', async () => {
+describe('useMeetSession — buildSlotFromSeat + applyLoadedQuiz', () => {
+  it('builds a slot from a pre-fetched seat without touching session state', async () => {
     const teamA = mockTeams[0]!
-    const teamB = mockTeams[1]!
-    vi.mocked(getScheduledQuiz).mockResolvedValueOnce(
-      makeQuizDetails({}, [
-        { seatNumber: 1, letter: 'A', seedRef: null, team: teamA, quizzers: mockQuizzers },
-        { seatNumber: 2, letter: 'B', seedRef: null, team: teamB, quizzers: mockQuizzers },
-      ]),
+    const { loadMeet, buildSlotFromSeat, getSlot } = useMeetSession()
+    await loadMeet(42, 'Finals')
+
+    const slot = buildSlotFromSeat(
+      { seatNumber: 1, letter: 'A', seedRef: null, team: teamA, quizzers: mockQuizzers },
+      emptyNames,
     )
-    const { loadFromQuiz, getSlot } = useMeetSession()
-    await loadFromQuiz(42, 777)
-    // assignTeam path would have called getTeamQuizzers once per team; the
-    // pre-fetched path must not.
-    expect(getTeamQuizzers).not.toHaveBeenCalled()
-    // Verify the roster actually landed in the slot.
-    expect(getSlot(0)?.quizzers[0]!.dbName).toBe('Alice')
+
+    expect(slot?.teamId).toBe(teamA.id)
+    expect(slot?.quizzers[0]!.dbName).toBe('Alice')
+    // Pure builder — session.slots[0] must still be unset.
+    expect(getSlot(0)).toBeUndefined()
+  })
+
+  it('returns undefined for unresolved seats (team: null)', async () => {
+    const { loadMeet, buildSlotFromSeat } = useMeetSession()
+    await loadMeet(42, 'Finals')
+
+    const slot = buildSlotFromSeat(
+      { seatNumber: 1, letter: null, seedRef: '1stA', team: null, quizzers: [] },
+      emptyNames,
+    )
+
+    expect(slot).toBeUndefined()
+  })
+
+  it('exact-match storeNames preserves seat positions', async () => {
+    const teamA = mockTeams[0]!
+    const { loadMeet, buildSlotFromSeat } = useMeetSession()
+    await loadMeet(42, 'Finals')
+
+    // Store has Bob in seat 0, Alice in seat 1 (reversed from DB order)
+    const slot = buildSlotFromSeat(
+      { seatNumber: 1, letter: 'A', seedRef: null, team: teamA, quizzers: mockQuizzers },
+      ['Bob', 'Alice', '', '', ''],
+    )
+
+    expect(slot?.quizzers[0]!.dbName).toBe('Bob')
+    expect(slot?.quizzers[1]!.dbName).toBe('Alice')
+  })
+
+  it('applyLoadedQuiz commits all 3 slots + quizId in one localStorage write', async () => {
+    const teamA = mockTeams[0]!
+    const { loadMeet, buildSlotFromSeat, applyLoadedQuiz, getSlot, quizId } = useMeetSession()
+    await loadMeet(42, 'Finals')
+
+    const seat = {
+      seatNumber: 1 as const,
+      letter: 'A',
+      seedRef: null,
+      team: teamA,
+      quizzers: mockQuizzers,
+    }
+    const slot = buildSlotFromSeat(seat, emptyNames)!
+    const writesBefore = localStorageWriteCount()
+    applyLoadedQuiz([slot, undefined, undefined], 555)
+    const writesAfter = localStorageWriteCount()
+
+    expect(writesAfter - writesBefore).toBe(1)
+    expect(getSlot(0)?.teamId).toBe(teamA.id)
+    expect(getSlot(1)).toBeUndefined()
+    expect(quizId.value).toBe(555)
   })
 })
 

--- a/apps/scoresheet/src/composables/__tests__/useMeetSession.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useMeetSession.spec.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { MeetTeam } from '../../api'
+import type { MeetTeam, ScheduledQuizDetails } from '../../api'
 
 // Mock the API module before importing useMeetSession
 vi.mock('../../api', () => ({
   getMeetTeams: vi.fn(),
   getTeamQuizzers: vi.fn(),
+  getScheduledQuiz: vi.fn(),
 }))
 
-import { getMeetTeams, getTeamQuizzers } from '../../api'
+import { getMeetTeams, getScheduledQuiz, getTeamQuizzers } from '../../api'
 import { useMeetSession } from '../useMeetSession'
 
 const mockTeams: MeetTeam[] = [
@@ -204,6 +205,98 @@ describe('useMeetSession — assignTeam', () => {
     expect(slot.quizzers[2]!.dbName).toBe('Charlie')
     expect(slot.quizzers[3]!.dbName).toBe('Dave')
     expect(slot.quizzers[4]!.dbName).toBe('')
+  })
+})
+
+describe('useMeetSession — loadFromQuiz', () => {
+  function makeQuizDetails(
+    overrides: Partial<ScheduledQuizDetails['quiz']> = {},
+    seats: ScheduledQuizDetails['seats'] = [],
+  ): ScheduledQuizDetails {
+    return {
+      quiz: {
+        id: 777,
+        meetId: 42,
+        slotId: 1,
+        roomId: 1,
+        division: '1',
+        phase: 'prelim',
+        lane: null,
+        label: 'D1-Q1',
+        bracketLabel: null,
+        slotStartAt: '2026-01-01T20:00:00.000Z',
+        roomName: 'Room A',
+        ...overrides,
+      },
+      seats,
+    }
+  }
+
+  it('assigns all 3 seats from a fully-resolved prelim quiz and stamps quizId', async () => {
+    const teamA = mockTeams[0]!
+    const teamB = mockTeams[1]!
+    const teamC: MeetTeam = {
+      id: 3,
+      churchId: 30,
+      churchName: 'Trinity Church',
+      churchShortName: 'TC',
+      division: '1',
+      number: 1,
+      consolation: false,
+    }
+    vi.mocked(getMeetTeams).mockResolvedValueOnce({
+      teams: [teamA, teamB, teamC],
+      meetDivisions: ['1'],
+    })
+    vi.mocked(getScheduledQuiz).mockResolvedValueOnce(
+      makeQuizDetails({}, [
+        { seatNumber: 1, letter: 'A', seedRef: null, team: teamA, quizzers: mockQuizzers },
+        { seatNumber: 2, letter: 'B', seedRef: null, team: teamB, quizzers: mockQuizzers },
+        { seatNumber: 3, letter: 'C', seedRef: null, team: teamC, quizzers: mockQuizzers },
+      ]),
+    )
+    const { loadFromQuiz, getSlot, quizId } = useMeetSession()
+    const result = await loadFromQuiz(42, 777, 'Finals', [emptyNames, emptyNames, emptyNames])
+
+    expect(result.quiz.id).toBe(777)
+    expect(getSlot(0)?.teamId).toBe(teamA.id)
+    expect(getSlot(1)?.teamId).toBe(teamB.id)
+    expect(getSlot(2)?.teamId).toBe(teamC.id)
+    expect(quizId.value).toBe(777)
+  })
+
+  it('leaves unresolved elim seats empty and assigns the rest', async () => {
+    const teamA = mockTeams[0]!
+    vi.mocked(getScheduledQuiz).mockResolvedValueOnce(
+      makeQuizDetails({ phase: 'elim', lane: 'main', bracketLabel: 'A', label: 'D1-QA' }, [
+        { seatNumber: 1, letter: null, seedRef: '1stA', team: teamA, quizzers: mockQuizzers },
+        { seatNumber: 2, letter: null, seedRef: '2ndA', team: null, quizzers: [] },
+        { seatNumber: 3, letter: null, seedRef: '1stB', team: null, quizzers: [] },
+      ]),
+    )
+    const { loadFromQuiz, getSlot } = useMeetSession()
+    await loadFromQuiz(42, 778, 'Finals', [emptyNames, emptyNames, emptyNames])
+
+    expect(getSlot(0)?.teamId).toBe(teamA.id)
+    expect(getSlot(1)).toBeUndefined()
+    expect(getSlot(2)).toBeUndefined()
+  })
+
+  it('persists quizId to localStorage', async () => {
+    vi.mocked(getScheduledQuiz).mockResolvedValueOnce(makeQuizDetails({}, []))
+    const { loadFromQuiz } = useMeetSession()
+    await loadFromQuiz(42, 999, 'Finals', [emptyNames, emptyNames, emptyNames])
+    const stored = JSON.parse(localStorage.getItem('qzr-meet-session')!)
+    expect(stored.quizId).toBe(999)
+  })
+
+  it('reuses an existing meet session without reloading the team list', async () => {
+    vi.mocked(getScheduledQuiz).mockResolvedValueOnce(makeQuizDetails({}, []))
+    const { loadMeet, loadFromQuiz } = useMeetSession()
+    await loadMeet(42, 'Finals')
+    vi.mocked(getMeetTeams).mockClear()
+    await loadFromQuiz(42, 777, 'Finals', [emptyNames, emptyNames, emptyNames])
+    expect(getMeetTeams).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
@@ -200,6 +200,7 @@ describe('useTutorial — meet link', () => {
       slots: [undefined, undefined, undefined],
       teamList: [],
       meetDivisions: ['1'],
+      quizId: null,
     })
     expect(meet.isActive.value).toBe(true)
 
@@ -233,6 +234,7 @@ describe('useTutorial — meet link', () => {
       slots: [undefined, undefined, undefined],
       teamList: [],
       meetDivisions: [],
+      quizId: null,
     })
 
     const s = useScoresheet()

--- a/apps/scoresheet/src/composables/useMeetList.ts
+++ b/apps/scoresheet/src/composables/useMeetList.ts
@@ -1,0 +1,104 @@
+import { ref } from 'vue'
+
+import { ApiError } from '@qzr/shared'
+
+import { getMyMeets, joinMeet, type MeetSummary } from '../api'
+import { initGuestSession, joinByCode, useGuestSession } from './useGuestSession'
+
+/**
+ * Shared logic for the "pick a meet" step used by both
+ * MeetPickerDialog and SchedulePickerDialog. Tracks the merged list of
+ * joined-guest meets and signed-in memberships, drives the "Have a
+ * code?" join flow, and exposes a flag for whether the last fetch saw
+ * a signed-in cookie session.
+ */
+export function useMeetList() {
+  const guest = useGuestSession()
+
+  const meets = ref<MeetSummary[]>([])
+  const loading = ref(false)
+  const error = ref('')
+  const joinCode = ref('')
+  const joinError = ref('')
+  const joining = ref(false)
+  const signedIn = ref(false)
+
+  async function fetchMeets() {
+    loading.value = true
+    error.value = ''
+    const seen = new Set<number>()
+    const list: MeetSummary[] = []
+    for (const j of guest.joinedMeets.value) {
+      list.push({ meetId: j.meetId, meetName: j.meetName, role: j.role })
+      seen.add(j.meetId)
+    }
+    try {
+      const res = await getMyMeets()
+      signedIn.value = true
+      for (const m of res.memberships) {
+        if (seen.has(m.meetId)) continue
+        seen.add(m.meetId)
+        list.push(m)
+      }
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 401) {
+        signedIn.value = false
+        if (list.length === 0) error.value = 'Not signed in.'
+      } else {
+        error.value = (e as Error).message
+      }
+    } finally {
+      meets.value = list
+      loading.value = false
+    }
+  }
+
+  /** Populate the meet list. Awaits the shared guest session init so
+   *  URL-shared guest meets are merged in before the first render. */
+  async function init() {
+    loading.value = true
+    await initGuestSession()
+    await fetchMeets()
+  }
+
+  async function handleJoinCode() {
+    const code = joinCode.value.trim()
+    if (!code) return
+    joining.value = true
+    joinError.value = ''
+    try {
+      if (signedIn.value) {
+        await joinMeet(code)
+      } else {
+        const data = await joinByCode(code)
+        if (!data) throw new Error('Invalid code.')
+      }
+      joinCode.value = ''
+      await fetchMeets()
+    } catch (e) {
+      joinError.value = (e as Error).message
+    } finally {
+      joining.value = false
+    }
+  }
+
+  /** Switches the active guest session (no-op for signed-in memberships)
+   *  so subsequent API requests target the picked meet's JWT. */
+  function setActiveGuest(meetId: number) {
+    guest.setActive(meetId)
+  }
+
+  return {
+    meets,
+    loading,
+    error,
+    joinCode,
+    joinError,
+    joining,
+    signedIn,
+    init,
+    fetchMeets,
+    handleJoinCode,
+    setActiveGuest,
+  }
+}

--- a/apps/scoresheet/src/composables/useMeetList.ts
+++ b/apps/scoresheet/src/composables/useMeetList.ts
@@ -95,7 +95,6 @@ export function useMeetList() {
     joinCode,
     joinError,
     joining,
-    signedIn,
     init,
     fetchMeets,
     handleJoinCode,

--- a/apps/scoresheet/src/composables/useMeetSession.ts
+++ b/apps/scoresheet/src/composables/useMeetSession.ts
@@ -5,6 +5,7 @@ import {
   getTeamQuizzers,
   type MeetTeam,
   type ScheduledQuizDetails,
+  type ScheduledQuizSeat,
 } from '../api'
 import { QUIZZERS_PER_TEAM } from '../types/scoresheet'
 
@@ -80,41 +81,47 @@ export function useMeetSession() {
   }
 
   /**
-   * Load a meet AND prefill the 3 team slots from a scheduled quiz.
-   * `storeNamesByTeamIdx` (optional) mirrors the per-slot store
-   * quizzer names so the levenshtein matcher in `matchQuizzers` can
-   * place edited names against the right roster entries. When
-   * omitted, every slot's names are treated as empty.
-   *
-   * Reuses `details.seats[i].quizzers` from the server response — no
-   * per-team `getTeamQuizzers` round-trips, no per-seat persist. The
-   * whole load is one network call + one localStorage write.
+   * Fetch a scheduled quiz's resolved seats. If the active session
+   * isn't already on this meet, also loads it. Does NOT populate
+   * slots or stamp quizId — the caller decides per-slot policy,
+   * builds the slot data via `buildSlotFromSeat`, and commits it
+   * all atomically through `applyLoadedQuiz`.
    */
-  async function loadFromQuiz(
-    meetId: number,
-    quizId: number,
-    storeNamesByTeamIdx?: string[][],
-  ): Promise<ScheduledQuizDetails> {
+  async function loadFromQuiz(meetId: number, quizId: number): Promise<ScheduledQuizDetails> {
     const details = await getScheduledQuiz(meetId, quizId)
     if (!session.value || session.value.meetId !== meetId) {
       await loadMeet(meetId, details.quiz.meetName)
     }
-    if (!session.value) return details
-    const slots: (SlotSession | undefined)[] = [undefined, undefined, undefined]
-    for (const seat of details.seats) {
-      const slotIdx = seat.seatNumber - 1
-      if (slotIdx < 0 || slotIdx > 2 || !seat.team) continue
-      const storeNames = storeNamesByTeamIdx?.[slotIdx] ?? Array<string>(QUIZZERS_PER_TEAM).fill('')
-      slots[slotIdx] = {
-        teamId: seat.team.id,
-        dbLabel: teamLabel(seat.team),
-        dbLabelFull: teamLabelFull(seat.team),
-        quizzers: matchQuizzers(storeNames, seat.quizzers),
-      }
+    return details
+  }
+
+  /**
+   * Pure builder: produces a `SlotSession` from a pre-fetched seat
+   * and matcher input. Returns undefined when the seat is
+   * unresolved (`team: null`). Does not mutate session state.
+   */
+  function buildSlotFromSeat(
+    seat: ScheduledQuizSeat,
+    storeNames: string[],
+  ): SlotSession | undefined {
+    if (!seat.team) return undefined
+    return {
+      teamId: seat.team.id,
+      dbLabel: teamLabel(seat.team),
+      dbLabelFull: teamLabelFull(seat.team),
+      quizzers: matchQuizzers(storeNames, seat.quizzers),
     }
+  }
+
+  /**
+   * Atomically commit a quiz load: replace the 3 slot assignments
+   * and stamp `quizId`. One reactivity tick, one `localStorage`
+   * write — vs. one per slot if callers used per-slot setters.
+   */
+  function applyLoadedQuiz(slots: (SlotSession | undefined)[], quizId: number): void {
+    if (!session.value) return
     session.value = { ...session.value, slots, quizId }
     persist()
-    return details
   }
 
   /** Assign a team to a slot and fetch its quizzers */
@@ -203,8 +210,15 @@ export function useMeetSession() {
   /** Re-fetch the team list (e.g. after a page restore, to pick up roster changes) */
   async function refresh(): Promise<void> {
     if (!session.value) return
+    // Capture meetId at call-time. Scoresheet.vue's onMounted fires
+    // refresh() and loadFromUrlParams() in parallel, so a concurrent
+    // loadMeet(B) can replace session.value while we await
+    // getMeetTeams(A). Only write back if the active meet hasn't
+    // changed — otherwise we'd clobber meet B's teamList with A's.
+    const capturedMeetId = session.value.meetId
     try {
-      const { teams, meetDivisions } = await getMeetTeams(session.value.meetId)
+      const { teams, meetDivisions } = await getMeetTeams(capturedMeetId)
+      if (!session.value || session.value.meetId !== capturedMeetId) return
       session.value = { ...session.value, teamList: teams, meetDivisions }
       persist()
     } catch {
@@ -224,6 +238,8 @@ export function useMeetSession() {
     teamLabelFull,
     loadMeet,
     loadFromQuiz,
+    buildSlotFromSeat,
+    applyLoadedQuiz,
     assignTeam,
     clearSlot,
     getSlot,

--- a/apps/scoresheet/src/composables/useMeetSession.ts
+++ b/apps/scoresheet/src/composables/useMeetSession.ts
@@ -1,5 +1,11 @@
 import { ref, computed } from 'vue'
-import { getMeetTeams, getTeamQuizzers, type MeetTeam } from '../api'
+import {
+  getMeetTeams,
+  getScheduledQuiz,
+  getTeamQuizzers,
+  type MeetTeam,
+  type ScheduledQuizDetails,
+} from '../api'
 import { QUIZZERS_PER_TEAM } from '../types/scoresheet'
 
 const STORAGE_KEY = 'qzr-meet-session'
@@ -21,6 +27,10 @@ export interface MeetSessionData {
   teamList: MeetTeam[]
   /** The meet's canonical division list, e.g. ["1", "2", "3"] */
   meetDivisions: string[]
+  /** Set when this session was loaded from a specific scheduled quiz
+   *  (via loadFromQuiz). Stamped onto submitted results in the future
+   *  Submit flow (#7) so they back-link to the schedule entry. */
+  quizId: number | null
 }
 
 const session = ref<MeetSessionData | null>(loadFromStorage())
@@ -29,6 +39,7 @@ export function useMeetSession() {
   const isActive = computed(() => session.value !== null)
   const meetName = computed(() => session.value?.meetName ?? null)
   const teamList = computed(() => session.value?.teamList ?? [])
+  const quizId = computed(() => session.value?.quizId ?? null)
 
   /** Division options for the scoresheet dropdown — the meet's canonical division list. */
   const divisionOptions = computed((): string[] => session.value?.meetDivisions ?? [])
@@ -62,8 +73,46 @@ export function useMeetSession() {
       slots: [undefined, undefined, undefined],
       teamList: teams,
       meetDivisions,
+      quizId: null,
     }
     persist()
+  }
+
+  /**
+   * Load a meet AND prefill the 3 team slots from a scheduled quiz.
+   * `meetName` is required when this opens a meet the user hasn't
+   * loaded before; pass the empty string to use the quiz's own
+   * source of truth (currently unused — the quiz response doesn't
+   * carry the meet name).
+   *
+   * `storeNamesByTeamIdx` mirrors the per-slot store quizzer names
+   * passed to `assignTeam`, so the levenshtein matcher in
+   * `matchQuizzers` can place edited names against the right roster
+   * entries.
+   */
+  async function loadFromQuiz(
+    meetId: number,
+    quizId: number,
+    meetName: string,
+    storeNamesByTeamIdx: string[][],
+  ): Promise<ScheduledQuizDetails> {
+    if (!session.value || session.value.meetId !== meetId) {
+      await loadMeet(meetId, meetName)
+    }
+    const details = await getScheduledQuiz(meetId, quizId)
+    for (const seat of details.seats) {
+      const slotIdx = seat.seatNumber - 1
+      if (slotIdx < 0 || slotIdx > 2) continue
+      if (!seat.team) continue
+      const storeNames =
+        storeNamesByTeamIdx[slotIdx] ?? (Array<string>(QUIZZERS_PER_TEAM).fill('') as string[])
+      await assignTeam(slotIdx, seat.team.id, storeNames)
+    }
+    if (session.value) {
+      session.value = { ...session.value, quizId }
+      persist()
+    }
+    return details
   }
 
   /** Assign a team to a slot and fetch its quizzers */
@@ -165,11 +214,13 @@ export function useMeetSession() {
     isActive,
     meetName,
     teamList,
+    quizId,
     divisionOptions,
     teamsForDivision,
     teamLabel,
     teamLabelFull,
     loadMeet,
+    loadFromQuiz,
     assignTeam,
     clearSlot,
     getSlot,
@@ -282,9 +333,10 @@ function loadFromStorage(): MeetSessionData | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return null
-    // meetDivisions may be absent in old sessions — default to empty array
     const data = JSON.parse(raw) as MeetSessionData
+    // Migrate fields added after old sessions were persisted.
     if (!data.meetDivisions) data.meetDivisions = []
+    if (data.quizId === undefined) data.quizId = null
     return data
   } catch {
     return null

--- a/apps/scoresheet/src/composables/useMeetSession.ts
+++ b/apps/scoresheet/src/composables/useMeetSession.ts
@@ -37,6 +37,7 @@ const session = ref<MeetSessionData | null>(loadFromStorage())
 
 export function useMeetSession() {
   const isActive = computed(() => session.value !== null)
+  const meetId = computed(() => session.value?.meetId ?? null)
   const meetName = computed(() => session.value?.meetName ?? null)
   const teamList = computed(() => session.value?.teamList ?? [])
   const quizId = computed(() => session.value?.quizId ?? null)
@@ -80,38 +81,39 @@ export function useMeetSession() {
 
   /**
    * Load a meet AND prefill the 3 team slots from a scheduled quiz.
-   * `meetName` is required when this opens a meet the user hasn't
-   * loaded before; pass the empty string to use the quiz's own
-   * source of truth (currently unused — the quiz response doesn't
-   * carry the meet name).
+   * `storeNamesByTeamIdx` (optional) mirrors the per-slot store
+   * quizzer names so the levenshtein matcher in `matchQuizzers` can
+   * place edited names against the right roster entries. When
+   * omitted, every slot's names are treated as empty.
    *
-   * `storeNamesByTeamIdx` mirrors the per-slot store quizzer names
-   * passed to `assignTeam`, so the levenshtein matcher in
-   * `matchQuizzers` can place edited names against the right roster
-   * entries.
+   * Reuses `details.seats[i].quizzers` from the server response — no
+   * per-team `getTeamQuizzers` round-trips, no per-seat persist. The
+   * whole load is one network call + one localStorage write.
    */
   async function loadFromQuiz(
     meetId: number,
     quizId: number,
-    meetName: string,
-    storeNamesByTeamIdx: string[][],
+    storeNamesByTeamIdx?: string[][],
   ): Promise<ScheduledQuizDetails> {
-    if (!session.value || session.value.meetId !== meetId) {
-      await loadMeet(meetId, meetName)
-    }
     const details = await getScheduledQuiz(meetId, quizId)
+    if (!session.value || session.value.meetId !== meetId) {
+      await loadMeet(meetId, details.quiz.meetName)
+    }
+    if (!session.value) return details
+    const slots: (SlotSession | undefined)[] = [undefined, undefined, undefined]
     for (const seat of details.seats) {
       const slotIdx = seat.seatNumber - 1
-      if (slotIdx < 0 || slotIdx > 2) continue
-      if (!seat.team) continue
-      const storeNames =
-        storeNamesByTeamIdx[slotIdx] ?? (Array<string>(QUIZZERS_PER_TEAM).fill('') as string[])
-      await assignTeam(slotIdx, seat.team.id, storeNames)
+      if (slotIdx < 0 || slotIdx > 2 || !seat.team) continue
+      const storeNames = storeNamesByTeamIdx?.[slotIdx] ?? Array<string>(QUIZZERS_PER_TEAM).fill('')
+      slots[slotIdx] = {
+        teamId: seat.team.id,
+        dbLabel: teamLabel(seat.team),
+        dbLabelFull: teamLabelFull(seat.team),
+        quizzers: matchQuizzers(storeNames, seat.quizzers),
+      }
     }
-    if (session.value) {
-      session.value = { ...session.value, quizId }
-      persist()
-    }
+    session.value = { ...session.value, slots, quizId }
+    persist()
     return details
   }
 
@@ -212,6 +214,7 @@ export function useMeetSession() {
 
   return {
     isActive,
+    meetId,
     meetName,
     teamList,
     quizId,

--- a/apps/scoresheet/src/quizMeta.ts
+++ b/apps/scoresheet/src/quizMeta.ts
@@ -1,0 +1,31 @@
+/**
+ * Helpers for deriving scoresheet quiz-meta fields (division, quiz
+ * number, consolation flag) from a scheduled quiz row.
+ */
+
+export interface ScheduledQuizMetaInput {
+  phase: 'prelim' | 'elim'
+  lane: 'main' | 'consolation' | 'intermediate' | null
+  label: string
+  bracketLabel: string | null
+}
+
+/**
+ * Best-effort quiz-number extraction. Elim quizzes carry their letter
+ * in `bracketLabel` (e.g. 'A', 'D', 'X'). Prelim quizzes follow the
+ * `D{div}-Q{n}` label convention from commit 457394a; pull the token
+ * after the last 'Q'. Hand-edited labels fall through to the raw
+ * label so the user at least sees what they typed.
+ */
+export function quizNumberFromScheduledQuiz(q: ScheduledQuizMetaInput): string {
+  if (q.bracketLabel) return q.bracketLabel
+  const m = q.label.match(/Q([^\s]+)$/)
+  if (m) return m[1]!
+  return q.label
+}
+
+/** Consolation lanes flip the scoresheet's consolation flag so the
+ *  team-picker dropdown filters down to the consolation-bracket teams. */
+export function consolationFromScheduledQuiz(q: { lane: ScheduledQuizMetaInput['lane'] }): boolean {
+  return q.lane === 'consolation'
+}

--- a/apps/web/src/components/schedule/ReviewSection.vue
+++ b/apps/web/src/components/schedule/ReviewSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue'
 
+import { ScheduleGrid, formatSlotTime, sortedSeats } from '@qzr/ui'
 import {
   type MeetRoom,
   type MeetSlot,
@@ -9,14 +10,6 @@ import {
   type ScheduledQuiz,
   type SeatInput,
 } from '../../api'
-import {
-  buildGrid,
-  formatSlotTime,
-  hasAnyQuiz,
-  seatRef,
-  seatTeam,
-  sortedSeats,
-} from '../../scheduleGrid'
 import TimePickerButton from './TimePickerButton.vue'
 
 interface PickerTime {
@@ -122,46 +115,6 @@ function onRoll() {
 function onSortLateness() {
   if (!confirmOverwrite('Sorting by lateness')) return
   emit('sort-by-lateness')
-}
-
-const grid = computed(() => buildGrid(props.rooms, props.slots, props.quizzes, null))
-const empty = computed(() => !hasAnyQuiz(grid.value))
-
-/** Group grid rows by their slot's local date so the template can break
- *  the schedule into "Friday, May 15 / Saturday, May 16 / …" sections,
- *  matching the day grouping the Skeleton tab uses. */
-interface DayGroup {
-  dateKey: string
-  label: string
-  rows: typeof grid.value.rows
-}
-const days = computed<DayGroup[]>(() => {
-  const map = new Map<string, DayGroup>()
-  for (const row of grid.value.rows) {
-    const d = new Date(row.slot.startAt)
-    if (Number.isNaN(d.getTime())) continue
-    const key = dateKey(d)
-    let group = map.get(key)
-    if (!group) {
-      group = { dateKey: key, label: dayLabel(d), rows: [] }
-      map.set(key, group)
-    }
-    group.rows.push(row)
-  }
-  return Array.from(map.values())
-})
-
-function dateKey(d: Date): string {
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
-}
-
-function dayLabel(d: Date): string {
-  return d.toLocaleDateString(undefined, {
-    weekday: 'long',
-    month: 'short',
-    day: 'numeric',
-  })
 }
 
 function slotTimeModel(iso: string): PickerTime {
@@ -379,122 +332,71 @@ function saveEdit() {
       </article>
     </div>
 
-    <p v-if="rooms.length === 0" class="empty">No rooms have been added to this meet yet.</p>
-    <p v-else-if="empty" class="empty">No quizzes scheduled yet. Add slots and quizzes to begin.</p>
+    <ScheduleGrid
+      :rooms="rooms"
+      :slots="slots"
+      :quizzes="quizzes"
+      :prelim-assignments="prelimAssignments"
+      :meet-teams="meetTeams"
+      empty-message="No quizzes scheduled yet. Add slots and quizzes to begin."
+    >
+      <template #time-cell="{ gridSlot }">
+        <TimePickerButton
+          v-if="editable"
+          :model-value="slotTimeModel(gridSlot.startAt)"
+          :title="`Change time for ${formatSlotTime(gridSlot.startAt)}`"
+          @update:model-value="onSlotTimeChange(gridSlot as MeetSlot, $event)"
+        >
+          {{ formatSlotTime(gridSlot.startAt) }}
+        </TimePickerButton>
+        <template v-else>{{ formatSlotTime(gridSlot.startAt) }}</template>
+      </template>
 
-    <div v-else class="schedule-scroll">
-      <table class="schedule-table">
-        <thead>
-          <tr>
-            <th class="time-col" scope="col">Time</th>
-            <th
-              v-for="room in grid.rooms"
-              :key="room.id"
-              :data-room-id="room.id"
-              class="room-col"
-              scope="col"
-            >
-              {{ room.name }}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <template v-for="group in days" :key="group.dateKey">
-            <tr class="day-row">
-              <th class="day-label" :colspan="grid.rooms.length + 1" scope="colgroup">
-                {{ group.label }}
-              </th>
-            </tr>
-            <tr
-              v-for="row in group.rows"
-              :key="row.slot.id"
-              :class="{ 'event-row': row.slot.kind === 'event' }"
-            >
-              <th class="time-col" scope="row">
-                <TimePickerButton
-                  v-if="editable"
-                  :model-value="slotTimeModel(row.slot.startAt)"
-                  :title="`Change time for ${formatSlotTime(row.slot.startAt)}`"
-                  @update:model-value="onSlotTimeChange(row.slot, $event)"
-                >
-                  {{ formatSlotTime(row.slot.startAt) }}
-                </TimePickerButton>
-                <template v-else>{{ formatSlotTime(row.slot.startAt) }}</template>
-              </th>
-              <td v-if="row.slot.kind === 'event'" class="event-cell" :colspan="grid.rooms.length">
-                <span class="event-label">{{ row.slot.eventLabel || 'Event' }}</span>
-              </td>
-              <template v-else>
-                <td
-                  v-for="(quiz, i) in row.cells"
-                  :key="grid.rooms[i]!.id"
-                  class="quiz-cell"
-                  :class="{ 'quiz-cell--empty': !quiz, 'quiz-cell--editable': editable }"
-                >
-                  <article v-if="quiz" class="quiz" :data-quiz-id="quiz.id">
-                    <header class="quiz-head">
-                      <button
-                        v-if="editable"
-                        type="button"
-                        class="quiz-label-btn"
-                        :title="`Edit ${quiz.label}`"
-                        @click="openEditDialog(row.slot, grid.rooms[i]!, quiz)"
-                      >
-                        {{ quiz.label }}
-                      </button>
-                      <a
-                        v-else-if="scoresheetHref"
-                        :href="scoresheetHref(quiz.id)"
-                        class="quiz-label quiz-label--link"
-                        :title="`Open ${quiz.label} in the scoresheet`"
-                      >
-                        {{ quiz.label }}
-                      </a>
-                      <span v-else class="quiz-label">{{ quiz.label }}</span>
-                      <button
-                        v-if="editable"
-                        type="button"
-                        class="quiz-delete no-print"
-                        :title="`Delete ${quiz.label}`"
-                        @click="onDeleteQuiz(quiz)"
-                      >
-                        ×
-                      </button>
-                    </header>
-                    <ol class="seat-list">
-                      <li
-                        v-for="seat in sortedSeats(quiz.seats)"
-                        :key="seat.id"
-                        class="seat"
-                        :data-seat-letter="seat.letter || undefined"
-                      >
-                        <span class="seat-ref">{{ seatRef(seat) }}</span>
-                        <span class="seat-team">{{
-                          seatTeam(seat, {
-                            division: quiz.division,
-                            assignments: prelimAssignments ?? [],
-                            teams: meetTeams ?? [],
-                          })
-                        }}</span>
-                      </li>
-                    </ol>
-                  </article>
-                  <button
-                    v-else-if="editable"
-                    type="button"
-                    class="quiz-add no-print"
-                    :title="`Add quiz at ${formatSlotTime(row.slot.startAt)} in ${grid.rooms[i]!.name}`"
-                    @click="openEditDialog(row.slot, grid.rooms[i]!, null)"
-                  >
-                    +
-                  </button>
-                </td>
-              </template>
-            </tr>
-          </template>
-        </tbody>
-      </table>
-    </div>
+      <template #quiz-label="{ quiz, gridSlot, room }">
+        <button
+          v-if="editable"
+          type="button"
+          class="quiz-label-btn"
+          :title="`Edit ${quiz.label}`"
+          @click="openEditDialog(gridSlot as MeetSlot, room as MeetRoom, quiz as ScheduledQuiz)"
+        >
+          {{ quiz.label }}
+        </button>
+        <a
+          v-else-if="scoresheetHref"
+          :href="scoresheetHref(quiz.id)"
+          class="quiz-label quiz-label--link"
+          :title="`Open ${quiz.label} in the scoresheet`"
+        >
+          {{ quiz.label }}
+        </a>
+        <span v-else class="quiz-label">{{ quiz.label }}</span>
+      </template>
+
+      <template #cell-actions="{ quiz }">
+        <button
+          v-if="editable"
+          type="button"
+          class="quiz-delete no-print"
+          :title="`Delete ${quiz.label}`"
+          @click="onDeleteQuiz(quiz as ScheduledQuiz)"
+        >
+          ×
+        </button>
+      </template>
+
+      <template #empty-cell="{ gridSlot, room }">
+        <button
+          v-if="editable"
+          type="button"
+          class="quiz-add no-print"
+          :title="`Add quiz at ${formatSlotTime(gridSlot.startAt)} in ${room.name}`"
+          @click="openEditDialog(gridSlot as MeetSlot, room as MeetRoom, null)"
+        >
+          +
+        </button>
+      </template>
+    </ScheduleGrid>
 
     <div v-if="editingCell" class="edit-overlay no-print" @click.self="closeEditDialog">
       <form class="edit-form" @submit.prevent="saveEdit">
@@ -723,122 +625,9 @@ function saveEdit() {
   border-color: var(--color-accent-hover);
 }
 
-.empty {
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-  margin: 0;
-}
-
-.schedule-scroll {
-  overflow-x: auto;
-  border: 1px solid var(--color-border-alt);
-  border-radius: 6px;
-}
-
-.schedule-table {
-  border-collapse: collapse;
-  width: 100%;
-  font-size: 0.78rem;
-  table-layout: fixed;
-}
-
-/* No padding/text-align on the parent rule — per-column class rules
-   below would lose the cascade ((0,1,0) vs (0,1,1)) and silently do
-   nothing. Each column class sets its own. */
-.schedule-table th,
-.schedule-table td {
-  border: 1px solid var(--color-border-alt);
-  vertical-align: top;
-}
-
-thead th {
-  background: var(--color-bg-raised);
-  color: var(--color-text-faint);
-  font-weight: 700;
-  font-size: 0.7rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  padding: 0.5rem 0.875rem;
-  text-align: center;
-}
-
-.time-col {
-  width: 7rem;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-  background: var(--color-bg);
-  padding: 0.55rem 0.875rem;
-  text-align: center;
-  position: sticky;
-  left: 0;
-  z-index: 1;
-}
-
-/* Body-only — keep header (.time-col in thead) faint/uppercase via thead th. */
-tbody .time-col {
-  font-weight: 500;
-  color: var(--color-text-muted);
-}
-
-thead .time-col {
-  background: var(--color-bg-raised);
-}
-
-.room-col {
-  min-width: 6.5rem;
-  font-weight: 600;
-  font-size: 0.78rem;
-  color: var(--color-text);
-  padding: 0.5rem 0.875rem;
-  text-align: center;
-}
-
-.day-row .day-label {
-  background: var(--color-bg-warm);
-  color: var(--color-text-muted);
-  font-weight: 700;
-  font-size: 0.72rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  padding: 0.45rem 0.875rem;
-  text-align: left;
-}
-
-.event-row .event-cell {
-  background: var(--color-bg-warm);
-  text-align: center;
-  padding: 0.55rem 0.6rem;
-}
-
-.event-label {
-  font-style: italic;
-  font-weight: 400;
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-}
-
-.quiz-cell {
-  min-width: 6.5rem;
-}
-
-.quiz-cell--empty {
-  background: transparent;
-}
-
-.quiz {
-  display: flex;
-  flex-direction: column;
-}
-
-.quiz-head {
-  position: relative;
-  font-weight: 600;
-  font-size: 0.78rem;
-  text-align: center;
-  padding: 0.3rem 0.4rem 0.25rem;
-  border-bottom: 1px solid var(--color-border-alt);
-  color: var(--color-text);
-}
+/* Slot-content styles below: rendered by this component into <ScheduleGrid>'s
+   slots, so they inherit this component's scoped attribute and need to live
+   here. Grid/cell skeleton styles moved to packages/ui/src/ScheduleGrid.vue. */
 
 .quiz-label-btn {
   background: none;
@@ -879,11 +668,12 @@ thead .time-col {
   font-size: 1.1rem;
   color: var(--color-text-faint);
   cursor: pointer;
-  opacity: 0;
+  /* Cell-hover reveal via the cascading custom property defined on
+     .schedule-grid-cell in @qzr/ui ScheduleGrid. */
+  opacity: var(--schedule-grid-action-opacity, 0);
   transition: opacity 100ms ease;
 }
 
-.quiz-cell--editable:hover .quiz-add,
 .quiz-add:focus-visible {
   opacity: 1;
   color: var(--color-accent);
@@ -902,11 +692,10 @@ thead .time-col {
   cursor: pointer;
   padding: 0.1rem 0.25rem;
   border-radius: 3px;
-  opacity: 0;
+  opacity: var(--schedule-grid-action-opacity, 0);
   transition: opacity 100ms ease;
 }
 
-.quiz:hover .quiz-delete,
 .quiz-delete:focus-visible {
   opacity: 1;
 }
@@ -914,38 +703,6 @@ thead .time-col {
 .quiz-delete:hover {
   color: var(--palette-error);
   background: var(--color-bg);
-}
-
-.seat-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.seat {
-  display: grid;
-  grid-template-columns: minmax(0, 1.6rem) minmax(0, 1fr);
-  gap: 0.4rem;
-  align-items: baseline;
-  padding: 0.18rem 0.45rem;
-  border-top: 1px dotted var(--color-border-alt);
-  font-variant-numeric: tabular-nums;
-}
-
-.seat:first-child {
-  border-top: none;
-}
-
-.seat-ref {
-  color: var(--color-text-muted);
-  font-weight: 500;
-}
-
-.seat-team {
-  color: var(--color-text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 /* Inline modal for the quiz add/edit form. Centered overlay with a

--- a/apps/web/src/components/schedule/ReviewSection.vue
+++ b/apps/web/src/components/schedule/ReviewSection.vue
@@ -83,6 +83,11 @@ const props = defineProps<{
    *  resolved team names instead of `—`. */
   prelimAssignments?: PrelimAssignment[]
   meetTeams?: MeetTeamRow[]
+  /** Builds the scoresheet URL for a given quiz. When set AND
+   *  editable is false, each quiz cell's label becomes a link to
+   *  this href so users can open the scoresheet pre-filled with
+   *  that scheduled quiz (issue #6). */
+  scoresheetHref?: (quizId: number) => string
 }>()
 
 const emit = defineEmits<{
@@ -437,6 +442,14 @@ function saveEdit() {
                       >
                         {{ quiz.label }}
                       </button>
+                      <a
+                        v-else-if="scoresheetHref"
+                        :href="scoresheetHref(quiz.id)"
+                        class="quiz-label quiz-label--link"
+                        :title="`Open ${quiz.label} in the scoresheet`"
+                      >
+                        {{ quiz.label }}
+                      </a>
                       <span v-else class="quiz-label">{{ quiz.label }}</span>
                       <button
                         v-if="editable"
@@ -841,6 +854,16 @@ thead .time-col {
 
 .quiz-label-btn:hover {
   color: var(--color-accent);
+}
+
+.quiz-label--link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.quiz-label--link:hover {
+  color: var(--color-accent);
+  text-decoration: underline;
 }
 
 .quiz-add {

--- a/apps/web/src/scheduleGrid.ts
+++ b/apps/web/src/scheduleGrid.ts
@@ -1,112 +1,29 @@
-import type { MeetRoom, MeetSlot, ScheduledQuiz, ScheduledQuizSeat } from './api'
-
-/** Reserved event-label that marks the schedule's prelim/elim divider.
- *  Stats break is required for Populate to know where prelim quizzes
- *  end and elim quizzes begin; Skeleton treats it as un-deletable
- *  without an extra confirmation. */
-export const STATS_BREAK_LABEL = 'Stats break'
-
-export function isStatsBreak(slot: MeetSlot): boolean {
-  return slot.kind === 'event' && slot.eventLabel === STATS_BREAK_LABEL
-}
-
-export interface GridRow {
-  slot: MeetSlot
-  /** Quiz at each room column (same order as `Grid.rooms`). null = empty cell.
-   *  Always empty for event slots — the renderer spans those across columns. */
-  cells: (ScheduledQuiz | null)[]
-}
-
-export interface Grid {
-  rooms: MeetRoom[]
-  rows: GridRow[]
-}
-
 /**
- * Build the schedule grid: rooms sorted by sortOrder then id (column order),
- * slots sorted by sortOrder then id (row order), each quiz placed at its
- * (slot, room) cell. `divisionFilter` drops off-division quizzes to null
- * cells but keeps every slot row so empty rooms are still visible.
+ * Schedule-grid helpers and types moved to `@qzr/ui` so the scoresheet
+ * picker can render the same grid as the portal viewer. This file
+ * re-exports for source compatibility — prefer importing from
+ * `@qzr/ui` directly in new code.
  */
-export function buildGrid(
-  rooms: MeetRoom[],
-  slots: MeetSlot[],
-  quizzes: ScheduledQuiz[],
-  divisionFilter: string | null,
-): Grid {
-  const sortedRooms = [...rooms].sort(bySortOrder)
-  const sortedSlots = [...slots].sort(bySortOrder)
-
-  const byCell = new Map<number, Map<number, ScheduledQuiz>>()
-  for (const q of quizzes) {
-    if (divisionFilter !== null && q.division !== divisionFilter) continue
-    let perSlot = byCell.get(q.slotId)
-    if (!perSlot) {
-      perSlot = new Map()
-      byCell.set(q.slotId, perSlot)
-    }
-    perSlot.set(q.roomId, q)
-  }
-
-  const rows: GridRow[] = sortedSlots.map((slot) => {
-    if (slot.kind === 'event') return { slot, cells: [] }
-    const perSlot = byCell.get(slot.id)
-    return {
-      slot,
-      cells: sortedRooms.map((r) => perSlot?.get(r.id) ?? null),
-    }
-  })
-
-  return { rooms: sortedRooms, rows }
-}
-
-export function hasAnyQuiz(grid: Grid): boolean {
-  return grid.rows.some((r) => r.cells.some((c) => c !== null))
-}
-
-/** "8:00 AM" — local-time hh:mm; `startAt` is an ISO string from the API. */
-export function formatSlotTime(startAt: string): string {
-  const d = new Date(startAt)
-  if (Number.isNaN(d.getTime())) return ''
-  return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
-}
-
-/** Comparator for sorting slots and rooms by their canonical position. */
-export function bySortOrder<T extends { sortOrder: number; id: number }>(a: T, b: T): number {
-  return a.sortOrder - b.sortOrder || a.id - b.id
-}
-
-/** Letter for prelim seats, seedRef for elim seats. The canonical seat
- *  identifier shown in letter mode. */
-export function seatRef(seat: ScheduledQuizSeat): string {
-  return seat.letter ?? seat.seedRef ?? ''
-}
-
-/** Seats ordered by seatNumber. Server doesn't guarantee order. */
-export function sortedSeats(seats: ReadonlyArray<ScheduledQuizSeat>): ScheduledQuizSeat[] {
-  return [...seats].sort((a, b) => a.seatNumber - b.seatNumber)
-}
-
-/** Resolved team name for a seat: looks up the seat's letter in the
- *  prelim assignments table, then renders the matching team's
- *  `{shortName} {number}`. Returns `—` until Roll Teams has run for
- *  this division (or for elim seats, which seed lazily via seedRefs).
- *
- *  Prelim assignments and the team list are passed in rather than
- *  imported, so this stays pure and consumers (V1 grid, V2 review)
- *  can both call it. */
-export function seatTeam(
-  seat: ScheduledQuizSeat,
-  ctx: {
-    division: string
-    assignments: ReadonlyArray<{ division: string; letter: string; teamId: number }>
-    teams: ReadonlyArray<{ id: number; churchShortName: string; number: number }>
-  },
-): string {
-  if (!seat.letter) return '—'
-  const a = ctx.assignments.find((x) => x.division === ctx.division && x.letter === seat.letter)
-  if (!a) return '—'
-  const t = ctx.teams.find((tm) => tm.id === a.teamId)
-  if (!t) return '—'
-  return `${t.churchShortName} ${t.number}`
-}
+export {
+  STATS_BREAK_LABEL,
+  buildGrid,
+  bySortOrder,
+  formatSlotTime,
+  groupRowsByDay,
+  hasAnyQuiz,
+  isStatsBreak,
+  seatRef,
+  seatTeam,
+  sortedSeats,
+} from '@qzr/ui'
+export type {
+  DayGroup,
+  Grid,
+  GridRow,
+  MeetTeamRow as MeetTeamGridRow,
+  PrelimAssignmentRow as PrelimAssignmentGridRow,
+  ScheduleRoom,
+  ScheduleSlot,
+  ScheduledQuiz as GridScheduledQuiz,
+  ScheduledSeat,
+} from '@qzr/ui'

--- a/apps/web/src/views/ScheduleView.vue
+++ b/apps/web/src/views/ScheduleView.vue
@@ -22,6 +22,14 @@ const {
   load,
 } = useScheduleData(toRef(props, 'slug'))
 
+/** Build the scoresheet URL for a given quiz cell. The scoresheet
+ *  is bundled under /scoresheet/ by the build:all step that copies
+ *  apps/scoresheet/dist into apps/web/dist, so a same-origin link
+ *  inherits cookie sessions + guest tokens automatically. */
+function scoresheetHref(quizId: number): string {
+  return meet.value ? `/scoresheet/?meet=${meet.value.id}&quiz=${quizId}` : '#'
+}
+
 onMounted(load)
 </script>
 
@@ -59,6 +67,7 @@ onMounted(load)
         :quizzes="quizzes"
         :prelim-assignments="prelimAssignments"
         :meet-teams="teams"
+        :scoresheet-href="scoresheetHref"
       />
     </template>
   </div>

--- a/apps/web/src/views/ScheduleView.vue
+++ b/apps/web/src/views/ScheduleView.vue
@@ -8,6 +8,8 @@ import { useScheduleData } from '../composables/useScheduleData'
 const props = defineProps<{ slug: string }>()
 const router = useRouter()
 
+declare const __SCORESHEET_URL__: string
+
 const {
   rooms,
   slots,
@@ -22,12 +24,14 @@ const {
   load,
 } = useScheduleData(toRef(props, 'slug'))
 
-/** Build the scoresheet URL for a given quiz cell. The scoresheet
- *  is bundled under /scoresheet/ by the build:all step that copies
- *  apps/scoresheet/dist into apps/web/dist, so a same-origin link
- *  inherits cookie sessions + guest tokens automatically. */
+/** Build the scoresheet URL for a given quiz cell. Vite injects
+ *  __SCORESHEET_URL__ as '/scoresheet/' in prod (same-origin bundle
+ *  via build:all) and 'http://localhost:5173' in dev (the scoresheet
+ *  Vite server). */
 function scoresheetHref(quizId: number): string {
-  return meet.value ? `/scoresheet/?meet=${meet.value.id}&quiz=${quizId}` : '#'
+  if (!meet.value) return '#'
+  const base = __SCORESHEET_URL__.replace(/\/$/, '')
+  return `${base}/?meet=${meet.value.id}&quiz=${quizId}`
 }
 
 onMounted(load)

--- a/packages/api/src/routes/__tests__/schedule.spec.ts
+++ b/packages/api/src/routes/__tests__/schedule.spec.ts
@@ -559,3 +559,184 @@ describe('POST /api/meets/:id/schedule/sync', () => {
     expect(body.teams.find((t) => t.id === t1.id)!.lateness).toBe(true)
   })
 })
+
+describe('GET /api/meets/:id/quizzes/:quizId/teams', () => {
+  let db: Db
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(async () => {
+    db = await createTestDb()
+    app = createApp(testSuperuser, db)
+  })
+
+  async function seedChurchTeams(meetId: number) {
+    const [church] = await db
+      .insert(schema.churches)
+      .values({ meetId, name: 'Grace Church', shortName: 'Grace', coachCodeHash: 'x' })
+      .returning()
+    const teams = await db
+      .insert(schema.teams)
+      .values([
+        { meetId, churchId: church!.id, division: '1', number: 1 },
+        { meetId, churchId: church!.id, division: '1', number: 2 },
+        { meetId, churchId: church!.id, division: '1', number: 3 },
+      ])
+      .returning()
+    for (const team of teams) {
+      const identities = await db.insert(schema.quizzerIdentities).values([{}, {}, {}]).returning()
+      await db.insert(schema.teamRosters).values([
+        { teamId: team.id, quizzerId: identities[0]!.id, name: `${team.number}-Alice` },
+        { teamId: team.id, quizzerId: identities[1]!.id, name: `${team.number}-Bob` },
+        { teamId: team.id, quizzerId: identities[2]!.id, name: `${team.number}-Carol` },
+      ])
+    }
+    return { church: church!, teams }
+  }
+
+  async function seedQuizWithSeats(
+    meetId: number,
+    slotId: number,
+    roomId: number,
+    seats: { seatNumber: number; letter?: string; seedRef?: string }[],
+    overrides: Partial<typeof schema.scheduledQuizzes.$inferInsert> = {},
+  ) {
+    const [quiz] = await db
+      .insert(schema.scheduledQuizzes)
+      .values({
+        meetId,
+        slotId,
+        roomId,
+        division: '1',
+        phase: 'prelim',
+        label: 'D1-Q1',
+        ...overrides,
+      })
+      .returning()
+    await db.insert(schema.scheduledQuizSeats).values(
+      seats.map((s) => ({
+        quizId: quiz!.id,
+        seatNumber: s.seatNumber,
+        letter: s.letter ?? null,
+        seedRef: s.seedRef ?? null,
+      })),
+    )
+    return quiz!
+  }
+
+  it('returns 3 resolved teams + rosters for a prelim quiz', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Room A')
+    const slot = await seedSlot(db, meet.id)
+    const { teams } = await seedChurchTeams(meet.id)
+    const now = new Date()
+    await db.insert(schema.prelimAssignments).values([
+      { meetId: meet.id, division: '1', letter: 'A', teamId: teams[0]!.id, assignedAt: now },
+      { meetId: meet.id, division: '1', letter: 'B', teamId: teams[1]!.id, assignedAt: now },
+      { meetId: meet.id, division: '1', letter: 'C', teamId: teams[2]!.id, assignedAt: now },
+    ])
+    const quiz = await seedQuizWithSeats(meet.id, slot.id, room.id, [
+      { seatNumber: 1, letter: 'A' },
+      { seatNumber: 2, letter: 'B' },
+      { seatNumber: 3, letter: 'C' },
+    ])
+
+    const res = await app.request(`/api/meets/${meet.id}/quizzes/${quiz.id}/teams`, {}, env)
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{
+      quiz: { id: number; division: string; phase: string; label: string; roomName: string }
+      seats: Array<{
+        seatNumber: number
+        letter: string | null
+        seedRef: string | null
+        team: { id: number; churchShortName: string; number: number } | null
+        quizzers: Array<{ name: string }>
+      }>
+    }>(res)
+
+    expect(body.quiz.id).toBe(quiz.id)
+    expect(body.quiz.division).toBe('1')
+    expect(body.quiz.phase).toBe('prelim')
+    expect(body.quiz.label).toBe('D1-Q1')
+    expect(body.quiz.roomName).toBe('Room A')
+    expect(body.seats).toHaveLength(3)
+    expect(body.seats.map((s) => s.seatNumber)).toEqual([1, 2, 3])
+    expect(body.seats[0]!.team!.id).toBe(teams[0]!.id)
+    expect(body.seats[0]!.team!.churchShortName).toBe('Grace')
+    expect(body.seats[0]!.quizzers.map((q) => q.name)).toEqual(['1-Alice', '1-Bob', '1-Carol'])
+    expect(body.seats[2]!.team!.number).toBe(3)
+  })
+
+  it('returns team: null + quizzers: [] for unresolved elim seedRefs', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Room A')
+    const slot = await seedSlot(db, meet.id)
+    const { teams } = await seedChurchTeams(meet.id)
+    const now = new Date()
+    await db.insert(schema.seedResolutions).values([
+      { meetId: meet.id, seedRef: '1stA', teamId: teams[0]!.id, resolvedAt: now },
+      // '2ndA' and '1stB' deliberately unresolved
+    ])
+    const quiz = await seedQuizWithSeats(
+      meet.id,
+      slot.id,
+      room.id,
+      [
+        { seatNumber: 1, seedRef: '1stA' },
+        { seatNumber: 2, seedRef: '2ndA' },
+        { seatNumber: 3, seedRef: '1stB' },
+      ],
+      { phase: 'elim', lane: 'main', label: 'D1-QA', bracketLabel: 'A' },
+    )
+
+    const res = await app.request(`/api/meets/${meet.id}/quizzes/${quiz.id}/teams`, {}, env)
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{
+      quiz: { phase: string; lane: string | null; bracketLabel: string | null }
+      seats: Array<{
+        seedRef: string | null
+        team: { id: number } | null
+        quizzers: Array<{ name: string }>
+      }>
+    }>(res)
+
+    expect(body.quiz.phase).toBe('elim')
+    expect(body.quiz.lane).toBe('main')
+    expect(body.quiz.bracketLabel).toBe('A')
+    expect(body.seats[0]!.team!.id).toBe(teams[0]!.id)
+    expect(body.seats[0]!.quizzers).toHaveLength(3)
+    expect(body.seats[1]!.team).toBeNull()
+    expect(body.seats[1]!.quizzers).toEqual([])
+    expect(body.seats[2]!.team).toBeNull()
+  })
+
+  it('404s when the quiz belongs to a different meet', async () => {
+    const meetA = await seedMeet(db, 'Meet A')
+    const meetB = await seedMeet(db, 'Meet B')
+    const roomA = await seedRoom(db, meetA.id, 'Room A')
+    const slotA = await seedSlot(db, meetA.id)
+    const quiz = await seedQuizWithSeats(meetA.id, slotA.id, roomA.id, [
+      { seatNumber: 1, letter: 'A' },
+    ])
+
+    const res = await app.request(`/api/meets/${meetB.id}/quizzes/${quiz.id}/teams`, {}, env)
+    expect(res.status).toBe(404)
+  })
+
+  it('404s when the quiz does not exist', async () => {
+    const meet = await seedMeet(db)
+    const res = await app.request(`/api/meets/${meet.id}/quizzes/99999/teams`, {}, env)
+    expect(res.status).toBe(404)
+  })
+
+  it('401s when not signed in', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Room A')
+    const slot = await seedSlot(db, meet.id)
+    const quiz = await seedQuizWithSeats(meet.id, slot.id, room.id, [
+      { seatNumber: 1, letter: 'A' },
+    ])
+    const anonApp = createApp(null, db)
+    const res = await anonApp.request(`/api/meets/${meet.id}/quizzes/${quiz.id}/teams`, {}, env)
+    expect(res.status).toBe(401)
+  })
+})

--- a/packages/api/src/routes/__tests__/schedule.spec.ts
+++ b/packages/api/src/routes/__tests__/schedule.spec.ts
@@ -558,6 +558,53 @@ describe('POST /api/meets/:id/schedule/sync', () => {
     expect(body.prelimAssignments).toHaveLength(1)
     expect(body.teams.find((t) => t.id === t1.id)!.lateness).toBe(true)
   })
+
+  it('chunks large quiz + seat inserts under D1 param cap', async () => {
+    // Regression: pre-fix, a single .insert().values(rows) statement
+    // exceeded D1's bound-parameter cap once a real-meet Populate
+    // generated ~80+ quizzes. 100 here is well above the legacy cap.
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Room A')
+    const QUIZ_COUNT = 100
+    const slots: object[] = []
+    const quizzes: object[] = []
+    for (let i = 0; i < QUIZ_COUNT; i++) {
+      slots.push({
+        id: -(i + 1),
+        startAt: new Date(2026, 0, 1, 8 + i, 0, 0).toISOString(),
+        durationMinutes: 25,
+        kind: 'quiz',
+        eventLabel: null,
+        sortOrder: i,
+      })
+      quizzes.push({
+        id: -(QUIZ_COUNT + i + 1),
+        slotId: -(i + 1),
+        roomId: room.id,
+        division: '1',
+        phase: 'prelim',
+        label: `D1-Q${i + 1}`,
+        bracketLabel: null,
+        seats: [
+          { seatNumber: 1, letter: 'A', seedRef: null },
+          { seatNumber: 2, letter: 'B', seedRef: null },
+          { seatNumber: 3, letter: 'C', seedRef: null },
+        ],
+      })
+    }
+
+    const res = await app.request(
+      `/api/meets/${meet.id}/schedule/sync`,
+      syncReq({ slots, quizzes, prelimAssignments: [], teamLateness: [] }),
+      env,
+    )
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ quizzes: { id: number }[] }>(res)
+    expect(body.quizzes).toHaveLength(QUIZ_COUNT)
+
+    const allSeats = await db.select().from(schema.scheduledQuizSeats)
+    expect(allSeats).toHaveLength(QUIZ_COUNT * 3)
+  })
 })
 
 describe('GET /api/meets/:id/quizzes/:quizId/teams', () => {

--- a/packages/api/src/routes/__tests__/schedule.spec.ts
+++ b/packages/api/src/routes/__tests__/schedule.spec.ts
@@ -605,6 +605,41 @@ describe('POST /api/meets/:id/schedule/sync', () => {
     const allSeats = await db.select().from(schema.scheduledQuizSeats)
     expect(allSeats).toHaveLength(QUIZ_COUNT * 3)
   })
+
+  it('chunks large prelim-assignment inserts under D1 param cap', async () => {
+    // Regression: a single division with 20+ letters × 5 cols/row
+    // exceeds D1's bound-parameter cap even though the for-loop
+    // already inserts one division at a time.
+    const meet = await seedMeet(db)
+    const church = await seedChurch(meet.id)
+    const LETTER_COUNT = 25
+    const teams = []
+    for (let i = 0; i < LETTER_COUNT; i++) {
+      teams.push(await seedTeam(meet.id, church.id, 'Division 1', i + 1))
+    }
+    const mapping = teams.map((t, i) => ({
+      letter: String.fromCharCode(65 + i),
+      teamId: t.id,
+    }))
+
+    const res = await app.request(
+      `/api/meets/${meet.id}/schedule/sync`,
+      syncReq({
+        slots: [],
+        quizzes: [],
+        prelimAssignments: [{ division: 'Division 1', mapping }],
+        teamLateness: [],
+      }),
+      env,
+    )
+    expect(res.status).toBe(200)
+
+    const all = await db
+      .select()
+      .from(schema.prelimAssignments)
+      .where(eq(schema.prelimAssignments.meetId, meet.id))
+    expect(all).toHaveLength(LETTER_COUNT)
+  })
 })
 
 describe('GET /api/meets/:id/quizzes/:quizId/teams', () => {

--- a/packages/api/src/routes/schedule.ts
+++ b/packages/api/src/routes/schedule.ts
@@ -165,6 +165,162 @@ schedule.get('/:id/quizzes', async (c) => {
 })
 
 /**
+ * GET /api/meets/:id/quizzes/:quizId/teams
+ *
+ * Returns one scheduled quiz with its 3 seats resolved end-to-end:
+ * each seat's `letter`/`seedRef`, the bound team (via
+ * `prelim_assignments` or `seed_resolutions`), and that team's
+ * roster. Unresolved seats (elim before #16 lands, prelim before
+ * Roll-Teams) return `team: null` and `quizzers: []`.
+ *
+ * Used by the scoresheet to prefill division/quiz #/teams when a
+ * user opens a scheduled quiz (issue #6).
+ */
+schedule.get('/:id/quizzes/:quizId/teams', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const quizId = Number(c.req.param('quizId'))
+  if (Number.isNaN(meetId) || Number.isNaN(quizId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const db = getDb(c)
+  const [quizRow] = await db
+    .select({
+      id: schema.scheduledQuizzes.id,
+      meetId: schema.scheduledQuizzes.meetId,
+      slotId: schema.scheduledQuizzes.slotId,
+      roomId: schema.scheduledQuizzes.roomId,
+      division: schema.scheduledQuizzes.division,
+      phase: schema.scheduledQuizzes.phase,
+      lane: schema.scheduledQuizzes.lane,
+      label: schema.scheduledQuizzes.label,
+      bracketLabel: schema.scheduledQuizzes.bracketLabel,
+      slotStartAt: schema.meetSlots.startAt,
+      roomName: schema.meetRooms.name,
+    })
+    .from(schema.scheduledQuizzes)
+    .innerJoin(schema.meetSlots, eq(schema.meetSlots.id, schema.scheduledQuizzes.slotId))
+    .innerJoin(schema.meetRooms, eq(schema.meetRooms.id, schema.scheduledQuizzes.roomId))
+    .where(and(eq(schema.scheduledQuizzes.id, quizId), eq(schema.scheduledQuizzes.meetId, meetId)))
+  if (!quizRow) return c.json({ error: 'Quiz not found' }, 404)
+
+  const seats = await db
+    .select()
+    .from(schema.scheduledQuizSeats)
+    .where(eq(schema.scheduledQuizSeats.quizId, quizId))
+    .orderBy(asc(schema.scheduledQuizSeats.seatNumber))
+
+  const prelimLetters = seats
+    .map((s) => s.letter)
+    .filter((l): l is string => l !== null && l !== '')
+  const elimRefs = seats.map((s) => s.seedRef).filter((r): r is string => r !== null && r !== '')
+
+  const prelimMap = new Map<string, number>()
+  if (prelimLetters.length > 0) {
+    const rows = await db
+      .select({
+        letter: schema.prelimAssignments.letter,
+        teamId: schema.prelimAssignments.teamId,
+      })
+      .from(schema.prelimAssignments)
+      .where(
+        and(
+          eq(schema.prelimAssignments.meetId, meetId),
+          eq(schema.prelimAssignments.division, quizRow.division),
+          inArray(schema.prelimAssignments.letter, prelimLetters),
+        ),
+      )
+    for (const r of rows) prelimMap.set(r.letter, r.teamId)
+  }
+
+  const elimMap = new Map<string, number>()
+  if (elimRefs.length > 0) {
+    const rows = await db
+      .select({
+        seedRef: schema.seedResolutions.seedRef,
+        teamId: schema.seedResolutions.teamId,
+      })
+      .from(schema.seedResolutions)
+      .where(
+        and(
+          eq(schema.seedResolutions.meetId, meetId),
+          inArray(schema.seedResolutions.seedRef, elimRefs),
+        ),
+      )
+    for (const r of rows) elimMap.set(r.seedRef, r.teamId)
+  }
+
+  const seatTeamIds = seats.map((s) => {
+    if (s.letter) return prelimMap.get(s.letter) ?? null
+    if (s.seedRef) return elimMap.get(s.seedRef) ?? null
+    return null
+  })
+
+  const teamIds = Array.from(new Set(seatTeamIds.filter((t): t is number => t !== null)))
+  const [teamRows, rosterRows] =
+    teamIds.length === 0
+      ? [[], []]
+      : await Promise.all([
+          db
+            .select({
+              id: schema.teams.id,
+              churchId: schema.churches.id,
+              churchName: schema.churches.name,
+              churchShortName: schema.churches.shortName,
+              division: schema.teams.division,
+              number: schema.teams.number,
+              consolation: schema.teams.consolation,
+            })
+            .from(schema.teams)
+            .innerJoin(schema.churches, eq(schema.churches.id, schema.teams.churchId))
+            .where(inArray(schema.teams.id, teamIds)),
+          db
+            .select({
+              teamId: schema.teamRosters.teamId,
+              quizzerId: schema.teamRosters.quizzerId,
+              name: schema.teamRosters.name,
+            })
+            .from(schema.teamRosters)
+            .where(inArray(schema.teamRosters.teamId, teamIds)),
+        ])
+
+  const teamById = new Map(teamRows.map((t) => [t.id, t]))
+  const rosterByTeam = new Map<number, { quizzerId: number; name: string }[]>()
+  for (const r of rosterRows) {
+    const arr = rosterByTeam.get(r.teamId) ?? []
+    arr.push({ quizzerId: r.quizzerId, name: r.name })
+    rosterByTeam.set(r.teamId, arr)
+  }
+
+  return c.json({
+    quiz: {
+      id: quizRow.id,
+      meetId: quizRow.meetId,
+      slotId: quizRow.slotId,
+      roomId: quizRow.roomId,
+      division: quizRow.division,
+      phase: quizRow.phase,
+      lane: quizRow.lane,
+      label: quizRow.label,
+      bracketLabel: quizRow.bracketLabel,
+      slotStartAt: quizRow.slotStartAt,
+      roomName: quizRow.roomName,
+    },
+    seats: seats.map((s, i) => {
+      const tid = seatTeamIds[i]
+      const team = tid !== null && tid !== undefined ? (teamById.get(tid) ?? null) : null
+      return {
+        seatNumber: s.seatNumber,
+        letter: s.letter,
+        seedRef: s.seedRef,
+        team,
+        quizzers: tid !== null && tid !== undefined ? (rosterByTeam.get(tid) ?? []) : [],
+      }
+    }),
+  })
+})
+
+/**
  * GET /api/meets/:id/prelim-assignments
  *
  * Returns the team→letter mapping for every division in the meet.

--- a/packages/api/src/routes/schedule.ts
+++ b/packages/api/src/routes/schedule.ts
@@ -184,71 +184,82 @@ schedule.get('/:id/quizzes/:quizId/teams', async (c) => {
   }
 
   const db = getDb(c)
-  const [quizRow] = await db
-    .select({
-      id: schema.scheduledQuizzes.id,
-      meetId: schema.scheduledQuizzes.meetId,
-      slotId: schema.scheduledQuizzes.slotId,
-      roomId: schema.scheduledQuizzes.roomId,
-      division: schema.scheduledQuizzes.division,
-      phase: schema.scheduledQuizzes.phase,
-      lane: schema.scheduledQuizzes.lane,
-      label: schema.scheduledQuizzes.label,
-      bracketLabel: schema.scheduledQuizzes.bracketLabel,
-      slotStartAt: schema.meetSlots.startAt,
-      roomName: schema.meetRooms.name,
-    })
-    .from(schema.scheduledQuizzes)
-    .innerJoin(schema.meetSlots, eq(schema.meetSlots.id, schema.scheduledQuizzes.slotId))
-    .innerJoin(schema.meetRooms, eq(schema.meetRooms.id, schema.scheduledQuizzes.roomId))
-    .where(and(eq(schema.scheduledQuizzes.id, quizId), eq(schema.scheduledQuizzes.meetId, meetId)))
+
+  // Phase 1: quiz row + seats in parallel — seats only depend on quizId
+  // (a route param), so they can race with the join. If quiz is missing
+  // we discard the seats; cost is negligible vs. a serial extra round-trip.
+  const [quizRows, seats] = await Promise.all([
+    db
+      .select({
+        id: schema.scheduledQuizzes.id,
+        meetId: schema.scheduledQuizzes.meetId,
+        meetName: schema.quizMeets.name,
+        slotId: schema.scheduledQuizzes.slotId,
+        roomId: schema.scheduledQuizzes.roomId,
+        division: schema.scheduledQuizzes.division,
+        phase: schema.scheduledQuizzes.phase,
+        lane: schema.scheduledQuizzes.lane,
+        label: schema.scheduledQuizzes.label,
+        bracketLabel: schema.scheduledQuizzes.bracketLabel,
+        slotStartAt: schema.meetSlots.startAt,
+        roomName: schema.meetRooms.name,
+      })
+      .from(schema.scheduledQuizzes)
+      .innerJoin(schema.quizMeets, eq(schema.quizMeets.id, schema.scheduledQuizzes.meetId))
+      .innerJoin(schema.meetSlots, eq(schema.meetSlots.id, schema.scheduledQuizzes.slotId))
+      .innerJoin(schema.meetRooms, eq(schema.meetRooms.id, schema.scheduledQuizzes.roomId))
+      .where(
+        and(eq(schema.scheduledQuizzes.id, quizId), eq(schema.scheduledQuizzes.meetId, meetId)),
+      ),
+    db
+      .select()
+      .from(schema.scheduledQuizSeats)
+      .where(eq(schema.scheduledQuizSeats.quizId, quizId))
+      .orderBy(asc(schema.scheduledQuizSeats.seatNumber)),
+  ])
+  const quizRow = quizRows[0]
   if (!quizRow) return c.json({ error: 'Quiz not found' }, 404)
 
-  const seats = await db
-    .select()
-    .from(schema.scheduledQuizSeats)
-    .where(eq(schema.scheduledQuizSeats.quizId, quizId))
-    .orderBy(asc(schema.scheduledQuizSeats.seatNumber))
-
+  // Phase 2: prelim + elim seat resolutions in parallel — both only need
+  // the seats from phase 1.
   const prelimLetters = seats
     .map((s) => s.letter)
     .filter((l): l is string => l !== null && l !== '')
   const elimRefs = seats.map((s) => s.seedRef).filter((r): r is string => r !== null && r !== '')
 
-  const prelimMap = new Map<string, number>()
-  if (prelimLetters.length > 0) {
-    const rows = await db
-      .select({
-        letter: schema.prelimAssignments.letter,
-        teamId: schema.prelimAssignments.teamId,
-      })
-      .from(schema.prelimAssignments)
-      .where(
-        and(
-          eq(schema.prelimAssignments.meetId, meetId),
-          eq(schema.prelimAssignments.division, quizRow.division),
-          inArray(schema.prelimAssignments.letter, prelimLetters),
-        ),
-      )
-    for (const r of rows) prelimMap.set(r.letter, r.teamId)
-  }
-
-  const elimMap = new Map<string, number>()
-  if (elimRefs.length > 0) {
-    const rows = await db
-      .select({
-        seedRef: schema.seedResolutions.seedRef,
-        teamId: schema.seedResolutions.teamId,
-      })
-      .from(schema.seedResolutions)
-      .where(
-        and(
-          eq(schema.seedResolutions.meetId, meetId),
-          inArray(schema.seedResolutions.seedRef, elimRefs),
-        ),
-      )
-    for (const r of rows) elimMap.set(r.seedRef, r.teamId)
-  }
+  const [prelimRows, elimRows] = await Promise.all([
+    prelimLetters.length === 0
+      ? Promise.resolve([] as { letter: string; teamId: number }[])
+      : db
+          .select({
+            letter: schema.prelimAssignments.letter,
+            teamId: schema.prelimAssignments.teamId,
+          })
+          .from(schema.prelimAssignments)
+          .where(
+            and(
+              eq(schema.prelimAssignments.meetId, meetId),
+              eq(schema.prelimAssignments.division, quizRow.division),
+              inArray(schema.prelimAssignments.letter, prelimLetters),
+            ),
+          ),
+    elimRefs.length === 0
+      ? Promise.resolve([] as { seedRef: string; teamId: number }[])
+      : db
+          .select({
+            seedRef: schema.seedResolutions.seedRef,
+            teamId: schema.seedResolutions.teamId,
+          })
+          .from(schema.seedResolutions)
+          .where(
+            and(
+              eq(schema.seedResolutions.meetId, meetId),
+              inArray(schema.seedResolutions.seedRef, elimRefs),
+            ),
+          ),
+  ])
+  const prelimMap = new Map(prelimRows.map((r) => [r.letter, r.teamId]))
+  const elimMap = new Map(elimRows.map((r) => [r.seedRef, r.teamId]))
 
   const seatTeamIds = seats.map((s) => {
     if (s.letter) return prelimMap.get(s.letter) ?? null
@@ -296,6 +307,7 @@ schedule.get('/:id/quizzes/:quizId/teams', async (c) => {
     quiz: {
       id: quizRow.id,
       meetId: quizRow.meetId,
+      meetName: quizRow.meetName,
       slotId: quizRow.slotId,
       roomId: quizRow.roomId,
       division: quizRow.division,

--- a/packages/api/src/routes/schedule.ts
+++ b/packages/api/src/routes/schedule.ts
@@ -27,6 +27,29 @@ function getDb(c: { get(key: 'db'): Db }): Db {
   return c.get('db')
 }
 
+/**
+ * D1 caps bound parameters at 100 per statement
+ * (https://developers.cloudflare.com/d1/platform/limits/). A full-meet
+ * Populate generates ~80–100 scheduled quizzes and ~250 seats — well
+ * past the cap. We chunk inserts so each statement fits, leaving a few
+ * params of headroom for any implicit binds Drizzle might add.
+ */
+const D1_MAX_PARAMS = 90
+
+async function chunkedInsert<TIn, TOut>(
+  rows: TIn[],
+  colsPerRow: number,
+  insertChunk: (chunk: TIn[]) => Promise<TOut[]>,
+): Promise<TOut[]> {
+  if (rows.length === 0) return []
+  const chunkSize = Math.max(1, Math.floor(D1_MAX_PARAMS / colsPerRow))
+  const out: TOut[] = []
+  for (let i = 0; i < rows.length; i += chunkSize) {
+    out.push(...(await insertChunk(rows.slice(i, i + chunkSize))))
+  }
+  return out
+}
+
 async function requireAdmin(c: Context<Env>, meetId: number) {
   const user = getUser(c)
   const db = getDb(c)
@@ -610,7 +633,10 @@ schedule.post('/:id/schedule/sync', async (c) => {
         bracketLabel: q.bracketLabel ?? null,
       })
     }
-    const inserted = await db.insert(schema.scheduledQuizzes).values(rows).returning()
+    // 8 cols per row — see chunkedInsert / D1_MAX_PARAMS at top of file.
+    const inserted = await chunkedInsert(rows, 8, (chunk) =>
+      db.insert(schema.scheduledQuizzes).values(chunk).returning(),
+    )
     newQuizzes.forEach((q, i) => quizTempIdMap.set(q.id, inserted[i]!.id))
   }
 
@@ -678,7 +704,11 @@ schedule.post('/:id/schedule/sync', async (c) => {
     }
   }
   if (seatRows.length > 0) {
-    await db.insert(schema.scheduledQuizSeats).values(seatRows)
+    // 4 cols per row — see chunkedInsert / D1_MAX_PARAMS at top of file.
+    await chunkedInsert(seatRows, 4, async (chunk) => {
+      await db.insert(schema.scheduledQuizSeats).values(chunk)
+      return []
+    })
   }
 
   // ---- Prelim assignments (full-replace per division in payload) ----

--- a/packages/api/src/routes/schedule.ts
+++ b/packages/api/src/routes/schedule.ts
@@ -785,15 +785,21 @@ schedule.post('/:id/schedule/sync', async (c) => {
         ),
       )
     if (div.mapping.length > 0) {
-      await db.insert(schema.prelimAssignments).values(
-        div.mapping.map((m) => ({
-          meetId,
-          division: div.division,
-          letter: m.letter,
-          teamId: m.teamId,
-          assignedAt: now,
-        })),
-      )
+      // 5 cols per row — a division with ~20+ letters trips D1's
+      // 100-param cap even though the for-loop only inserts one
+      // division at a time.
+      await chunkedInsert(div.mapping, 5, async (chunk) => {
+        await db.insert(schema.prelimAssignments).values(
+          chunk.map((m) => ({
+            meetId,
+            division: div.division,
+            letter: m.letter,
+            teamId: m.teamId,
+            assignedAt: now,
+          })),
+        )
+        return []
+      })
     }
   }
 

--- a/packages/ui/src/ScheduleGrid.vue
+++ b/packages/ui/src/ScheduleGrid.vue
@@ -15,7 +15,6 @@ import {
   groupRowsByDay,
   hasAnyQuiz,
   seatRef,
-  seatTeam,
   sortedSeats,
 } from './scheduleGrid'
 
@@ -55,12 +54,22 @@ const days = computed<DayGroup<ScheduledQuiz, ScheduleSlot>[]>(() =>
 
 const empty = computed(() => !hasAnyQuiz(grid.value))
 
+// Precomputed lookup maps so seat-team resolution is O(1) per seat
+// instead of O(assignments + teams). Without these, rendering a meet
+// with hundreds of seats does thousands of .find() scans per render.
+const assignmentByDivisionLetter = computed(() => {
+  const m = new Map<string, number>()
+  for (const a of props.prelimAssignments ?? []) m.set(`${a.division}|${a.letter}`, a.teamId)
+  return m
+})
+const teamById = computed(() => new Map((props.meetTeams ?? []).map((t) => [t.id, t])))
+
 function seatTeamLabel(quiz: ScheduledQuiz, seat: ScheduledSeat): string {
-  return seatTeam(seat, {
-    division: quiz.division,
-    assignments: props.prelimAssignments ?? [],
-    teams: props.meetTeams ?? [],
-  })
+  if (!seat.letter) return '—'
+  const teamId = assignmentByDivisionLetter.value.get(`${quiz.division}|${seat.letter}`)
+  if (teamId === undefined) return '—'
+  const t = teamById.value.get(teamId)
+  return t ? `${t.churchShortName} ${t.number}` : '—'
 }
 </script>
 

--- a/packages/ui/src/ScheduleGrid.vue
+++ b/packages/ui/src/ScheduleGrid.vue
@@ -1,0 +1,323 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import {
+  type DayGroup,
+  type Grid,
+  type MeetTeamRow,
+  type PrelimAssignmentRow,
+  type ScheduleRoom,
+  type ScheduleSlot,
+  type ScheduledQuiz,
+  type ScheduledSeat,
+  buildGrid,
+  formatSlotTime,
+  groupRowsByDay,
+  hasAnyQuiz,
+  seatRef,
+  seatTeam,
+  sortedSeats,
+} from './scheduleGrid'
+
+const props = defineProps<{
+  rooms: ScheduleRoom[]
+  slots: ScheduleSlot[]
+  quizzes: ScheduledQuiz[]
+  prelimAssignments?: PrelimAssignmentRow[]
+  meetTeams?: MeetTeamRow[]
+  divisionFilter?: string | null
+  /** Empty-state message when there are no quizzes / no rooms. */
+  emptyMessage?: string
+}>()
+
+defineSlots<{
+  /** Cell shown in the time column for each row. Defaults to formatted time. */
+  'time-cell'(props: { gridSlot: ScheduleSlot }): unknown
+  /** Quiz label inside an occupied quiz cell. Defaults to a plain span. */
+  'quiz-label'(props: { quiz: ScheduledQuiz; gridSlot: ScheduleSlot; room: ScheduleRoom }): unknown
+  /** Trailing actions inside an occupied quiz cell (e.g. delete button). */
+  'cell-actions'(props: {
+    quiz: ScheduledQuiz
+    gridSlot: ScheduleSlot
+    room: ScheduleRoom
+  }): unknown
+  /** Contents of an empty quiz cell (e.g. add button). */
+  'empty-cell'(props: { gridSlot: ScheduleSlot; room: ScheduleRoom }): unknown
+}>()
+
+const grid = computed<Grid<ScheduledQuiz, ScheduleSlot, ScheduleRoom>>(() =>
+  buildGrid(props.rooms, props.slots, props.quizzes, props.divisionFilter ?? null),
+)
+
+const days = computed<DayGroup<ScheduledQuiz, ScheduleSlot>[]>(() =>
+  groupRowsByDay(grid.value.rows),
+)
+
+const empty = computed(() => !hasAnyQuiz(grid.value))
+
+function seatTeamLabel(quiz: ScheduledQuiz, seat: ScheduledSeat): string {
+  return seatTeam(seat, {
+    division: quiz.division,
+    assignments: props.prelimAssignments ?? [],
+    teams: props.meetTeams ?? [],
+  })
+}
+</script>
+
+<template>
+  <p v-if="rooms.length === 0" class="schedule-grid-empty">
+    {{ emptyMessage ?? 'No rooms have been added to this meet yet.' }}
+  </p>
+  <p v-else-if="empty" class="schedule-grid-empty">
+    {{ emptyMessage ?? 'No quizzes scheduled yet.' }}
+  </p>
+
+  <div v-else class="schedule-grid-scroll">
+    <table class="schedule-grid-table">
+      <thead>
+        <tr>
+          <th class="schedule-grid-time-col" scope="col">Time</th>
+          <th
+            v-for="room in grid.rooms"
+            :key="room.id"
+            :data-room-id="room.id"
+            class="schedule-grid-room-col"
+            scope="col"
+          >
+            {{ room.name }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <template v-for="group in days" :key="group.dateKey">
+          <tr class="schedule-grid-day-row">
+            <th class="schedule-grid-day-label" :colspan="grid.rooms.length + 1" scope="colgroup">
+              {{ group.label }}
+            </th>
+          </tr>
+          <tr
+            v-for="row in group.rows"
+            :key="row.slot.id"
+            :class="{ 'schedule-grid-event-row': row.slot.kind === 'event' }"
+          >
+            <th class="schedule-grid-time-col" scope="row">
+              <slot name="time-cell" :grid-slot="row.slot">{{
+                formatSlotTime(row.slot.startAt)
+              }}</slot>
+            </th>
+            <td
+              v-if="row.slot.kind === 'event'"
+              class="schedule-grid-event-cell"
+              :colspan="grid.rooms.length"
+            >
+              <span class="schedule-grid-event-label">
+                {{ row.slot.eventLabel || 'Event' }}
+              </span>
+            </td>
+            <template v-else>
+              <td
+                v-for="(quiz, i) in row.cells"
+                :key="grid.rooms[i]!.id"
+                class="schedule-grid-cell"
+                :class="{ 'schedule-grid-cell--empty': !quiz }"
+              >
+                <article v-if="quiz" class="schedule-grid-quiz" :data-quiz-id="quiz.id">
+                  <header class="schedule-grid-quiz-head">
+                    <slot
+                      name="quiz-label"
+                      :quiz="quiz"
+                      :grid-slot="row.slot"
+                      :room="grid.rooms[i]!"
+                    >
+                      <span class="schedule-grid-quiz-label">{{ quiz.label }}</span>
+                    </slot>
+                    <slot
+                      name="cell-actions"
+                      :quiz="quiz"
+                      :grid-slot="row.slot"
+                      :room="grid.rooms[i]!"
+                    />
+                  </header>
+                  <ol class="schedule-grid-seat-list">
+                    <li
+                      v-for="seat in sortedSeats(quiz.seats)"
+                      :key="seat.id"
+                      class="schedule-grid-seat"
+                      :data-seat-letter="seat.letter || undefined"
+                    >
+                      <span class="schedule-grid-seat-ref">{{ seatRef(seat) }}</span>
+                      <span class="schedule-grid-seat-team">{{ seatTeamLabel(quiz, seat) }}</span>
+                    </li>
+                  </ol>
+                </article>
+                <slot v-else name="empty-cell" :grid-slot="row.slot" :room="grid.rooms[i]!" />
+              </td>
+            </template>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<style scoped>
+.schedule-grid-empty {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.schedule-grid-scroll {
+  overflow-x: auto;
+  border: 1px solid var(--color-border-alt);
+  border-radius: 6px;
+}
+
+.schedule-grid-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.78rem;
+  table-layout: fixed;
+}
+
+.schedule-grid-table th,
+.schedule-grid-table td {
+  border: 1px solid var(--color-border-alt);
+  vertical-align: top;
+}
+
+.schedule-grid-table thead th {
+  background: var(--color-bg-raised, var(--color-bg-warm));
+  color: var(--color-text-faint);
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.5rem 0.875rem;
+  text-align: center;
+}
+
+.schedule-grid-time-col {
+  width: 7rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  background: var(--color-bg);
+  padding: 0.55rem 0.875rem;
+  text-align: center;
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
+
+.schedule-grid-table tbody .schedule-grid-time-col {
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.schedule-grid-table thead .schedule-grid-time-col {
+  background: var(--color-bg-raised, var(--color-bg-warm));
+}
+
+.schedule-grid-room-col {
+  min-width: 6.5rem;
+  font-weight: 600;
+  font-size: 0.78rem;
+  color: var(--color-text);
+  padding: 0.5rem 0.875rem;
+  text-align: center;
+}
+
+.schedule-grid-day-row .schedule-grid-day-label {
+  background: var(--color-bg-warm);
+  color: var(--color-text-muted);
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.45rem 0.875rem;
+  text-align: left;
+}
+
+.schedule-grid-event-row .schedule-grid-event-cell {
+  background: var(--color-bg-warm);
+  text-align: center;
+  padding: 0.55rem 0.6rem;
+}
+
+.schedule-grid-event-label {
+  font-style: italic;
+  font-weight: 400;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+/* --schedule-grid-action-opacity cascades into slot content so consumers
+   can render hover-revealed action buttons (e.g. add / delete) without
+   needing :deep() across scoped-style boundaries. */
+.schedule-grid-cell {
+  min-width: 6.5rem;
+  padding: 0;
+  --schedule-grid-action-opacity: 0;
+}
+
+.schedule-grid-cell:hover,
+.schedule-grid-cell:focus-within {
+  --schedule-grid-action-opacity: 1;
+}
+
+.schedule-grid-cell--empty {
+  background: transparent;
+}
+
+.schedule-grid-quiz {
+  display: flex;
+  flex-direction: column;
+}
+
+.schedule-grid-quiz-head {
+  position: relative;
+  font-weight: 600;
+  font-size: 0.78rem;
+  text-align: center;
+  padding: 0.3rem 0.4rem 0.25rem;
+  border-bottom: 1px solid var(--color-border-alt);
+  color: var(--color-text);
+}
+
+.schedule-grid-quiz-label {
+  font-weight: 600;
+  font-size: 0.78rem;
+}
+
+.schedule-grid-seat-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.schedule-grid-seat {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6rem) minmax(0, 1fr);
+  gap: 0.4rem;
+  align-items: baseline;
+  padding: 0.18rem 0.45rem;
+  border-top: 1px dotted var(--color-border-alt);
+  font-variant-numeric: tabular-nums;
+}
+
+.schedule-grid-seat:first-child {
+  border-top: none;
+}
+
+.schedule-grid-seat-ref {
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.schedule-grid-seat-team {
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,25 @@
 export { default as SignInForm } from './SignInForm.vue'
+export { default as ScheduleGrid } from './ScheduleGrid.vue'
+export {
+  STATS_BREAK_LABEL,
+  buildGrid,
+  bySortOrder,
+  formatSlotTime,
+  groupRowsByDay,
+  hasAnyQuiz,
+  isStatsBreak,
+  seatRef,
+  seatTeam,
+  sortedSeats,
+} from './scheduleGrid'
+export type {
+  DayGroup,
+  Grid,
+  GridRow,
+  MeetTeamRow,
+  PrelimAssignmentRow,
+  ScheduleRoom,
+  ScheduleSlot,
+  ScheduledQuiz,
+  ScheduledSeat,
+} from './scheduleGrid'

--- a/packages/ui/src/scheduleGrid.ts
+++ b/packages/ui/src/scheduleGrid.ts
@@ -1,0 +1,201 @@
+/**
+ * Shared schedule-grid types and helpers used by the read-only viewer
+ * (apps/web) and the scoresheet picker (apps/scoresheet).
+ *
+ * Types are intentionally structural — both apps' API types satisfy
+ * these without an explicit import, so neither needs to depend on the
+ * other's `api.ts`.
+ */
+
+export interface ScheduleRoom {
+  id: number
+  name: string
+  sortOrder: number
+}
+
+export interface ScheduleSlot {
+  id: number
+  startAt: string
+  durationMinutes: number
+  kind: 'quiz' | 'event'
+  eventLabel?: string | null
+  sortOrder: number
+}
+
+export interface ScheduledSeat {
+  id: number
+  seatNumber: number
+  letter: string | null
+  seedRef: string | null
+}
+
+export interface ScheduledQuiz {
+  id: number
+  slotId: number
+  roomId: number
+  division: string
+  phase: 'prelim' | 'elim'
+  label: string
+  seats: ScheduledSeat[]
+}
+
+export interface PrelimAssignmentRow {
+  division: string
+  letter: string
+  teamId: number
+}
+
+export interface MeetTeamRow {
+  id: number
+  churchShortName: string
+  number: number
+}
+
+/** Reserved event-label that marks the schedule's prelim/elim divider. */
+export const STATS_BREAK_LABEL = 'Stats break'
+
+export function isStatsBreak(slot: ScheduleSlot): boolean {
+  return slot.kind === 'event' && slot.eventLabel === STATS_BREAK_LABEL
+}
+
+export interface GridRow<Q extends ScheduledQuiz, S extends ScheduleSlot> {
+  slot: S
+  /** Quiz at each room column (same order as `Grid.rooms`). null = empty cell.
+   *  Always empty for event slots — the renderer spans those across columns. */
+  cells: (Q | null)[]
+}
+
+export interface Grid<Q extends ScheduledQuiz, S extends ScheduleSlot, R extends ScheduleRoom> {
+  rooms: R[]
+  rows: GridRow<Q, S>[]
+}
+
+/**
+ * Build the schedule grid: rooms sorted by sortOrder then id (column order),
+ * slots sorted by sortOrder then id (row order), each quiz placed at its
+ * (slot, room) cell. `divisionFilter` drops off-division quizzes to null
+ * cells but keeps every slot row so empty rooms are still visible.
+ */
+export function buildGrid<R extends ScheduleRoom, S extends ScheduleSlot, Q extends ScheduledQuiz>(
+  rooms: R[],
+  slots: S[],
+  quizzes: Q[],
+  divisionFilter: string | null,
+): Grid<Q, S, R> {
+  const sortedRooms = [...rooms].sort(bySortOrder)
+  const sortedSlots = [...slots].sort(bySortOrder)
+
+  const byCell = new Map<number, Map<number, Q>>()
+  for (const q of quizzes) {
+    if (divisionFilter !== null && q.division !== divisionFilter) continue
+    let perSlot = byCell.get(q.slotId)
+    if (!perSlot) {
+      perSlot = new Map()
+      byCell.set(q.slotId, perSlot)
+    }
+    perSlot.set(q.roomId, q)
+  }
+
+  const rows: GridRow<Q, S>[] = sortedSlots.map((slot) => {
+    if (slot.kind === 'event') return { slot, cells: [] }
+    const perSlot = byCell.get(slot.id)
+    return {
+      slot,
+      cells: sortedRooms.map((r) => perSlot?.get(r.id) ?? null),
+    }
+  })
+
+  return { rooms: sortedRooms, rows }
+}
+
+export function hasAnyQuiz<Q extends ScheduledQuiz, S extends ScheduleSlot, R extends ScheduleRoom>(
+  grid: Grid<Q, S, R>,
+): boolean {
+  return grid.rows.some((r) => r.cells.some((c) => c !== null))
+}
+
+/** "8:00 AM" — local-time hh:mm; `startAt` is an ISO string from the API. */
+export function formatSlotTime(startAt: string): string {
+  const d = new Date(startAt)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+}
+
+/** Comparator for sorting slots and rooms by their canonical position. */
+export function bySortOrder<T extends { sortOrder: number; id: number }>(a: T, b: T): number {
+  return a.sortOrder - b.sortOrder || a.id - b.id
+}
+
+/** Letter for prelim seats, seedRef for elim seats. The canonical seat
+ *  identifier shown in letter mode. */
+export function seatRef(seat: ScheduledSeat): string {
+  return seat.letter ?? seat.seedRef ?? ''
+}
+
+/** Seats ordered by seatNumber. Server doesn't guarantee order. */
+export function sortedSeats(seats: ReadonlyArray<ScheduledSeat>): ScheduledSeat[] {
+  return [...seats].sort((a, b) => a.seatNumber - b.seatNumber)
+}
+
+/** Resolved team name for a seat: looks up the seat's letter in the
+ *  prelim assignments table, then renders the matching team's
+ *  `{shortName} {number}`. Returns `—` until Roll Teams has run for
+ *  this division (or for elim seats, which seed lazily via seedRefs). */
+export function seatTeam(
+  seat: ScheduledSeat,
+  ctx: {
+    division: string
+    assignments: ReadonlyArray<PrelimAssignmentRow>
+    teams: ReadonlyArray<MeetTeamRow>
+  },
+): string {
+  if (!seat.letter) return '—'
+  const a = ctx.assignments.find((x) => x.division === ctx.division && x.letter === seat.letter)
+  if (!a) return '—'
+  const t = ctx.teams.find((tm) => tm.id === a.teamId)
+  if (!t) return '—'
+  return `${t.churchShortName} ${t.number}`
+}
+
+interface DayLabelInput {
+  startAt: string
+}
+
+export interface DayGroup<Q extends ScheduledQuiz, S extends ScheduleSlot> {
+  dateKey: string
+  label: string
+  rows: GridRow<Q, S>[]
+}
+
+/** Group grid rows by their slot's local date so the template can break
+ *  the schedule into "Friday, May 15 / Saturday, May 16 / …" sections. */
+export function groupRowsByDay<Q extends ScheduledQuiz, S extends ScheduleSlot & DayLabelInput>(
+  rows: GridRow<Q, S>[],
+): DayGroup<Q, S>[] {
+  const map = new Map<string, DayGroup<Q, S>>()
+  for (const row of rows) {
+    const d = new Date(row.slot.startAt)
+    if (Number.isNaN(d.getTime())) continue
+    const key = dateKey(d)
+    let group = map.get(key)
+    if (!group) {
+      group = { dateKey: key, label: dayLabel(d), rows: [] }
+      map.set(key, group)
+    }
+    group.rows.push(row)
+  }
+  return Array.from(map.values())
+}
+
+function dateKey(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+function dayLabel(d: Date): string {
+  return d.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  })
+}


### PR DESCRIPTION
## Summary

Click a quiz cell in the portal schedule view → opens the scoresheet with division, quiz #, and all 3 teams (+ rosters) prefilled. Also adds an in-app "Load from schedule…" button so the same flow works from inside the scoresheet (especially Tauri desktop).

* **API**: new `GET /api/meets/:id/quizzes/:quizId/teams` returns the quiz + its 3 seats joined to teams (via `prelim_assignments` / `seed_resolutions`) and rosters in one round-trip. Unresolved seats (elim before #16, prelim before Roll-Teams) return `team: null` so partial schedules still render.
* **Scoresheet**: `useMeetSession.loadFromQuiz(meetId, quizId, …)` hydrates from the new endpoint, reusing `assignTeam` + the levenshtein roster matcher. Adds `quizId` to the session (persisted) so the future Submit flow (#7) can back-link results.
* **URL entry point**: `Scoresheet.vue` parses `?meet=&quiz=` on mount, runs `loadFromQuiz`, populates `quiz.division` / `quiz.quizNumber` / `quiz.consolation` (via new `quizMeta` helpers), then strips the params so a reload doesn't re-clobber edits.
* **Portal link**: `ReviewSection` quiz labels become `<a>` to `/scoresheet/?meet=…&quiz=…` when read-only. Same-origin (PWA bundled at `/scoresheet/` by `build:all`), so cookie sessions + guest tokens carry over.
* **Shared grid component**: extracts the schedule grid renderer + helpers from `apps/web/src/scheduleGrid.ts` into `@qzr/ui` as a reusable `<ScheduleGrid>` with named slots (\`time-cell\`, \`quiz-label\`, \`cell-actions\`, \`empty-cell\`) — the portal viewer and the scoresheet picker render the same component, so future viewer upgrades benefit both.
* **In-app picker**: new "📅 Load from schedule…" menu button + \`SchedulePickerDialog\`. If a meet is already loaded, jumps straight to the quiz step (renders \`<ScheduleGrid>\` with the meet's quizzes); otherwise meet picker first. Shared meet-list logic between dialogs lives in a new \`useMeetList\` composable.

## Closes

\#6 — Load teams from schedule

## Test plan

- [x] \`pnpm test:unit\` — 1131 tests pass (5 new for API route, 4 new for \`loadFromQuiz\`, 4 new for \`quizMeta\`)
- [x] \`pnpm type-check\` — clean across all 5 packages
- [ ] Manual: seed a meet with schedule + Roll-Teams done; click a quiz cell in \`/m/<slug>/schedule\` → scoresheet opens with division, quiz #, 3 teams + rosters prefilled
- [ ] Manual: click "Load from schedule…" in the scoresheet with no meet loaded → meet picker → pick meet → quiz grid → click quiz → prefill
- [ ] Manual: click "Load from schedule…" while a meet is already loaded → jumps straight to the quiz grid for that meet
- [ ] Manual: portal schedule grid still looks correct after the refactor (editable + read-only modes both render via \`<ScheduleGrid>\` slots)
- [ ] Manual: confirm \`?meet\`/\`?quiz\` are stripped from the URL after the prefill

## Notes for reviewer

* \`9a318ff\` (CLAUDE.md scope-discipline rule) is on this branch because it was an unpushed local commit on master when I branched off. Not related to #6.
* Sub-branch \`feat/schedule-picker\` was used for the 3-commit picker work and merged back via \`chore: merge feat/schedule-picker\`.
* Schedule API still requires a signed-in user (no relaxation to guests in this PR; tracked under #10).
* The dev workflow link lands on \`:5174\` (portal) → \`:5173\` (scoresheet) which is a 404 in \`pnpm dev\`; production same-origin layout is what the link targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)