### PR TITLE
feat: results submission (#7)

### DIFF
--- a/apps/scoresheet/CHANGELOG.md
+++ b/apps/scoresheet/CHANGELOG.md
@@ -15,6 +15,28 @@ portal/API/infra work shipped on that tag.
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-05-23
+
+### Added
+
+* **Submit results** — officials can POST a completed scoresheet to the server with one click. The
+  button appears in the file-action bar whenever a meet is linked and the scoresheet is complete +
+  clean. Confirms with a per-meet/per-room summary before posting, then locks the scoresheet UI with
+  a "✓ Submitted" badge so the same content can't be edited and re-sent. 409 (duplicate of a
+  scheduled quiz) surfaces a distinct alert pointing the official to the existing submission;
+  orphaned submissions (no scheduled quiz binding) succeed and become an admin-reconcile task on the
+  server. Schedule-loaded quizzes auto-stamp `quizId` + `roomId` on the request so the server can
+  keep the back-link; standalone scoresheets submit with both null.
+* **`roomId` + `roomName` on the meet session** — populated when loading from a scheduled quiz, read
+  by the submit payload. Persists alongside `quizId` across reloads.
+* **`submittedAt` on the meet session** — locks the scoresheet UI until the session is replaced (New
+  quiz, Open file, different scheduled-quiz load, or Unlink meet). Survives reloads via the existing
+  localStorage persistence.
+
+### Bundled contract
+
+* `@qzr/shared@0.9.2` — unchanged (submission consumes the existing QuizFile shape).
+
 ## [0.9.2] — 2026-05-21
 
 First per-package scoresheet release. No source changes since 0.9.1 — bumping to establish the

--- a/apps/scoresheet/package.json
+++ b/apps/scoresheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scoresheet",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/scoresheet/src-tauri/tauri.conf.json
+++ b/apps/scoresheet/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "qzr-sheet",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "identifier": "com.quizmeet.sheet",
   "build": {
     "frontendDist": "../dist",

--- a/apps/scoresheet/src/api.ts
+++ b/apps/scoresheet/src/api.ts
@@ -1,4 +1,4 @@
-import { createApiClient } from '@qzr/shared'
+import { createApiClient, type QuizFile } from '@qzr/shared'
 import { getGuestToken } from './composables/useGuestSession'
 
 declare const __API_URL__: string
@@ -180,4 +180,25 @@ export async function joinMeetGuest(
   })
   if (!res.ok) return null
   return (await res.json()) as { token: string; meet: { id: number; name: string }; role: string }
+}
+
+// ---- Results ----
+
+export interface SubmitResultResponse {
+  id: number
+  submittedAt: string
+}
+
+export function postResult(
+  meetId: number,
+  payload: {
+    quizFile: QuizFile
+    quizId: number | null
+    roomId: number | null
+  },
+): Promise<SubmitResultResponse> {
+  return request(`/api/meets/${meetId}/results`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
 }

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -136,7 +136,10 @@ async function loadScheduledQuiz(meetId: number, quizId: number): Promise<boolea
     slots[slotIdx] = change.slot
     storeMirrors.push(change.mirrorToStore)
   }
-  meetSession.applyLoadedQuiz(slots, quizId)
+  meetSession.applyLoadedQuiz(slots, quizId, {
+    roomId: details.quiz.roomId,
+    roomName: details.quiz.roomName,
+  })
   for (const mirror of storeMirrors) mirror()
   return true
 }

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -26,6 +26,7 @@ import MeetPickerDialog from './MeetPickerDialog.vue'
 import SchedulePickerDialog from './SchedulePickerDialog.vue'
 import SignInWidget from './SignInWidget.vue'
 import TutorialOverlay from './TutorialOverlay.vue'
+import { useResultSubmission } from '../composables/useResultSubmission'
 
 const { theme, toggleTheme } = useTheme()
 
@@ -399,6 +400,44 @@ const tutorial = useTutorial({
   resetStore,
 })
 tutorial.recoverFromCrash()
+
+const submission = useResultSubmission({
+  hasAnyErrors,
+  allQuestionsComplete,
+  quiz,
+  buildQuizFile: () =>
+    serialize({
+      quiz: store.quiz,
+      teams: store.teams,
+      quizzers: store.quizzers,
+      answers: store.answers,
+      noJumps: noJumpMap.value,
+      timeouts: timeoutMap.value,
+    }),
+})
+
+async function doSubmit() {
+  if (!submission.canSubmit.value) return
+  const meetLabel = meetSession.meetName.value ?? 'this meet'
+  const roomLabel = meetSession.roomName.value ? ` (${meetSession.roomName.value})` : ''
+  if (
+    !(await confirmAction(
+      `Submit Div ${quiz.value.division} Q${quiz.value.quizNumber}${roomLabel} to ${meetLabel}? Results are immutable.`,
+    ))
+  ) {
+    return
+  }
+  const outcome = await submission.submit()
+  if (outcome.ok) {
+    alert('Submitted. The scoresheet is now locked.')
+  } else if (outcome.duplicate) {
+    alert(
+      'A result has already been submitted for this scheduled quiz. Save the JSON locally if you need to compare with the existing submission.',
+    )
+  } else if (outcome.error) {
+    alert(`Submit failed: ${outcome.error}`)
+  }
+}
 
 /** All unique validation messages for the status tooltip */
 const allValidationMessages = computed(() => {
@@ -826,7 +865,7 @@ const appVersion: string = __APP_VERSION__
     <div
       ref="wrapperRef"
       class="scoresheet-wrapper"
-      :class="{ 'is-dragging': dragState }"
+      :class="{ 'is-dragging': dragState, 'is-submitted': meetSession.isSubmitted.value }"
       @dragstart.prevent
     >
       <div
@@ -935,6 +974,26 @@ const appVersion: string = __APP_VERSION__
               </span>
               <span class="meta-divider" />
               <div class="meta-field meta-field--file">
+                <button
+                  v-if="meetSession.isActive.value && !meetSession.isSubmitted.value"
+                  class="submit-btn"
+                  :disabled="!submission.canSubmit.value || submission.submitting.value"
+                  :title="
+                    submission.canSubmit.value
+                      ? `Submit to ${meetSession.meetName.value}`
+                      : 'Complete + clean scoresheet required'
+                  "
+                  @click="doSubmit"
+                >
+                  {{ submission.submitting.value ? '…' : '⇪ Submit' }}
+                </button>
+                <span
+                  v-else-if="meetSession.isSubmitted.value"
+                  class="submit-badge"
+                  :title="`Submitted at ${meetSession.submittedAt.value}`"
+                >
+                  ✓ Submitted
+                </span>
                 <div class="file-menu">
                   <button title="Save / Export (Ctrl+S)" @click="toggleSaveMenu">⤓ Save ▾</button>
                   <div v-if="saveMenuOpen" class="file-menu__dropdown">
@@ -1925,6 +1984,45 @@ const appVersion: string = __APP_VERSION__
   color: var(--color-text);
   border-color: var(--color-text-faint);
   background: var(--color-border-alt);
+}
+
+.meta-field--file .submit-btn {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+.meta-field--file .submit-btn:not(:disabled):hover {
+  filter: brightness(1.08);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+.meta-field--file .submit-btn:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.submit-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.3rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--color-accent);
+  border: 1px solid var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+}
+
+/* Lock the scoring surface once submitted. Buttons in the meta header
+ * (Save, Open, New, Submit-badge) stay clickable so the user can still
+ * download / start a new quiz / unlink the meet. */
+.scoresheet-wrapper.is-submitted .scoresheet,
+.scoresheet-wrapper.is-submitted .quiz-meta--right {
+  pointer-events: none;
+  opacity: 0.7;
 }
 
 .menu-backdrop {

--- a/apps/scoresheet/src/composables/__tests__/useMeetSession.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useMeetSession.spec.ts
@@ -330,6 +330,40 @@ describe('useMeetSession — buildSlotFromSeat + applyLoadedQuiz', () => {
     expect(getSlot(1)).toBeUndefined()
     expect(quizId.value).toBe(555)
   })
+
+  it('applyLoadedQuiz captures roomId + roomName when room context is supplied', async () => {
+    const { loadMeet, applyLoadedQuiz, roomId, roomName } = useMeetSession()
+    await loadMeet(42, 'Finals')
+
+    applyLoadedQuiz([undefined, undefined, undefined], 555, {
+      roomId: 9,
+      roomName: 'Sanctuary',
+    })
+
+    expect(roomId.value).toBe(9)
+    expect(roomName.value).toBe('Sanctuary')
+  })
+
+  it('applyLoadedQuiz nulls roomId + roomName when no room context is supplied', async () => {
+    const { loadMeet, applyLoadedQuiz, roomId, roomName } = useMeetSession()
+    await loadMeet(42, 'Finals')
+
+    // Stamp a room, then commit a load without one — should clear back to null.
+    applyLoadedQuiz([undefined, undefined, undefined], 555, { roomId: 9, roomName: 'Sanctuary' })
+    applyLoadedQuiz([undefined, undefined, undefined], 556)
+
+    expect(roomId.value).toBeNull()
+    expect(roomName.value).toBeNull()
+  })
+
+  it('loadMeet (no quiz) clears any stamped room context', async () => {
+    const { loadMeet, applyLoadedQuiz, roomId, roomName } = useMeetSession()
+    await loadMeet(42, 'Finals')
+    applyLoadedQuiz([undefined, undefined, undefined], 555, { roomId: 9, roomName: 'Sanctuary' })
+    await loadMeet(42, 'Finals')
+    expect(roomId.value).toBeNull()
+    expect(roomName.value).toBeNull()
+  })
 })
 
 describe('useMeetSession — clearSlot', () => {

--- a/apps/scoresheet/src/composables/__tests__/useResultSubmission.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useResultSubmission.spec.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { ApiError, FILE_VERSION, PlacementFormula, type QuizFile } from '@qzr/shared'
+import { useMeetSession } from '../useMeetSession'
+import { useResultSubmission, type ScoresheetSubmitDeps } from '../useResultSubmission'
+
+vi.mock('../../api', () => ({
+  postResult: vi.fn(),
+}))
+
+import { postResult } from '../../api'
+
+function makeQuizFile(): QuizFile {
+  return {
+    version: FILE_VERSION,
+    quiz: {
+      division: '1',
+      quizNumber: '1',
+      overtime: false,
+      placementFormula: PlacementFormula.Rules,
+      questionTypes: [],
+    },
+    teams: [],
+    answers: [],
+    noJumps: [],
+  }
+}
+
+function makeDeps(overrides: Partial<ScoresheetSubmitDeps> = {}): ScoresheetSubmitDeps {
+  return {
+    hasAnyErrors: ref(false),
+    allQuestionsComplete: ref(true),
+    quiz: { value: { division: '1', quizNumber: '1' } },
+    buildQuizFile: () => makeQuizFile(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.mocked(postResult).mockReset()
+})
+
+describe('useResultSubmission — canSubmit', () => {
+  it('is false when no meet session is active', () => {
+    const { canSubmit } = useResultSubmission(makeDeps())
+    expect(canSubmit.value).toBe(false)
+  })
+
+  it('is true when meet active + valid + complete + meta filled', () => {
+    const session = useMeetSession()
+    session.restoreSession({
+      meetId: 1,
+      meetName: 'Meet',
+      slots: [undefined, undefined, undefined],
+      teamList: [],
+      meetDivisions: [],
+      quizId: null,
+      roomId: null,
+      roomName: null,
+      submittedAt: null,
+    })
+    const { canSubmit } = useResultSubmission(makeDeps())
+    expect(canSubmit.value).toBe(true)
+    session.clearSession()
+  })
+
+  it('is false when there are validation errors', () => {
+    const session = useMeetSession()
+    session.restoreSession({
+      meetId: 1,
+      meetName: 'Meet',
+      slots: [undefined, undefined, undefined],
+      teamList: [],
+      meetDivisions: [],
+      quizId: null,
+      roomId: null,
+      roomName: null,
+      submittedAt: null,
+    })
+    const { canSubmit } = useResultSubmission(makeDeps({ hasAnyErrors: ref(true) }))
+    expect(canSubmit.value).toBe(false)
+    session.clearSession()
+  })
+
+  it('is false when questions are incomplete', () => {
+    const session = useMeetSession()
+    session.restoreSession({
+      meetId: 1,
+      meetName: 'Meet',
+      slots: [undefined, undefined, undefined],
+      teamList: [],
+      meetDivisions: [],
+      quizId: null,
+      roomId: null,
+      roomName: null,
+      submittedAt: null,
+    })
+    const { canSubmit } = useResultSubmission(makeDeps({ allQuestionsComplete: ref(false) }))
+    expect(canSubmit.value).toBe(false)
+    session.clearSession()
+  })
+
+  it('is false when division or quizNumber is blank', () => {
+    const session = useMeetSession()
+    session.restoreSession({
+      meetId: 1,
+      meetName: 'Meet',
+      slots: [undefined, undefined, undefined],
+      teamList: [],
+      meetDivisions: [],
+      quizId: null,
+      roomId: null,
+      roomName: null,
+      submittedAt: null,
+    })
+    const { canSubmit } = useResultSubmission(
+      makeDeps({ quiz: { value: { division: '', quizNumber: '1' } } }),
+    )
+    expect(canSubmit.value).toBe(false)
+    session.clearSession()
+  })
+
+  it('is false once submitted (lock until session is replaced)', () => {
+    const session = useMeetSession()
+    session.restoreSession({
+      meetId: 1,
+      meetName: 'Meet',
+      slots: [undefined, undefined, undefined],
+      teamList: [],
+      meetDivisions: [],
+      quizId: null,
+      roomId: null,
+      roomName: null,
+      submittedAt: '2026-01-01T00:00:00.000Z',
+    })
+    const { canSubmit } = useResultSubmission(makeDeps())
+    expect(canSubmit.value).toBe(false)
+    session.clearSession()
+  })
+})
+
+describe('useResultSubmission — submit', () => {
+  function setupSession() {
+    const session = useMeetSession()
+    session.restoreSession({
+      meetId: 42,
+      meetName: 'Finals',
+      slots: [undefined, undefined, undefined],
+      teamList: [],
+      meetDivisions: [],
+      quizId: 777,
+      roomId: 9,
+      roomName: 'Sanctuary',
+      submittedAt: null,
+    })
+    return session
+  }
+
+  it('posts quizFile + quizId + roomId and marks submitted on success', async () => {
+    const session = setupSession()
+    vi.mocked(postResult).mockResolvedValueOnce({ id: 1, submittedAt: 'now' })
+    const { submit } = useResultSubmission(makeDeps())
+
+    const outcome = await submit()
+    expect(outcome).toEqual({ ok: true })
+    expect(postResult).toHaveBeenCalledWith(42, {
+      quizFile: makeQuizFile(),
+      quizId: 777,
+      roomId: 9,
+    })
+    expect(session.isSubmitted.value).toBe(true)
+    session.clearSession()
+  })
+
+  it('surfaces 409 as { ok: false, duplicate: true } without marking submitted', async () => {
+    const session = setupSession()
+    vi.mocked(postResult).mockRejectedValueOnce(new ApiError(409, 'already exists'))
+    const { submit } = useResultSubmission(makeDeps())
+
+    const outcome = await submit()
+    expect(outcome).toEqual({ ok: false, duplicate: true })
+    expect(session.isSubmitted.value).toBe(false)
+    session.clearSession()
+  })
+
+  it('surfaces other errors via submitError', async () => {
+    const session = setupSession()
+    vi.mocked(postResult).mockRejectedValueOnce(new ApiError(500, 'boom'))
+    const { submit, submitError } = useResultSubmission(makeDeps())
+
+    const outcome = await submit()
+    expect(outcome.ok).toBe(false)
+    expect(submitError.value).toBe('boom')
+    expect(session.isSubmitted.value).toBe(false)
+    session.clearSession()
+  })
+
+  it('skips the post when canSubmit is false', async () => {
+    // No meet session active — canSubmit is false.
+    const { submit } = useResultSubmission(makeDeps())
+    const outcome = await submit()
+    expect(outcome).toEqual({ ok: false })
+    expect(postResult).not.toHaveBeenCalled()
+  })
+
+  it('toggles submitting around the post', async () => {
+    setupSession()
+    let resolvePost!: (v: { id: number; submittedAt: string }) => void
+    vi.mocked(postResult).mockReturnValueOnce(
+      new Promise((r) => {
+        resolvePost = r
+      }),
+    )
+    const { submit, submitting } = useResultSubmission(makeDeps())
+
+    const promise = submit()
+    expect(submitting.value).toBe(true)
+    resolvePost({ id: 1, submittedAt: 'now' })
+    await promise
+    expect(submitting.value).toBe(false)
+    useMeetSession().clearSession()
+  })
+})

--- a/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
@@ -201,6 +201,8 @@ describe('useTutorial — meet link', () => {
       teamList: [],
       meetDivisions: ['1'],
       quizId: null,
+      roomId: null,
+      roomName: null,
     })
     expect(meet.isActive.value).toBe(true)
 
@@ -235,6 +237,8 @@ describe('useTutorial — meet link', () => {
       teamList: [],
       meetDivisions: [],
       quizId: null,
+      roomId: null,
+      roomName: null,
     })
 
     const s = useScoresheet()

--- a/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
@@ -203,6 +203,7 @@ describe('useTutorial — meet link', () => {
       quizId: null,
       roomId: null,
       roomName: null,
+      submittedAt: null,
     })
     expect(meet.isActive.value).toBe(true)
 
@@ -239,6 +240,7 @@ describe('useTutorial — meet link', () => {
       quizId: null,
       roomId: null,
       roomName: null,
+      submittedAt: null,
     })
 
     const s = useScoresheet()

--- a/apps/scoresheet/src/composables/useMeetSession.ts
+++ b/apps/scoresheet/src/composables/useMeetSession.ts
@@ -29,9 +29,14 @@ export interface MeetSessionData {
   /** The meet's canonical division list, e.g. ["1", "2", "3"] */
   meetDivisions: string[]
   /** Set when this session was loaded from a specific scheduled quiz
-   *  (via loadFromQuiz). Stamped onto submitted results in the future
-   *  Submit flow (#7) so they back-link to the schedule entry. */
+   *  (via loadFromQuiz). Stamped onto submitted results so they
+   *  back-link to the schedule entry. */
   quizId: number | null
+  /** Room context from the scheduled-quiz load, mirrored to the submit
+   *  payload. Null when the scoresheet isn't pinned to a scheduled
+   *  quiz — those submissions are orphans for an admin to reconcile. */
+  roomId: number | null
+  roomName: string | null
 }
 
 const session = ref<MeetSessionData | null>(loadFromStorage())
@@ -42,6 +47,8 @@ export function useMeetSession() {
   const meetName = computed(() => session.value?.meetName ?? null)
   const teamList = computed(() => session.value?.teamList ?? [])
   const quizId = computed(() => session.value?.quizId ?? null)
+  const roomId = computed(() => session.value?.roomId ?? null)
+  const roomName = computed(() => session.value?.roomName ?? null)
 
   /** Division options for the scoresheet dropdown — the meet's canonical division list. */
   const divisionOptions = computed((): string[] => session.value?.meetDivisions ?? [])
@@ -76,6 +83,8 @@ export function useMeetSession() {
       teamList: teams,
       meetDivisions,
       quizId: null,
+      roomId: null,
+      roomName: null,
     }
     persist()
   }
@@ -114,13 +123,24 @@ export function useMeetSession() {
   }
 
   /**
-   * Atomically commit a quiz load: replace the 3 slot assignments
-   * and stamp `quizId`. One reactivity tick, one `localStorage`
-   * write — vs. one per slot if callers used per-slot setters.
+   * Atomically commit a quiz load: replace the 3 slot assignments,
+   * stamp `quizId`, and capture room context from the load. One
+   * reactivity tick, one `localStorage` write — vs. one per slot if
+   * callers used per-slot setters.
    */
-  function applyLoadedQuiz(slots: (SlotSession | undefined)[], quizId: number): void {
+  function applyLoadedQuiz(
+    slots: (SlotSession | undefined)[],
+    quizId: number,
+    room: { roomId: number; roomName: string } | null = null,
+  ): void {
     if (!session.value) return
-    session.value = { ...session.value, slots, quizId }
+    session.value = {
+      ...session.value,
+      slots,
+      quizId,
+      roomId: room?.roomId ?? null,
+      roomName: room?.roomName ?? null,
+    }
     persist()
   }
 
@@ -232,6 +252,8 @@ export function useMeetSession() {
     meetName,
     teamList,
     quizId,
+    roomId,
+    roomName,
     divisionOptions,
     teamsForDivision,
     teamLabel,
@@ -356,6 +378,8 @@ function loadFromStorage(): MeetSessionData | null {
     // Migrate fields added after old sessions were persisted.
     if (!data.meetDivisions) data.meetDivisions = []
     if (data.quizId === undefined) data.quizId = null
+    if (data.roomId === undefined) data.roomId = null
+    if (data.roomName === undefined) data.roomName = null
     return data
   } catch {
     return null

--- a/apps/scoresheet/src/composables/useMeetSession.ts
+++ b/apps/scoresheet/src/composables/useMeetSession.ts
@@ -37,6 +37,12 @@ export interface MeetSessionData {
    *  quiz — those submissions are orphans for an admin to reconcile. */
   roomId: number | null
   roomName: string | null
+  /** ISO timestamp set by markSubmitted after a successful POST. The
+   *  Submit button hides and inputs disable while this is set. Cleared
+   *  whenever the session is replaced (New quiz, different schedule
+   *  load, unlink meet) — so the user must commit to leaving this
+   *  binding behind before they can submit again. */
+  submittedAt: string | null
 }
 
 const session = ref<MeetSessionData | null>(loadFromStorage())
@@ -49,6 +55,8 @@ export function useMeetSession() {
   const quizId = computed(() => session.value?.quizId ?? null)
   const roomId = computed(() => session.value?.roomId ?? null)
   const roomName = computed(() => session.value?.roomName ?? null)
+  const submittedAt = computed(() => session.value?.submittedAt ?? null)
+  const isSubmitted = computed(() => session.value?.submittedAt != null)
 
   /** Division options for the scoresheet dropdown — the meet's canonical division list. */
   const divisionOptions = computed((): string[] => session.value?.meetDivisions ?? [])
@@ -85,6 +93,7 @@ export function useMeetSession() {
       quizId: null,
       roomId: null,
       roomName: null,
+      submittedAt: null,
     }
     persist()
   }
@@ -140,7 +149,18 @@ export function useMeetSession() {
       quizId,
       roomId: room?.roomId ?? null,
       roomName: room?.roomName ?? null,
+      // Loading a quiz unlocks — the binding is fresh.
+      submittedAt: null,
     }
+    persist()
+  }
+
+  /** Mark the current scoresheet as submitted. Locks the UI until the
+   *  session is replaced. Idempotent — re-calling overwrites the
+   *  timestamp but has no other effect. */
+  function markSubmitted(at: Date = new Date()): void {
+    if (!session.value) return
+    session.value = { ...session.value, submittedAt: at.toISOString() }
     persist()
   }
 
@@ -254,6 +274,9 @@ export function useMeetSession() {
     quizId,
     roomId,
     roomName,
+    submittedAt,
+    isSubmitted,
+    markSubmitted,
     divisionOptions,
     teamsForDivision,
     teamLabel,
@@ -380,6 +403,7 @@ function loadFromStorage(): MeetSessionData | null {
     if (data.quizId === undefined) data.quizId = null
     if (data.roomId === undefined) data.roomId = null
     if (data.roomName === undefined) data.roomName = null
+    if (data.submittedAt === undefined) data.submittedAt = null
     return data
   } catch {
     return null

--- a/apps/scoresheet/src/composables/useResultSubmission.ts
+++ b/apps/scoresheet/src/composables/useResultSubmission.ts
@@ -1,0 +1,75 @@
+import { ref, computed, type ComputedRef, type Ref } from 'vue'
+import { ApiError, type QuizFile } from '@qzr/shared'
+import { postResult } from '../api'
+import { useMeetSession } from './useMeetSession'
+
+/** What the composable needs from useScoresheet. Decoupled so tests
+ *  can fake it without spinning up the full store. */
+export interface ScoresheetSubmitDeps {
+  hasAnyErrors: Ref<boolean> | ComputedRef<boolean>
+  allQuestionsComplete: Ref<boolean> | ComputedRef<boolean>
+  quiz: { value: { division: string; quizNumber: string } }
+  /** Build the full QuizFile object for the POST body. Caller supplies
+   *  this so we don't need to drag the whole serializeStore signature
+   *  (and its dependency tree) into the test surface. */
+  buildQuizFile: () => QuizFile
+}
+
+export type SubmitOutcome = { ok: true } | { ok: false; duplicate?: boolean; error?: string }
+
+/**
+ * Orchestrates the submit flow: gates on completion + validity + meet
+ * binding, calls postResult with quizId/roomId from the meet session,
+ * surfaces a 409 as `{ ok: false, duplicate: true }` so the caller can
+ * present the right alert, marks the meet session submitted on success
+ * (which locks the UI via meetSession.isSubmitted).
+ */
+export function useResultSubmission(deps: ScoresheetSubmitDeps, session = useMeetSession()) {
+  const submitting = ref(false)
+  const submitError = ref<string | null>(null)
+
+  const canSubmit = computed(
+    () =>
+      session.isActive.value &&
+      !session.isSubmitted.value &&
+      !deps.hasAnyErrors.value &&
+      deps.allQuestionsComplete.value &&
+      deps.quiz.value.division.trim() !== '' &&
+      deps.quiz.value.quizNumber.trim() !== '',
+  )
+
+  async function submit(): Promise<SubmitOutcome> {
+    if (!canSubmit.value) return { ok: false }
+    const meetId = session.meetId.value
+    if (meetId == null) return { ok: false }
+
+    submitting.value = true
+    submitError.value = null
+    try {
+      await postResult(meetId, {
+        quizFile: deps.buildQuizFile(),
+        quizId: session.quizId.value,
+        roomId: session.roomId.value,
+      })
+      session.markSubmitted()
+      return { ok: true }
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 409) {
+        return { ok: false, duplicate: true }
+      }
+      const msg = e instanceof Error ? e.message : String(e)
+      submitError.value = msg
+      return { ok: false, error: msg }
+    } finally {
+      submitting.value = false
+    }
+  }
+
+  return {
+    submitting,
+    submitError,
+    canSubmit,
+    submit,
+    isSubmitted: session.isSubmitted,
+  }
+}

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -17,6 +17,33 @@ wire/state compatibility signal — see CLAUDE.md "Contract package versioning".
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-05-23
+
+### Added
+
+* **`quiz_results` + `quiz_disputes` tables** — immutable submission record with the QuizFile JSON,
+  plus a flag/resolve loop for admins. `quiz_results.quizId` and `roomId` are nullable so orphan
+  submissions (scoresheet not loaded from the schedule) succeed; SQLite NULL≠NULL semantics mean the
+  (meetId, quizId) UNIQUE constraint only fires for scheduled submissions, returning 409.
+* **`POST /api/meets/:id/results`** — first mutation route in the codebase that admits guest
+  officials (via the new `isOfficialOf` helper). Validates the QuizFile against the shared TypeBox
+  schema before insert. Stamps the submitter as either an account or a guest label.
+* **`GET /api/meets/:id/results`** — admin/superuser list, newest first, with an `openDisputes`
+  count per row for the future review UI.
+* **`GET /api/meets/:id/results/:resultId`** — admin detail with the full QuizFile parsed back out
+  of storage.
+* **`POST /api/meets/:id/results/:resultId/disputes`** + **`PATCH /api/meets/:id/disputes/:id`** —
+  flag-and-resolve dispute lifecycle. Officials raise; admins resolve. Resolved-state toggle stamps
+  and clears the resolver attribution symmetrically.
+* **`isOfficialOf(c, db, meetId)` permission helper** — superuser, meet admin, meet official, or
+  guest-JWT official scoped to the meet. Composed inside the new submission and dispute routes.
+* **`@sinclair/typebox` direct dependency** — needed for `Value.Check(QuizFileSchema, …)` so the API
+  enforces the same schema the scoresheet serialises against.
+
+### Bundled contract
+
+* `@qzr/shared@0.9.2` — unchanged (the new endpoints consume the existing `QuizFileSchema`).
+
 ## [0.10.0] — 2026-05-21
 
 First per-package API release. Covers everything shipped on master since unified tag `v0.9.1`.

--- a/packages/api/migrations/0004_dusty_golden_guardian.sql
+++ b/packages/api/migrations/0004_dusty_golden_guardian.sql
@@ -1,0 +1,33 @@
+CREATE TABLE `quiz_disputes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`result_id` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	`created_by_account_id` text,
+	`created_by_guest_label` text,
+	`reason` text NOT NULL,
+	`resolved` integer DEFAULT false NOT NULL,
+	`resolved_at` integer,
+	`resolved_by_account_id` text,
+	FOREIGN KEY (`result_id`) REFERENCES `quiz_results`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by_account_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`resolved_by_account_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `quiz_results` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`meet_id` integer NOT NULL,
+	`quiz_id` integer,
+	`room_id` integer,
+	`division` text NOT NULL,
+	`round` text NOT NULL,
+	`submitted_at` integer NOT NULL,
+	`submitted_by_account_id` text,
+	`submitted_by_guest_label` text,
+	`quiz_file` text NOT NULL,
+	FOREIGN KEY (`meet_id`) REFERENCES `quiz_meets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`quiz_id`) REFERENCES `scheduled_quizzes`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`room_id`) REFERENCES `meet_rooms`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`submitted_by_account_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `quiz_results_meet_id_quiz_id_unique` ON `quiz_results` (`meet_id`,`quiz_id`);

--- a/packages/api/migrations/meta/0004_snapshot.json
+++ b/packages/api/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1764 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7f0ed006-24b0-4c8a-96eb-2877faf659ee",
+  "prevId": "f4e4c02f-ae46-4439-9858-44c54a76095c",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "admin_memberships": {
+      "name": "admin_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "admin_memberships_account_id_meet_id_unique": {
+          "name": "admin_memberships_account_id_meet_id_unique",
+          "columns": [
+            "account_id",
+            "meet_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "admin_memberships_account_id_user_id_fk": {
+          "name": "admin_memberships_account_id_user_id_fk",
+          "tableFrom": "admin_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "admin_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "admin_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "churches": {
+      "name": "churches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coach_code_hash": {
+          "name": "coach_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "churches_meet_id_quiz_meets_id_fk": {
+          "name": "churches_meet_id_quiz_meets_id_fk",
+          "tableFrom": "churches",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coach_memberships": {
+      "name": "coach_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "church_id": {
+          "name": "church_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "coach_memberships_account_id_church_id_unique": {
+          "name": "coach_memberships_account_id_church_id_unique",
+          "columns": [
+            "account_id",
+            "church_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "coach_memberships_account_id_user_id_fk": {
+          "name": "coach_memberships_account_id_user_id_fk",
+          "tableFrom": "coach_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_memberships_church_id_churches_id_fk": {
+          "name": "coach_memberships_church_id_churches_id_fk",
+          "tableFrom": "coach_memberships",
+          "tableTo": "churches",
+          "columnsFrom": [
+            "church_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "coach_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "coach_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "division_states": {
+      "name": "division_states",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'prelim_running'"
+        },
+        "transitioned_at": {
+          "name": "transitioned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "division_states_meet_id_division_unique": {
+          "name": "division_states_meet_id_division_unique",
+          "columns": [
+            "meet_id",
+            "division"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "division_states_meet_id_quiz_meets_id_fk": {
+          "name": "division_states_meet_id_quiz_meets_id_fk",
+          "tableFrom": "division_states",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meet_rooms": {
+      "name": "meet_rooms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meet_rooms_meet_id_quiz_meets_id_fk": {
+          "name": "meet_rooms_meet_id_quiz_meets_id_fk",
+          "tableFrom": "meet_rooms",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meet_slots": {
+      "name": "meet_slots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_label": {
+          "name": "event_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meet_slots_meet_id_quiz_meets_id_fk": {
+          "name": "meet_slots_meet_id_quiz_meets_id_fk",
+          "tableFrom": "meet_slots",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "official_memberships": {
+      "name": "official_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "official_memberships_account_id_meet_id_room_id_unique": {
+          "name": "official_memberships_account_id_meet_id_room_id_unique",
+          "columns": [
+            "account_id",
+            "meet_id",
+            "room_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "official_memberships_account_id_user_id_fk": {
+          "name": "official_memberships_account_id_user_id_fk",
+          "tableFrom": "official_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "official_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "official_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "official_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "official_memberships_room_id_meet_rooms_id_fk": {
+          "name": "official_memberships_room_id_meet_rooms_id_fk",
+          "tableFrom": "official_memberships",
+          "tableTo": "meet_rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prelim_assignments": {
+      "name": "prelim_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "letter": {
+          "name": "letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prelim_assignments_meet_id_division_letter_unique": {
+          "name": "prelim_assignments_meet_id_division_letter_unique",
+          "columns": [
+            "meet_id",
+            "division",
+            "letter"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "prelim_assignments_meet_id_quiz_meets_id_fk": {
+          "name": "prelim_assignments_meet_id_quiz_meets_id_fk",
+          "tableFrom": "prelim_assignments",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prelim_assignments_team_id_teams_id_fk": {
+          "name": "prelim_assignments_team_id_teams_id_fk",
+          "tableFrom": "prelim_assignments",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_disputes": {
+      "name": "quiz_disputes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_guest_label": {
+          "name": "created_by_guest_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by_account_id": {
+          "name": "resolved_by_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_disputes_result_id_quiz_results_id_fk": {
+          "name": "quiz_disputes_result_id_quiz_results_id_fk",
+          "tableFrom": "quiz_disputes",
+          "tableTo": "quiz_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_disputes_created_by_account_id_user_id_fk": {
+          "name": "quiz_disputes_created_by_account_id_user_id_fk",
+          "tableFrom": "quiz_disputes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "quiz_disputes_resolved_by_account_id_user_id_fk": {
+          "name": "quiz_disputes_resolved_by_account_id_user_id_fk",
+          "tableFrom": "quiz_disputes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "resolved_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_meets": {
+      "name": "quiz_meets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_from": {
+          "name": "date_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_to": {
+          "name": "date_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_code_hash": {
+          "name": "admin_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "viewer_code": {
+          "name": "viewer_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "divisions": {
+          "name": "divisions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'registration'"
+        },
+        "registration_closes_at": {
+          "name": "registration_closes_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meet_starts_at": {
+          "name": "meet_starts_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_results": {
+      "name": "quiz_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "submitted_by_account_id": {
+          "name": "submitted_by_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted_by_guest_label": {
+          "name": "submitted_by_guest_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quiz_file": {
+          "name": "quiz_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quiz_results_meet_id_quiz_id_unique": {
+          "name": "quiz_results_meet_id_quiz_id_unique",
+          "columns": [
+            "meet_id",
+            "quiz_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "quiz_results_meet_id_quiz_meets_id_fk": {
+          "name": "quiz_results_meet_id_quiz_meets_id_fk",
+          "tableFrom": "quiz_results",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_results_quiz_id_scheduled_quizzes_id_fk": {
+          "name": "quiz_results_quiz_id_scheduled_quizzes_id_fk",
+          "tableFrom": "quiz_results",
+          "tableTo": "scheduled_quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "quiz_results_room_id_meet_rooms_id_fk": {
+          "name": "quiz_results_room_id_meet_rooms_id_fk",
+          "tableFrom": "quiz_results",
+          "tableTo": "meet_rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "quiz_results_submitted_by_account_id_user_id_fk": {
+          "name": "quiz_results_submitted_by_account_id_user_id_fk",
+          "tableFrom": "quiz_results",
+          "tableTo": "user",
+          "columnsFrom": [
+            "submitted_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quizzer_identities": {
+      "name": "quizzer_identities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_quiz_seats": {
+      "name": "scheduled_quiz_seats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seat_number": {
+          "name": "seat_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "letter": {
+          "name": "letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seed_ref": {
+          "name": "seed_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_quiz_seats_quiz_id_scheduled_quizzes_id_fk": {
+          "name": "scheduled_quiz_seats_quiz_id_scheduled_quizzes_id_fk",
+          "tableFrom": "scheduled_quiz_seats",
+          "tableTo": "scheduled_quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_quizzes": {
+      "name": "scheduled_quizzes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lane": {
+          "name": "lane",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bracket_label": {
+          "name": "bracket_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_quizzes_meet_id_quiz_meets_id_fk": {
+          "name": "scheduled_quizzes_meet_id_quiz_meets_id_fk",
+          "tableFrom": "scheduled_quizzes",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_quizzes_slot_id_meet_slots_id_fk": {
+          "name": "scheduled_quizzes_slot_id_meet_slots_id_fk",
+          "tableFrom": "scheduled_quizzes",
+          "tableTo": "meet_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_quizzes_room_id_meet_rooms_id_fk": {
+          "name": "scheduled_quizzes_room_id_meet_rooms_id_fk",
+          "tableFrom": "scheduled_quizzes",
+          "tableTo": "meet_rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "seed_resolutions": {
+      "name": "seed_resolutions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed_ref": {
+          "name": "seed_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "seed_resolutions_meet_id_seed_ref_unique": {
+          "name": "seed_resolutions_meet_id_seed_ref_unique",
+          "columns": [
+            "meet_id",
+            "seed_ref"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "seed_resolutions_meet_id_quiz_meets_id_fk": {
+          "name": "seed_resolutions_meet_id_quiz_meets_id_fk",
+          "tableFrom": "seed_resolutions",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seed_resolutions_team_id_teams_id_fk": {
+          "name": "seed_resolutions_team_id_teams_id_fk",
+          "tableFrom": "seed_resolutions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_rosters": {
+      "name": "team_rosters",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quizzer_id": {
+          "name": "quizzer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_rosters_team_id_quizzer_id_unique": {
+          "name": "team_rosters_team_id_quizzer_id_unique",
+          "columns": [
+            "team_id",
+            "quizzer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_rosters_team_id_teams_id_fk": {
+          "name": "team_rosters_team_id_teams_id_fk",
+          "tableFrom": "team_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_rosters_quizzer_id_quizzer_identities_id_fk": {
+          "name": "team_rosters_quizzer_id_quizzer_identities_id_fk",
+          "tableFrom": "team_rosters",
+          "tableTo": "quizzer_identities",
+          "columnsFrom": [
+            "quizzer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "church_id": {
+          "name": "church_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consolation": {
+          "name": "consolation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "lateness": {
+          "name": "lateness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_meet_id_quiz_meets_id_fk": {
+          "name": "teams_meet_id_quiz_meets_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_church_id_churches_id_fk": {
+          "name": "teams_church_id_churches_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "churches",
+          "columnsFrom": [
+            "church_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "viewer_memberships": {
+      "name": "viewer_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "viewer_memberships_account_id_meet_id_unique": {
+          "name": "viewer_memberships_account_id_meet_id_unique",
+          "columns": [
+            "account_id",
+            "meet_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "viewer_memberships_account_id_user_id_fk": {
+          "name": "viewer_memberships_account_id_user_id_fk",
+          "tableFrom": "viewer_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "viewer_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "viewer_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "viewer_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1778793724215,
       "tag": "0003_dear_venus",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1779553408432,
+      "tag": "0004_dusty_golden_guardian",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qzr/api",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@qzr/shared": "workspace:*",
+    "@sinclair/typebox": "^0.34.0",
     "better-auth": "^1.2.7",
     "drizzle-orm": "^0.44.0",
     "hono": "^4.7.0",

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -295,6 +295,59 @@ export const seedResolutions = sqliteTable(
   (t) => [unique().on(t.meetId, t.seedRef)],
 )
 
+// ---- Results ----
+
+// Immutable submission record. `quizId` and `roomId` are nullable for
+// orphaned submissions — a scoresheet not loaded from the schedule can
+// still submit; an admin reconciles the result later. SQLite treats
+// NULL as distinct in unique indexes, so two orphan submissions for the
+// same (division, round) coexist; the (meetId, quizId) constraint only
+// fires for scheduled submissions.
+export const quizResults = sqliteTable(
+  'quiz_results',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    meetId: integer('meet_id')
+      .notNull()
+      .references(() => quizMeets.id, { onDelete: 'cascade' }),
+    quizId: integer('quiz_id').references(() => scheduledQuizzes.id, {
+      onDelete: 'set null',
+    }),
+    roomId: integer('room_id').references(() => meetRooms.id, { onDelete: 'set null' }),
+    division: text('division').notNull(),
+    round: text('round').notNull(),
+    submittedAt: integer('submitted_at', { mode: 'timestamp' }).notNull(),
+    // null when submitted via guest JWT — guest label is stored in the next field.
+    submittedByAccountId: text('submitted_by_account_id').references(() => user.id, {
+      onDelete: 'set null',
+    }),
+    submittedByGuestLabel: text('submitted_by_guest_label'),
+    // Full serialised QuizFile JSON. Parse at read-time.
+    quizFile: text('quiz_file').notNull(),
+  },
+  (t) => [unique().on(t.meetId, t.quizId)],
+)
+
+// Flag a submitted result for admin review. Officials and admins can
+// raise; only admins resolve. Multiple disputes per result are allowed.
+export const quizDisputes = sqliteTable('quiz_disputes', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  resultId: integer('result_id')
+    .notNull()
+    .references(() => quizResults.id, { onDelete: 'cascade' }),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  createdByAccountId: text('created_by_account_id').references(() => user.id, {
+    onDelete: 'set null',
+  }),
+  createdByGuestLabel: text('created_by_guest_label'),
+  reason: text('reason').notNull(),
+  resolved: integer('resolved', { mode: 'boolean' }).notNull().default(false),
+  resolvedAt: integer('resolved_at', { mode: 'timestamp' }),
+  resolvedByAccountId: text('resolved_by_account_id').references(() => user.id, {
+    onDelete: 'set null',
+  }),
+})
+
 // ---- Inferred types ----
 
 export type User = typeof user.$inferSelect
@@ -315,3 +368,5 @@ export type ScheduledQuiz = typeof scheduledQuizzes.$inferSelect
 export type ScheduledQuizSeat = typeof scheduledQuizSeats.$inferSelect
 export type PrelimAssignment = typeof prelimAssignments.$inferSelect
 export type SeedResolution = typeof seedResolutions.$inferSelect
+export type QuizResult = typeof quizResults.$inferSelect
+export type QuizDispute = typeof quizDisputes.$inferSelect

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -12,6 +12,7 @@ import { memberships } from './routes/memberships'
 import { churches } from './routes/churches'
 import { phase } from './routes/phase'
 import { schedule } from './routes/schedule'
+import { results } from './routes/results'
 import { createAuth } from './lib/auth'
 import { createDb } from './lib/db'
 import { autoAdvancePhases } from './scheduler'
@@ -58,6 +59,7 @@ app.route('/api/my-meets', memberships)
 app.route('/api', churches)
 app.route('/api/meets', phase)
 app.route('/api/meets', schedule)
+app.route('/api/meets', results)
 
 export { app }
 

--- a/packages/api/src/lib/permissions.ts
+++ b/packages/api/src/lib/permissions.ts
@@ -1,6 +1,6 @@
 import { eq, and, sql } from 'drizzle-orm'
 import type { Context } from 'hono'
-import { AccountRole } from '@qzr/shared'
+import { AccountRole, MeetRole } from '@qzr/shared'
 import * as schema from '../db/schema'
 import type { Db } from './db'
 import type { SessionVariables } from '../middleware/session'
@@ -61,6 +61,38 @@ export async function isViewerOf<E extends { Variables: SessionVariables }>(
       SELECT 1 FROM ${schema.viewerMemberships}
         WHERE ${schema.viewerMemberships.accountId} = ${user.id}
           AND ${schema.viewerMemberships.meetId} = ${meetId}
+    ) AS found`,
+  )
+  return Boolean(result?.found)
+}
+
+/**
+ * True if the requester is authorised to submit/manage results for this
+ * meet — superuser, meet admin, meet official (any room), or a guest
+ * JWT carrying role=Official for this meetId. First mutation gate that
+ * admits guests; readers should stay on isViewerOf.
+ */
+export async function isOfficialOf<E extends { Variables: SessionVariables }>(
+  c: Context<E>,
+  db: Db,
+  meetId: number,
+): Promise<boolean> {
+  const guest = c.get('guest')
+  if (guest && guest.meetId === meetId && guest.role === MeetRole.Official) return true
+
+  const user = c.get('user')
+  if (!user) return false
+  if (user.role === AccountRole.Superuser) return true
+
+  const result = await db.get<{ found: number }>(
+    sql`SELECT EXISTS (
+      SELECT 1 FROM ${schema.adminMemberships}
+        WHERE ${schema.adminMemberships.accountId} = ${user.id}
+          AND ${schema.adminMemberships.meetId} = ${meetId}
+      UNION ALL
+      SELECT 1 FROM ${schema.officialMemberships}
+        WHERE ${schema.officialMemberships.accountId} = ${user.id}
+          AND ${schema.officialMemberships.meetId} = ${meetId}
     ) AS found`,
   )
   return Boolean(result?.found)

--- a/packages/api/src/routes/__tests__/results.spec.ts
+++ b/packages/api/src/routes/__tests__/results.spec.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { FILE_VERSION, MeetRole, PlacementFormula, type QuizFile } from '@qzr/shared'
+import type { Bindings } from '../../bindings'
+import type { SessionVariables } from '../../middleware/session'
+import { results } from '../results'
+import * as schema from '../../db/schema'
+import {
+  mockSession,
+  mockDb,
+  testSuperuser,
+  testUser,
+  jsonOf,
+  jsonRequest,
+  seedMeet,
+} from '../../test-utils'
+import { createTestDb } from '../../test-db'
+import type { Db } from '../../lib/db'
+import type { GuestPayload } from '../../lib/jwt'
+import type { SessionUser } from '../../middleware/session'
+
+const env = { ENVIRONMENT: 'test' } as unknown as Bindings
+
+function createApp(user: SessionUser | null, db: Db, guest: GuestPayload | null = null) {
+  const app = new Hono<{ Bindings: Bindings; Variables: SessionVariables & { db: Db } }>()
+  app.use('*', mockSession(user, guest))
+  app.use('*', mockDb(db))
+  app.route('/api/meets', results)
+  return app
+}
+
+/** Minimal QuizFile that passes schema validation. */
+function makeQuizFile(overrides: Partial<QuizFile['quiz']> = {}): QuizFile {
+  return {
+    version: FILE_VERSION,
+    quiz: {
+      division: '1',
+      quizNumber: '1',
+      overtime: false,
+      placementFormula: PlacementFormula.Rules,
+      questionTypes: [],
+      ...overrides,
+    },
+    teams: [],
+    answers: [],
+    noJumps: [],
+  }
+}
+
+async function seedRoom(db: Db, meetId: number, name = 'Room A') {
+  const [room] = await db
+    .insert(schema.meetRooms)
+    .values({ meetId, name, sortOrder: 0 })
+    .returning()
+  return room!
+}
+
+async function seedSlot(db: Db, meetId: number) {
+  const [slot] = await db
+    .insert(schema.meetSlots)
+    .values({
+      meetId,
+      startAt: new Date('2026-01-01T20:00:00Z'),
+      durationMinutes: 25,
+      kind: 'quiz',
+      sortOrder: 0,
+    })
+    .returning()
+  return slot!
+}
+
+async function seedScheduledQuiz(db: Db, meetId: number, opts: { roomId?: number } = {}) {
+  const room = opts.roomId
+    ? { id: opts.roomId }
+    : await seedRoom(db, meetId, `Room ${Math.random().toString(36).slice(2, 6)}`)
+  const slot = await seedSlot(db, meetId)
+  const [quiz] = await db
+    .insert(schema.scheduledQuizzes)
+    .values({
+      meetId,
+      slotId: slot.id,
+      roomId: room.id,
+      division: '1',
+      phase: 'prelim',
+      label: 'D1-Q1',
+    })
+    .returning()
+  return quiz!
+}
+
+async function seedOfficial(db: Db, meetId: number, accountId: string, roomId: number) {
+  await db.insert(schema.officialMemberships).values({ accountId, meetId, roomId })
+}
+
+async function seedAdmin(db: Db, meetId: number, accountId: string) {
+  await db.insert(schema.adminMemberships).values({ accountId, meetId })
+}
+
+const postJson = (body: Record<string, unknown>) => jsonRequest('POST', body)
+
+describe('POST /api/meets/:id/results — auth matrix', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('401 when no signed-in user and no guest', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, null)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('404 when meet does not exist', async () => {
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/999/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('403 when signed-in non-member', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testUser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('403 when guest carries role=Viewer', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, { meetId: meet.id, role: MeetRole.Viewer })
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('403 when guest official is scoped to a different meet', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, { meetId: meet.id + 1, role: MeetRole.Official })
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('201 for superuser', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(201)
+  })
+
+  it('201 for meet admin', async () => {
+    const meet = await seedMeet(db)
+    await seedAdmin(db, meet.id, testUser.id)
+    const app = createApp(testUser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(201)
+  })
+
+  it('201 for meet official', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id)
+    await seedOfficial(db, meet.id, testUser.id, room.id)
+    const app = createApp(testUser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(201)
+  })
+
+  it('201 for guest with role=Official', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, {
+      meetId: meet.id,
+      role: MeetRole.Official,
+      label: 'Room 1 official',
+    })
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(201)
+  })
+})
+
+describe('POST /api/meets/:id/results — payload validation', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('400 when QuizFile is missing required fields', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: { version: 2 } }),
+      env,
+    )
+    expect(res.status).toBe(400)
+    const body = await jsonOf<{ error: string }>(res)
+    expect(body.error).toContain('Invalid QuizFile')
+  })
+
+  it('400 when quizId belongs to a different meet', async () => {
+    const meetA = await seedMeet(db, 'Meet A')
+    const meetB = await seedMeet(db, 'Meet B')
+    const quiz = await seedScheduledQuiz(db, meetB.id)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meetA.id}/results`,
+      postJson({ quizFile: makeQuizFile(), quizId: quiz.id }),
+      env,
+    )
+    expect(res.status).toBe(400)
+    expect((await jsonOf<{ error: string }>(res)).error).toContain('Quiz')
+  })
+
+  it('400 when roomId belongs to a different meet', async () => {
+    const meetA = await seedMeet(db, 'Meet A')
+    const meetB = await seedMeet(db, 'Meet B')
+    const room = await seedRoom(db, meetB.id, 'Other Room')
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meetA.id}/results`,
+      postJson({ quizFile: makeQuizFile(), roomId: room.id }),
+      env,
+    )
+    expect(res.status).toBe(400)
+    expect((await jsonOf<{ error: string }>(res)).error).toContain('Room')
+  })
+})
+
+describe('POST /api/meets/:id/results — happy path + storage', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('stores scheduled submission with quizId, roomId, division, round', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id, 'Sanctuary')
+    const quiz = await seedScheduledQuiz(db, meet.id, { roomId: room.id })
+    const app = createApp(testSuperuser, db)
+    const qf = makeQuizFile({ division: '2', quizNumber: 'A' })
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: qf, quizId: quiz.id, roomId: room.id }),
+      env,
+    )
+    expect(res.status).toBe(201)
+    const body = await jsonOf<{ id: number; submittedAt: string }>(res)
+    expect(body.id).toBeGreaterThan(0)
+
+    const [row] = await db.select().from(schema.quizResults)
+    expect(row?.meetId).toBe(meet.id)
+    expect(row?.quizId).toBe(quiz.id)
+    expect(row?.roomId).toBe(room.id)
+    expect(row?.division).toBe('2')
+    expect(row?.round).toBe('A')
+    expect(row?.submittedByAccountId).toBe(testSuperuser.id)
+    expect(row?.submittedByGuestLabel).toBeNull()
+    expect(JSON.parse(row!.quizFile)).toEqual(qf)
+  })
+
+  it('stores orphan submission with null quizId + roomId', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(201)
+    const [row] = await db.select().from(schema.quizResults)
+    expect(row?.quizId).toBeNull()
+    expect(row?.roomId).toBeNull()
+  })
+
+  it('records guest label and null accountId on guest submission', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, {
+      meetId: meet.id,
+      role: MeetRole.Official,
+      label: 'Room 3 official',
+    })
+    await app.request(`/api/meets/${meet.id}/results`, postJson({ quizFile: makeQuizFile() }), env)
+    const [row] = await db.select().from(schema.quizResults)
+    expect(row?.submittedByAccountId).toBeNull()
+    expect(row?.submittedByGuestLabel).toBe('Room 3 official')
+  })
+
+  it('409 when submitting the same scheduled quiz twice', async () => {
+    const meet = await seedMeet(db)
+    const quiz = await seedScheduledQuiz(db, meet.id)
+    const app = createApp(testSuperuser, db)
+    const first = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile(), quizId: quiz.id }),
+      env,
+    )
+    expect(first.status).toBe(201)
+    const second = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile(), quizId: quiz.id }),
+      env,
+    )
+    expect(second.status).toBe(409)
+  })
+
+  it('allows two orphaned submissions for the same meet (NULL ≠ NULL)', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const a = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    const b = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(a.status).toBe(201)
+    expect(b.status).toBe(201)
+    const rows = await db.select().from(schema.quizResults)
+    expect(rows).toHaveLength(2)
+  })
+})

--- a/packages/api/src/routes/__tests__/results.spec.ts
+++ b/packages/api/src/routes/__tests__/results.spec.ts
@@ -464,3 +464,175 @@ describe('GET /api/meets/:id/results/:resultId — admin detail', () => {
     expect(body.result.quizFile).toEqual(qf)
   })
 })
+
+describe('POST /api/meets/:id/results/:resultId/disputes', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  async function seedResult(meetId: number, suUser = testSuperuser): Promise<number> {
+    const app = createApp(suUser, db)
+    const post = await app.request(
+      `/api/meets/${meetId}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    return (await jsonOf<{ id: number }>(post)).id
+  }
+
+  it('403 when signed-in non-member raises a dispute', async () => {
+    const meet = await seedMeet(db)
+    const resultId = await seedResult(meet.id)
+    const app = createApp(testUser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results/${resultId}/disputes`,
+      postJson({ reason: 'wrong' }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('404 when the result is in a different meet', async () => {
+    const meetA = await seedMeet(db, 'A')
+    const meetB = await seedMeet(db, 'B')
+    const resultId = await seedResult(meetB.id)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meetA.id}/results/${resultId}/disputes`,
+      postJson({ reason: 'wrong' }),
+      env,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('400 when reason is blank', async () => {
+    const meet = await seedMeet(db)
+    const resultId = await seedResult(meet.id)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results/${resultId}/disputes`,
+      postJson({ reason: '   ' }),
+      env,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('201 for guest official with stored label and reason', async () => {
+    const meet = await seedMeet(db)
+    const resultId = await seedResult(meet.id)
+    const app = createApp(null, db, {
+      meetId: meet.id,
+      role: MeetRole.Official,
+      label: 'Room 2',
+    })
+    const res = await app.request(
+      `/api/meets/${meet.id}/results/${resultId}/disputes`,
+      postJson({ reason: 'score does not match my sheet' }),
+      env,
+    )
+    expect(res.status).toBe(201)
+    const [row] = await db.select().from(schema.quizDisputes)
+    expect(row?.resultId).toBe(resultId)
+    expect(row?.reason).toBe('score does not match my sheet')
+    expect(row?.createdByAccountId).toBeNull()
+    expect(row?.createdByGuestLabel).toBe('Room 2')
+    expect(row?.resolved).toBe(false)
+  })
+})
+
+describe('PATCH /api/meets/:id/disputes/:disputeId', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  async function seedResultAndDispute(meetId: number): Promise<number> {
+    const app = createApp(testSuperuser, db)
+    const post = await app.request(
+      `/api/meets/${meetId}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    const { id: resultId } = await jsonOf<{ id: number }>(post)
+    const flag = await app.request(
+      `/api/meets/${meetId}/results/${resultId}/disputes`,
+      postJson({ reason: 'flag me' }),
+      env,
+    )
+    return (await jsonOf<{ id: number }>(flag)).id
+  }
+
+  it('403 for non-admin', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id)
+    await seedOfficial(db, meet.id, testUser.id, room.id)
+    const disputeId = await seedResultAndDispute(meet.id)
+    const app = createApp(testUser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/disputes/${disputeId}`,
+      jsonRequest('PATCH', { resolved: true }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('404 when dispute belongs to a different meet', async () => {
+    const meetA = await seedMeet(db, 'A')
+    const meetB = await seedMeet(db, 'B')
+    const disputeId = await seedResultAndDispute(meetA.id)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meetB.id}/disputes/${disputeId}`,
+      jsonRequest('PATCH', { resolved: true }),
+      env,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('400 when resolved is not a boolean', async () => {
+    const meet = await seedMeet(db)
+    const disputeId = await seedResultAndDispute(meet.id)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/disputes/${disputeId}`,
+      jsonRequest('PATCH', {}),
+      env,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('toggles resolved + stamps resolver on true, clears on false', async () => {
+    const meet = await seedMeet(db)
+    const disputeId = await seedResultAndDispute(meet.id)
+    const app = createApp(testSuperuser, db)
+
+    const resolveRes = await app.request(
+      `/api/meets/${meet.id}/disputes/${disputeId}`,
+      jsonRequest('PATCH', { resolved: true }),
+      env,
+    )
+    expect(resolveRes.status).toBe(200)
+    let [row] = await db
+      .select()
+      .from(schema.quizDisputes)
+      .where(eq(schema.quizDisputes.id, disputeId))
+    expect(row?.resolved).toBe(true)
+    expect(row?.resolvedAt).not.toBeNull()
+    expect(row?.resolvedByAccountId).toBe(testSuperuser.id)
+
+    const reopenRes = await app.request(
+      `/api/meets/${meet.id}/disputes/${disputeId}`,
+      jsonRequest('PATCH', { resolved: false }),
+      env,
+    )
+    expect(reopenRes.status).toBe(200)
+    ;[row] = await db
+      .select()
+      .from(schema.quizDisputes)
+      .where(eq(schema.quizDisputes.id, disputeId))
+    expect(row?.resolved).toBe(false)
+    expect(row?.resolvedAt).toBeNull()
+    expect(row?.resolvedByAccountId).toBeNull()
+  })
+})

--- a/packages/api/src/routes/__tests__/results.spec.ts
+++ b/packages/api/src/routes/__tests__/results.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { Hono } from 'hono'
+import { eq } from 'drizzle-orm'
 import { FILE_VERSION, MeetRole, PlacementFormula, type QuizFile } from '@qzr/shared'
 import type { Bindings } from '../../bindings'
 import type { SessionVariables } from '../../middleware/session'
@@ -352,5 +353,114 @@ describe('POST /api/meets/:id/results — happy path + storage', () => {
     expect(b.status).toBe(201)
     const rows = await db.select().from(schema.quizResults)
     expect(rows).toHaveLength(2)
+  })
+})
+
+describe('GET /api/meets/:id/results — admin list', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('401 when no signed-in user', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, { meetId: meet.id, role: MeetRole.Official })
+    const res = await app.request(`/api/meets/${meet.id}/results`, {}, env)
+    expect(res.status).toBe(401)
+  })
+
+  it('403 when signed-in non-admin', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id)
+    await seedOfficial(db, meet.id, testUser.id, room.id)
+    const app = createApp(testUser, db)
+    const res = await app.request(`/api/meets/${meet.id}/results`, {}, env)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns rows newest first with openDisputes count', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const earlyRes = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile({ quizNumber: 'early' }) }),
+      env,
+    )
+    const earlyId = (await jsonOf<{ id: number }>(earlyRes)).id
+    // Force the second row's submittedAt strictly later than the first.
+    await db
+      .update(schema.quizResults)
+      .set({ submittedAt: new Date(Date.now() - 60_000) })
+      .where(eq(schema.quizResults.id, earlyId))
+    await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile({ quizNumber: 'late' }) }),
+      env,
+    )
+    // Flag the earlier result twice; resolve one. openDisputes should be 1.
+    await db.insert(schema.quizDisputes).values([
+      {
+        resultId: earlyId,
+        createdAt: new Date(),
+        reason: 'looks wrong',
+        resolved: false,
+      },
+      {
+        resultId: earlyId,
+        createdAt: new Date(),
+        reason: 'already addressed',
+        resolved: true,
+      },
+    ])
+
+    const res = await app.request(`/api/meets/${meet.id}/results`, {}, env)
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{
+      results: { id: number; round: string; openDisputes: number }[]
+    }>(res)
+    expect(body.results.map((r) => r.round)).toEqual(['late', 'early'])
+    expect(body.results.find((r) => r.id === earlyId)?.openDisputes).toBe(1)
+  })
+})
+
+describe('GET /api/meets/:id/results/:resultId — admin detail', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('403 for non-admin', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testUser, db)
+    const res = await app.request(`/api/meets/${meet.id}/results/1`, {}, env)
+    expect(res.status).toBe(403)
+  })
+
+  it('404 when the result is in a different meet', async () => {
+    const meetA = await seedMeet(db, 'Meet A')
+    const meetB = await seedMeet(db, 'Meet B')
+    const app = createApp(testSuperuser, db)
+    const post = await app.request(
+      `/api/meets/${meetA.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    const { id } = await jsonOf<{ id: number }>(post)
+    const res = await app.request(`/api/meets/${meetB.id}/results/${id}`, {}, env)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns the row with the QuizFile parsed', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const qf = makeQuizFile({ division: '3' })
+    const post = await app.request(`/api/meets/${meet.id}/results`, postJson({ quizFile: qf }), env)
+    const { id } = await jsonOf<{ id: number }>(post)
+    const res = await app.request(`/api/meets/${meet.id}/results/${id}`, {}, env)
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ result: { id: number; division: string; quizFile: QuizFile } }>(res)
+    expect(body.result.id).toBe(id)
+    expect(body.result.division).toBe('3')
+    expect(body.result.quizFile).toEqual(qf)
   })
 })

--- a/packages/api/src/routes/results.ts
+++ b/packages/api/src/routes/results.ts
@@ -201,3 +201,97 @@ results.get('/:id/results/:resultId', async (c) => {
 
   return c.json({ result: { ...row, quizFile: JSON.parse(row.quizFile) as QuizFile } })
 })
+
+/**
+ * POST /api/meets/:id/results/:resultId/disputes
+ *
+ * Flag a submitted result for admin review. Officials (signed-in or
+ * guest) can raise; admins resolve via PATCH below.
+ */
+results.post('/:id/results/:resultId/disputes', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const resultId = Number(c.req.param('resultId'))
+  if (Number.isNaN(meetId) || Number.isNaN(resultId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const db = getDb(c)
+  const [result] = await db
+    .select({ id: schema.quizResults.id })
+    .from(schema.quizResults)
+    .where(and(eq(schema.quizResults.id, resultId), eq(schema.quizResults.meetId, meetId)))
+  if (!result) return c.json({ error: 'Result not found' }, 404)
+
+  if (!(await isOfficialOf(c, db, meetId))) {
+    return c.json({ error: 'Official access required' }, 403)
+  }
+
+  const body = await c.req.json<{ reason?: string }>()
+  const reason = body.reason?.trim() ?? ''
+  if (!reason) return c.json({ error: 'reason is required' }, 400)
+
+  const user = c.get('user')
+  const guest = c.get('guest')
+
+  const [inserted] = await db
+    .insert(schema.quizDisputes)
+    .values({
+      resultId,
+      createdAt: new Date(),
+      createdByAccountId: user?.id ?? null,
+      createdByGuestLabel: !user && guest ? (guest.label ?? null) : null,
+      reason,
+      resolved: false,
+    })
+    .returning({ id: schema.quizDisputes.id, createdAt: schema.quizDisputes.createdAt })
+  return c.json({ id: inserted!.id, createdAt: inserted!.createdAt }, 201)
+})
+
+/**
+ * PATCH /api/meets/:id/disputes/:disputeId
+ *
+ * Admin-only resolve/unresolve toggle. Body: `{ resolved: boolean }`.
+ * `resolvedAt` and `resolvedByAccountId` are stamped on transitions to
+ * resolved=true and cleared on transitions back to false.
+ */
+results.patch('/:id/disputes/:disputeId', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const disputeId = Number(c.req.param('disputeId'))
+  if (Number.isNaN(meetId) || Number.isNaN(disputeId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const db = getDb(c)
+  // Cross-meet guard: ensure the dispute's parent result belongs to this meet.
+  const [dispute] = await db
+    .select({
+      id: schema.quizDisputes.id,
+      resultMeetId: schema.quizResults.meetId,
+    })
+    .from(schema.quizDisputes)
+    .innerJoin(schema.quizResults, eq(schema.quizResults.id, schema.quizDisputes.resultId))
+    .where(eq(schema.quizDisputes.id, disputeId))
+  if (!dispute || dispute.resultMeetId !== meetId) {
+    return c.json({ error: 'Dispute not found' }, 404)
+  }
+
+  const body = await c.req.json<{ resolved?: boolean }>()
+  if (typeof body.resolved !== 'boolean') {
+    return c.json({ error: 'resolved (boolean) is required' }, 400)
+  }
+
+  const user = c.get('user')!
+  const [updated] = await db
+    .update(schema.quizDisputes)
+    .set({
+      resolved: body.resolved,
+      resolvedAt: body.resolved ? new Date() : null,
+      resolvedByAccountId: body.resolved ? user.id : null,
+    })
+    .where(eq(schema.quizDisputes.id, disputeId))
+    .returning()
+  return c.json({ dispute: updated })
+})

--- a/packages/api/src/routes/results.ts
+++ b/packages/api/src/routes/results.ts
@@ -1,0 +1,115 @@
+import { Hono } from 'hono'
+import { eq, and } from 'drizzle-orm'
+import { Value } from '@sinclair/typebox/value'
+import { QuizFileSchema, type QuizFile } from '@qzr/shared'
+import type { Bindings } from '../bindings'
+import type { SessionVariables } from '../middleware/session'
+import { requireAuthOrGuest } from '../middleware/session'
+import { createDb, type Db } from '../lib/db'
+import { isOfficialOf } from '../lib/permissions'
+import * as schema from '../db/schema'
+
+interface ResultsVariables extends SessionVariables {
+  db: Db
+}
+
+type Env = { Bindings: Bindings; Variables: ResultsVariables }
+
+export const results = new Hono<Env>()
+
+// Mutation routes here admit guests with role=Official — see isOfficialOf
+// below. Read routes layer requireAuth() on top because admin lists do
+// not yet expose to guests.
+results.use('*', requireAuthOrGuest())
+results.use('*', async (c, next) => {
+  if (!c.get('db')) {
+    c.set('db', createDb(c.env.DB) as unknown as Db)
+  }
+  await next()
+})
+
+function getDb(c: { get(key: 'db'): Db }): Db {
+  return c.get('db')
+}
+
+/**
+ * POST /api/meets/:id/results
+ *
+ * Submit a completed scoresheet. Body: `{ quizFile, quizId?, roomId? }`.
+ * The QuizFile JSON is stored verbatim; (meetId, quizId) is unique when
+ * quizId is set, returning 409 on a second scheduled submission of the
+ * same quiz. Orphaned submissions (no quizId, no roomId) coexist
+ * freely — admins reconcile them post-hoc.
+ */
+results.post('/:id/results', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const db = getDb(c)
+  const [meet] = await db
+    .select({ id: schema.quizMeets.id })
+    .from(schema.quizMeets)
+    .where(eq(schema.quizMeets.id, meetId))
+  if (!meet) return c.json({ error: 'Meet not found' }, 404)
+
+  if (!(await isOfficialOf(c, db, meetId))) {
+    return c.json({ error: 'Official access required' }, 403)
+  }
+
+  const body = await c.req.json<{
+    quizFile: unknown
+    quizId?: number | null
+    roomId?: number | null
+  }>()
+
+  if (!Value.Check(QuizFileSchema, body.quizFile)) {
+    return c.json({ error: 'Invalid QuizFile' }, 400)
+  }
+  const quizFile = body.quizFile as QuizFile
+
+  if (body.quizId != null) {
+    const [q] = await db
+      .select({ id: schema.scheduledQuizzes.id })
+      .from(schema.scheduledQuizzes)
+      .where(
+        and(
+          eq(schema.scheduledQuizzes.id, body.quizId),
+          eq(schema.scheduledQuizzes.meetId, meetId),
+        ),
+      )
+    if (!q) return c.json({ error: 'Quiz does not belong to this meet' }, 400)
+  }
+  if (body.roomId != null) {
+    const [r] = await db
+      .select({ id: schema.meetRooms.id })
+      .from(schema.meetRooms)
+      .where(and(eq(schema.meetRooms.id, body.roomId), eq(schema.meetRooms.meetId, meetId)))
+    if (!r) return c.json({ error: 'Room does not belong to this meet' }, 400)
+  }
+
+  const user = c.get('user')
+  const guest = c.get('guest')
+
+  try {
+    const [inserted] = await db
+      .insert(schema.quizResults)
+      .values({
+        meetId,
+        quizId: body.quizId ?? null,
+        roomId: body.roomId ?? null,
+        division: quizFile.quiz.division,
+        round: quizFile.quiz.quizNumber,
+        submittedAt: new Date(),
+        submittedByAccountId: user?.id ?? null,
+        submittedByGuestLabel: !user && guest ? (guest.label ?? null) : null,
+        quizFile: JSON.stringify(quizFile),
+      })
+      .returning({ id: schema.quizResults.id, submittedAt: schema.quizResults.submittedAt })
+    return c.json({ id: inserted!.id, submittedAt: inserted!.submittedAt }, 201)
+  } catch (e) {
+    if (e instanceof Error && /UNIQUE.*quiz_results/.test(e.message)) {
+      return c.json({ error: 'A result already exists for this scheduled quiz' }, 409)
+    }
+    throw e
+  }
+})

--- a/packages/api/src/routes/results.ts
+++ b/packages/api/src/routes/results.ts
@@ -1,12 +1,12 @@
-import { Hono } from 'hono'
-import { eq, and } from 'drizzle-orm'
+import { Hono, type Context } from 'hono'
+import { eq, and, desc, inArray, sql } from 'drizzle-orm'
 import { Value } from '@sinclair/typebox/value'
 import { QuizFileSchema, type QuizFile } from '@qzr/shared'
 import type { Bindings } from '../bindings'
 import type { SessionVariables } from '../middleware/session'
 import { requireAuthOrGuest } from '../middleware/session'
 import { createDb, type Db } from '../lib/db'
-import { isOfficialOf } from '../lib/permissions'
+import { isAdminOrSuperuser, isOfficialOf } from '../lib/permissions'
 import * as schema from '../db/schema'
 
 interface ResultsVariables extends SessionVariables {
@@ -30,6 +30,16 @@ results.use('*', async (c, next) => {
 
 function getDb(c: { get(key: 'db'): Db }): Db {
   return c.get('db')
+}
+
+async function requireAdmin(c: Context<Env>, meetId: number) {
+  const user = c.get('user')
+  if (!user) return c.json({ error: 'Sign-in required' }, 401)
+  const db = getDb(c)
+  if (!(await isAdminOrSuperuser(db, user.id, user.role, meetId))) {
+    return c.json({ error: 'Admin or superuser access required' }, 403)
+  }
+  return null
 }
 
 /**
@@ -112,4 +122,82 @@ results.post('/:id/results', async (c) => {
     }
     throw e
   }
+})
+
+/**
+ * GET /api/meets/:id/results
+ *
+ * Admin/superuser list of submitted results for a meet, newest first.
+ * Includes an `openDisputes` count per row so the future admin UI can
+ * surface the badge without a second round-trip.
+ */
+results.get('/:id/results', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const db = getDb(c)
+  const rows = await db
+    .select({
+      id: schema.quizResults.id,
+      meetId: schema.quizResults.meetId,
+      quizId: schema.quizResults.quizId,
+      roomId: schema.quizResults.roomId,
+      division: schema.quizResults.division,
+      round: schema.quizResults.round,
+      submittedAt: schema.quizResults.submittedAt,
+      submittedByAccountId: schema.quizResults.submittedByAccountId,
+      submittedByGuestLabel: schema.quizResults.submittedByGuestLabel,
+    })
+    .from(schema.quizResults)
+    .where(eq(schema.quizResults.meetId, meetId))
+    .orderBy(desc(schema.quizResults.submittedAt), desc(schema.quizResults.id))
+
+  // Open-dispute counts as a separate query — cheaper than a left-join
+  // aggregate and the admin list will be small.
+  const resultIds = rows.map((r) => r.id)
+  const disputeRows =
+    resultIds.length === 0
+      ? []
+      : await db
+          .select({
+            resultId: schema.quizDisputes.resultId,
+            open: sql<number>`SUM(CASE WHEN ${schema.quizDisputes.resolved} = 0 THEN 1 ELSE 0 END)`,
+          })
+          .from(schema.quizDisputes)
+          .where(inArray(schema.quizDisputes.resultId, resultIds))
+          .groupBy(schema.quizDisputes.resultId)
+  const openByResult = new Map(disputeRows.map((d) => [d.resultId, Number(d.open)]))
+
+  return c.json({
+    results: rows.map((r) => ({ ...r, openDisputes: openByResult.get(r.id) ?? 0 })),
+  })
+})
+
+/**
+ * GET /api/meets/:id/results/:resultId
+ *
+ * Returns one result with the full QuizFile parsed back out of storage
+ * for admins to inspect.
+ */
+results.get('/:id/results/:resultId', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const resultId = Number(c.req.param('resultId'))
+  if (Number.isNaN(meetId) || Number.isNaN(resultId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const db = getDb(c)
+  const [row] = await db
+    .select()
+    .from(schema.quizResults)
+    .where(and(eq(schema.quizResults.id, resultId), eq(schema.quizResults.meetId, meetId)))
+  if (!row) return c.json({ error: 'Result not found' }, 404)
+
+  return c.json({ result: { ...row, quizFile: JSON.parse(row.quizFile) as QuizFile } })
 })

--- a/packages/api/src/test-db.ts
+++ b/packages/api/src/test-db.ts
@@ -198,6 +198,32 @@ export async function createTestDb(): Promise<Db> {
       resolved_at INTEGER NOT NULL,
       UNIQUE(meet_id, seed_ref)
     );
+
+    CREATE TABLE quiz_results (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      meet_id INTEGER NOT NULL REFERENCES quiz_meets(id) ON DELETE CASCADE,
+      quiz_id INTEGER REFERENCES scheduled_quizzes(id) ON DELETE SET NULL,
+      room_id INTEGER REFERENCES meet_rooms(id) ON DELETE SET NULL,
+      division TEXT NOT NULL,
+      round TEXT NOT NULL,
+      submitted_at INTEGER NOT NULL,
+      submitted_by_account_id TEXT REFERENCES user(id) ON DELETE SET NULL,
+      submitted_by_guest_label TEXT,
+      quiz_file TEXT NOT NULL,
+      UNIQUE(meet_id, quiz_id)
+    );
+
+    CREATE TABLE quiz_disputes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      result_id INTEGER NOT NULL REFERENCES quiz_results(id) ON DELETE CASCADE,
+      created_at INTEGER NOT NULL,
+      created_by_account_id TEXT REFERENCES user(id) ON DELETE SET NULL,
+      created_by_guest_label TEXT,
+      reason TEXT NOT NULL,
+      resolved INTEGER NOT NULL DEFAULT 0,
+      resolved_at INTEGER,
+      resolved_by_account_id TEXT REFERENCES user(id) ON DELETE SET NULL
+    );
   `)
 
   // Seed test users so FK constraints on membership tables are satisfied

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       '@qzr/shared':
         specifier: workspace:*
         version: link:../shared
+      '@sinclair/typebox':
+        specifier: ^0.34.0
+        version: 0.34.49
       better-auth:
         specifier: ^1.2.7
         version: 1.5.6(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.28.15)(sql.js@1.14.1))(vitest@3.2.4(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.28(typescript@5.9.3))
@@ -6119,7 +6122,7 @@ snapshots:
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260329.1
 
-  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.28.15)(sql.js@1.14.1))':
+  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(better-sqlite3@11.10.0)(kysely@0.28.15)(sql.js@1.14.1))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
@@ -7702,7 +7705,7 @@ snapshots:
   better-auth@1.5.6(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(better-sqlite3@11.10.0)(kysely@0.28.15)(sql.js@1.14.1))(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.28(typescript@5.9.3)):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.28.15)(sql.js@1.14.1))
+      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(better-sqlite3@11.10.0)(kysely@0.28.15)(sql.js@1.14.1))
       '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.15)
       '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
       '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
@@ -7731,7 +7734,7 @@ snapshots:
   better-auth@1.5.6(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.28.15)(sql.js@1.14.1))(vitest@3.2.4(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.28(typescript@5.9.3)):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.28.15)(sql.js@1.14.1))
+      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(better-sqlite3@11.10.0)(kysely@0.28.15)(sql.js@1.14.1))
       '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.15)
       '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
       '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)


### PR DESCRIPTION
Closes #7.

## Summary

- **API**: new `quiz_results` + `quiz_disputes` tables. `POST /meets/:id/results` accepts a QuizFile (validated via the shared TypeBox schema), enforces uniqueness on `(meetId, quizId)` only when a quizId is set (orphan submissions coexist freely), and stamps the submitter as either an account or a guest label. `GET /meets/:id/results` lists for admins with an `openDisputes` count per row; `GET /:resultId` returns the full QuizFile detail. POST `/results/:id/disputes` + PATCH `/disputes/:id` give a minimal flag-and-resolve loop.
- **Auth**: first mutation route that admits guest officials. New `isOfficialOf(c, db, meetId)` helper composes signed-in admin / official memberships and guest JWT `role=Official` for the meet.
- **Scoresheet**: `useResultSubmission` composable gates submission on validity + completion + meet binding, POSTs with `quizId` + `roomId` from the meet session, surfaces 409 as a duplicate-specific alert, and marks the session submitted on success. Submit button lives in the file-action bar; after success it's replaced by a "✓ Submitted" badge and the scoring surface dims + drops pointer events. Session-level lock clears whenever the binding is replaced (New, Open, different scheduled load, Unlink).
- **Versions**: `@qzr/api` 0.10.0 → 0.11.0, `scoresheet` 0.9.2 → 0.10.0. `@qzr/shared` unchanged.

## What's deferred (out of scope here)

- Admin UI for browsing submitted results / resolving disputes — the endpoints exist, the surface in `apps/web` ships later (tied to #16 / #8).
- "View this result on the schedule" linkage in the portal — still 4.10.
- Room-restricted guest tokens — the guest JWT doesn't carry `roomId` today; any guest official can submit for any room in the meet. Tightening that is a separate auth-model change.
- Re-submit / amend — server treats results as immutable. Admin can delete + ask for resubmit; that endpoint isn't here.

## Test plan

- [x] `pnpm test:unit` — api 250 tests + scoresheet 714 tests, all pass (45 new API tests + 11 new scoresheet composable tests).
- [x] `pnpm type-check` clean across all packages.
- [ ] Manual: sign in as admin, score a quiz to completion, click **Submit** → confirm → success alert → UI locked → second submit of the same scheduled quiz returns 409 alert.
- [ ] Manual: orphan path — score a quiz with Division + Quiz # set but no schedule load, Submit → another row with `quiz_id IS NULL` and `room_id IS NULL`.
- [ ] Manual: guest official token submits successfully; guest viewer gets 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)