### PR TITLE
feat: results history + submit (#7)

### DIFF
--- a/apps/scoresheet/CHANGELOG.md
+++ b/apps/scoresheet/CHANGELOG.md
@@ -15,6 +15,33 @@ portal/API/infra work shipped on that tag.
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-05-23
+
+### Added
+
+* **Server-side autosave** — when a meet is linked and server save is enabled, the scoresheet
+  streams its QuizFile to `/api/meets/:id/saves` on a 10-second debounce. Auto-enables when loaded
+  from a scheduled quiz; otherwise an explicit "Server autosave" toggle in the New menu turns it on
+  (requires sign-in or guest-official permission). Same- content dedupe so a quiet scoresheet
+  doesn't generate identical history rows. localStorage autosave continues unchanged — the server
+  path is best-effort, the local copy is durable.
+* **Manual "Save to server" checkpoint** — under the Save menu. Prompts for an optional label
+  ("after Q15") and POSTs immediately as `kind: 'checkpoint'`, bypassing the autosave debounce. Lets
+  officials pin a named milestone in the audit history.
+* **Submit (mark this quiz done)** — primary button in the file-action group when a meet is linked
+  and the scoresheet is complete + clean. POSTs to `/results` to freeze the current QuizFile as the
+  immutable official record. After success the local UI locks (scoring surface dims, "✓ Submitted"
+  badge replaces the button). Distinct from saves — Submit is a status flip; the server's save
+  history keeps growing for audit after Submit.
+* **`roomId` + `roomName` on the meet session** — captured from scheduled loads, mirrored to save /
+  result payloads. Persists alongside `quizId` across reloads.
+* **`serverSaveEnabled` + `submittedAt` on the meet session** — opt-in flag and lock timestamp. Both
+  auto-clear when the session is replaced (New, Open, different scheduled load, Unlink).
+
+### Bundled contract
+
+* `@qzr/shared@0.9.2` — unchanged.
+
 ## [0.9.2] — 2026-05-21
 
 First per-package scoresheet release. No source changes since 0.9.1 — bumping to establish the

--- a/apps/scoresheet/package.json
+++ b/apps/scoresheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scoresheet",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/scoresheet/src-tauri/tauri.conf.json
+++ b/apps/scoresheet/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "qzr-sheet",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "identifier": "com.quizmeet.sheet",
   "build": {
     "frontendDist": "../dist",

--- a/apps/scoresheet/src/api.ts
+++ b/apps/scoresheet/src/api.ts
@@ -1,4 +1,4 @@
-import { createApiClient } from '@qzr/shared'
+import { createApiClient, type QuizFile } from '@qzr/shared'
 import { getGuestToken } from './composables/useGuestSession'
 
 declare const __API_URL__: string
@@ -180,4 +180,46 @@ export async function joinMeetGuest(
   })
   if (!res.ok) return null
   return (await res.json()) as { token: string; meet: { id: number; name: string }; role: string }
+}
+
+// ---- Saves + results ----
+
+export interface SubmitSaveResponse {
+  id: number
+  savedAt: string
+}
+
+export function postSave(
+  meetId: number,
+  payload: {
+    quizFile: QuizFile
+    kind: 'autosave' | 'checkpoint'
+    scheduledQuizId: number | null
+    roomId: number | null
+    label?: string | null
+  },
+): Promise<SubmitSaveResponse> {
+  return request(`/api/meets/${meetId}/saves`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+}
+
+export interface SubmitResultResponse {
+  id: number
+  submittedAt: string
+}
+
+export function postResult(
+  meetId: number,
+  payload: {
+    quizFile: QuizFile
+    quizId: number | null
+    roomId: number | null
+  },
+): Promise<SubmitResultResponse> {
+  return request(`/api/meets/${meetId}/results`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
 }

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -26,6 +26,8 @@ import MeetPickerDialog from './MeetPickerDialog.vue'
 import SchedulePickerDialog from './SchedulePickerDialog.vue'
 import SignInWidget from './SignInWidget.vue'
 import TutorialOverlay from './TutorialOverlay.vue'
+import { useResultSubmission } from '../composables/useResultSubmission'
+import { useServerAutoSave } from '../composables/useServerAutoSave'
 
 const { theme, toggleTheme } = useTheme()
 
@@ -399,6 +401,65 @@ const tutorial = useTutorial({
   resetStore,
 })
 tutorial.recoverFromCrash()
+
+const liveQuizFile = computed(() =>
+  serialize({
+    quiz: store.quiz,
+    teams: store.teams,
+    quizzers: store.quizzers,
+    answers: store.answers,
+    noJumps: noJumpMap.value,
+    timeouts: timeoutMap.value,
+  }),
+)
+
+const autoSave = useServerAutoSave({ quizFile: liveQuizFile })
+
+const submission = useResultSubmission({
+  hasAnyErrors,
+  allQuestionsComplete,
+  quiz,
+  buildQuizFile: () => liveQuizFile.value,
+})
+
+async function doSaveToServer() {
+  closeMenus()
+  const label = window.prompt('Optional checkpoint label (e.g. "after Q15")') ?? undefined
+  const ok = await autoSave.saveCheckpoint(label?.trim() || undefined)
+  if (ok) {
+    alert('Checkpoint saved to the server.')
+  } else if (autoSave.lastError.value) {
+    alert(`Save failed: ${autoSave.lastError.value}`)
+  }
+}
+
+function toggleServerSave() {
+  closeMenus()
+  meetSession.setServerSaveEnabled(!meetSession.serverSaveEnabled.value)
+}
+
+async function doSubmit() {
+  if (!submission.canSubmit.value) return
+  const meetLabel = meetSession.meetName.value ?? 'this meet'
+  const roomLabel = meetSession.roomName.value ? ` (${meetSession.roomName.value})` : ''
+  if (
+    !(await confirmAction(
+      `Submit Div ${quiz.value.division} Q${quiz.value.quizNumber}${roomLabel} to ${meetLabel} as the final result? The scoresheet will lock.`,
+    ))
+  ) {
+    return
+  }
+  const outcome = await submission.submit()
+  if (outcome.ok) {
+    alert('Submitted. The scoresheet is now locked.')
+  } else if (outcome.duplicate) {
+    alert(
+      'A final result has already been submitted for this scheduled quiz. Save the JSON locally if you need to compare.',
+    )
+  } else if (outcome.error) {
+    alert(`Submit failed: ${outcome.error}`)
+  }
+}
 
 /** All unique validation messages for the status tooltip */
 const allValidationMessages = computed(() => {
@@ -826,7 +887,7 @@ const appVersion: string = __APP_VERSION__
     <div
       ref="wrapperRef"
       class="scoresheet-wrapper"
-      :class="{ 'is-dragging': dragState }"
+      :class="{ 'is-dragging': dragState, 'is-submitted': meetSession.isSubmitted.value }"
       @dragstart.prevent
     >
       <div
@@ -935,11 +996,45 @@ const appVersion: string = __APP_VERSION__
               </span>
               <span class="meta-divider" />
               <div class="meta-field meta-field--file">
+                <button
+                  v-if="meetSession.isActive.value && !meetSession.isSubmitted.value"
+                  class="submit-btn"
+                  :disabled="!submission.canSubmit.value || submission.submitting.value"
+                  :title="
+                    submission.canSubmit.value
+                      ? `Submit final result to ${meetSession.meetName.value}`
+                      : 'Complete + clean scoresheet required'
+                  "
+                  @click="doSubmit"
+                >
+                  {{ submission.submitting.value ? '…' : '⇪ Submit' }}
+                </button>
+                <span
+                  v-else-if="meetSession.isSubmitted.value"
+                  class="submit-badge"
+                  :title="`Submitted at ${meetSession.submittedAt.value}`"
+                >
+                  ✓ Submitted
+                </span>
                 <div class="file-menu">
                   <button title="Save / Export (Ctrl+S)" @click="toggleSaveMenu">⤓ Save ▾</button>
                   <div v-if="saveMenuOpen" class="file-menu__dropdown">
                     <button @click="doSaveFile">⤓ Save as JSON</button>
                     <button @click="doExportOds">⬡ Export ODS</button>
+                    <template v-if="meetSession.isActive.value && !meetSession.isSubmitted.value">
+                      <hr class="file-menu__divider" />
+                      <button
+                        :disabled="!meetSession.serverSaveEnabled.value || autoSave.inflight.value"
+                        :title="
+                          meetSession.serverSaveEnabled.value
+                            ? 'Save a labelled checkpoint to the server'
+                            : 'Enable server save first (New menu)'
+                        "
+                        @click="doSaveToServer"
+                      >
+                        ☁ Save to server
+                      </button>
+                    </template>
                   </div>
                 </div>
                 <button title="Open quiz from file (Ctrl+O)" @click="openFile">⤒ Open</button>
@@ -952,6 +1047,12 @@ const appVersion: string = __APP_VERSION__
                       ⚡ Unlink meet
                     </button>
                     <button v-else @click="doClearNames">✕ Clear names</button>
+                    <template v-if="meetSession.isActive.value">
+                      <hr class="file-menu__divider" />
+                      <button @click="toggleServerSave">
+                        {{ meetSession.serverSaveEnabled.value ? '◉' : '○' }} Server autosave
+                      </button>
+                    </template>
                     <hr class="file-menu__divider" />
                     <button @click="openMeetPicker">🔗 Load teams from meet…</button>
                     <button @click="openSchedulePicker">📅 Load from schedule…</button>
@@ -1925,6 +2026,45 @@ const appVersion: string = __APP_VERSION__
   color: var(--color-text);
   border-color: var(--color-text-faint);
   background: var(--color-border-alt);
+}
+
+.meta-field--file .submit-btn {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+.meta-field--file .submit-btn:not(:disabled):hover {
+  filter: brightness(1.08);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+.meta-field--file .submit-btn:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.submit-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.3rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--color-accent);
+  border: 1px solid var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+}
+
+/* Lock the scoring surface once submitted. The meta header stays
+ * interactive (Save, Open, New, Submit badge) so the user can still
+ * download / start over / unlink. */
+.scoresheet-wrapper.is-submitted .scoresheet,
+.scoresheet-wrapper.is-submitted .quiz-meta--right {
+  pointer-events: none;
+  opacity: 0.7;
 }
 
 .menu-backdrop {

--- a/apps/scoresheet/src/components/Scoresheet.vue
+++ b/apps/scoresheet/src/components/Scoresheet.vue
@@ -136,7 +136,10 @@ async function loadScheduledQuiz(meetId: number, quizId: number): Promise<boolea
     slots[slotIdx] = change.slot
     storeMirrors.push(change.mirrorToStore)
   }
-  meetSession.applyLoadedQuiz(slots, quizId)
+  meetSession.applyLoadedQuiz(slots, quizId, {
+    roomId: details.quiz.roomId,
+    roomName: details.quiz.roomName,
+  })
   for (const mirror of storeMirrors) mirror()
   return true
 }

--- a/apps/scoresheet/src/composables/__tests__/useMeetSession.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useMeetSession.spec.ts
@@ -330,6 +330,56 @@ describe('useMeetSession — buildSlotFromSeat + applyLoadedQuiz', () => {
     expect(getSlot(1)).toBeUndefined()
     expect(quizId.value).toBe(555)
   })
+
+  it('applyLoadedQuiz captures roomId + roomName + auto-enables server save', async () => {
+    const { loadMeet, applyLoadedQuiz, roomId, roomName, serverSaveEnabled } = useMeetSession()
+    await loadMeet(42, 'Finals')
+    expect(serverSaveEnabled.value).toBe(false)
+
+    applyLoadedQuiz([undefined, undefined, undefined], 555, { roomId: 9, roomName: 'Sanctuary' })
+
+    expect(roomId.value).toBe(9)
+    expect(roomName.value).toBe('Sanctuary')
+    expect(serverSaveEnabled.value).toBe(true)
+  })
+
+  it('loadMeet without quiz clears any prior room context + server-save opt-in', async () => {
+    const { loadMeet, applyLoadedQuiz, roomId, roomName, serverSaveEnabled } = useMeetSession()
+    await loadMeet(42, 'Finals')
+    applyLoadedQuiz([undefined, undefined, undefined], 555, { roomId: 9, roomName: 'Sanctuary' })
+    await loadMeet(42, 'Finals')
+    expect(roomId.value).toBeNull()
+    expect(roomName.value).toBeNull()
+    expect(serverSaveEnabled.value).toBe(false)
+  })
+
+  it('setServerSaveEnabled toggles the opt-in flag', async () => {
+    const { loadMeet, setServerSaveEnabled, serverSaveEnabled } = useMeetSession()
+    await loadMeet(42, 'Finals')
+    expect(serverSaveEnabled.value).toBe(false)
+    setServerSaveEnabled(true)
+    expect(serverSaveEnabled.value).toBe(true)
+    setServerSaveEnabled(false)
+    expect(serverSaveEnabled.value).toBe(false)
+  })
+
+  it('markSubmitted stamps submittedAt and isSubmitted flips', async () => {
+    const { loadMeet, markSubmitted, isSubmitted, submittedAt } = useMeetSession()
+    await loadMeet(42, 'Finals')
+    expect(isSubmitted.value).toBe(false)
+    markSubmitted(new Date('2026-05-23T18:00:00.000Z'))
+    expect(isSubmitted.value).toBe(true)
+    expect(submittedAt.value).toBe('2026-05-23T18:00:00.000Z')
+  })
+
+  it('applyLoadedQuiz clears submittedAt (fresh binding unlocks)', async () => {
+    const { loadMeet, markSubmitted, applyLoadedQuiz, isSubmitted } = useMeetSession()
+    await loadMeet(42, 'Finals')
+    markSubmitted()
+    expect(isSubmitted.value).toBe(true)
+    applyLoadedQuiz([undefined, undefined, undefined], 556)
+    expect(isSubmitted.value).toBe(false)
+  })
 })
 
 describe('useMeetSession — clearSlot', () => {

--- a/apps/scoresheet/src/composables/__tests__/useResultSubmission.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useResultSubmission.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { ApiError, FILE_VERSION, PlacementFormula, type QuizFile } from '@qzr/shared'
+import { useMeetSession } from '../useMeetSession'
+import { useResultSubmission, type ScoresheetSubmitDeps } from '../useResultSubmission'
+
+vi.mock('../../api', () => ({
+  postResult: vi.fn(),
+}))
+
+import { postResult } from '../../api'
+
+function makeQuizFile(): QuizFile {
+  return {
+    version: FILE_VERSION,
+    quiz: {
+      division: '1',
+      quizNumber: '1',
+      overtime: false,
+      placementFormula: PlacementFormula.Rules,
+      questionTypes: [],
+    },
+    teams: [],
+    answers: [],
+    noJumps: [],
+  }
+}
+
+function makeDeps(overrides: Partial<ScoresheetSubmitDeps> = {}): ScoresheetSubmitDeps {
+  return {
+    hasAnyErrors: ref(false),
+    allQuestionsComplete: ref(true),
+    quiz: { value: { division: '1', quizNumber: '1' } },
+    buildQuizFile: () => makeQuizFile(),
+    ...overrides,
+  }
+}
+
+function activateSession(
+  overrides: Partial<Parameters<ReturnType<typeof useMeetSession>['restoreSession']>[0]> = {},
+) {
+  const session = useMeetSession()
+  session.restoreSession({
+    meetId: 42,
+    meetName: 'Finals',
+    slots: [undefined, undefined, undefined],
+    teamList: [],
+    meetDivisions: [],
+    quizId: 777,
+    roomId: 9,
+    roomName: 'Sanctuary',
+    serverSaveEnabled: true,
+    submittedAt: null,
+    ...overrides,
+  })
+  return session
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.mocked(postResult).mockReset()
+})
+
+describe('useResultSubmission — canSubmit', () => {
+  it('false without meet session', () => {
+    const { canSubmit } = useResultSubmission(makeDeps())
+    expect(canSubmit.value).toBe(false)
+  })
+
+  it('true with valid + complete + meet binding', () => {
+    activateSession()
+    const { canSubmit } = useResultSubmission(makeDeps())
+    expect(canSubmit.value).toBe(true)
+    useMeetSession().clearSession()
+  })
+
+  it('false when there are validation errors', () => {
+    activateSession()
+    const { canSubmit } = useResultSubmission(makeDeps({ hasAnyErrors: ref(true) }))
+    expect(canSubmit.value).toBe(false)
+    useMeetSession().clearSession()
+  })
+
+  it('false when incomplete', () => {
+    activateSession()
+    const { canSubmit } = useResultSubmission(makeDeps({ allQuestionsComplete: ref(false) }))
+    expect(canSubmit.value).toBe(false)
+    useMeetSession().clearSession()
+  })
+
+  it('false when meta is blank', () => {
+    activateSession()
+    const { canSubmit } = useResultSubmission(
+      makeDeps({ quiz: { value: { division: '', quizNumber: '1' } } }),
+    )
+    expect(canSubmit.value).toBe(false)
+    useMeetSession().clearSession()
+  })
+
+  it('false once submitted', () => {
+    activateSession({ submittedAt: '2026-05-23T00:00:00.000Z' })
+    const { canSubmit } = useResultSubmission(makeDeps())
+    expect(canSubmit.value).toBe(false)
+    useMeetSession().clearSession()
+  })
+})
+
+describe('useResultSubmission — submit', () => {
+  it('posts quizFile + quizId + roomId and marks submitted', async () => {
+    const session = activateSession()
+    vi.mocked(postResult).mockResolvedValueOnce({ id: 1, submittedAt: 'now' })
+    const { submit } = useResultSubmission(makeDeps())
+
+    const outcome = await submit()
+    expect(outcome).toEqual({ ok: true })
+    expect(postResult).toHaveBeenCalledWith(42, {
+      quizFile: makeQuizFile(),
+      quizId: 777,
+      roomId: 9,
+    })
+    expect(session.isSubmitted.value).toBe(true)
+    session.clearSession()
+  })
+
+  it('surfaces 409 as duplicate without marking submitted', async () => {
+    const session = activateSession()
+    vi.mocked(postResult).mockRejectedValueOnce(new ApiError(409, 'already exists'))
+    const { submit } = useResultSubmission(makeDeps())
+    const outcome = await submit()
+    expect(outcome).toEqual({ ok: false, duplicate: true })
+    expect(session.isSubmitted.value).toBe(false)
+    session.clearSession()
+  })
+
+  it('surfaces other errors via submitError', async () => {
+    const session = activateSession()
+    vi.mocked(postResult).mockRejectedValueOnce(new ApiError(500, 'boom'))
+    const { submit, submitError } = useResultSubmission(makeDeps())
+    const outcome = await submit()
+    expect(outcome.ok).toBe(false)
+    expect(submitError.value).toBe('boom')
+    expect(session.isSubmitted.value).toBe(false)
+    session.clearSession()
+  })
+
+  it('skips the post when canSubmit is false', async () => {
+    const { submit } = useResultSubmission(makeDeps())
+    const outcome = await submit()
+    expect(outcome).toEqual({ ok: false })
+    expect(postResult).not.toHaveBeenCalled()
+  })
+})

--- a/apps/scoresheet/src/composables/__tests__/useServerAutoSave.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useServerAutoSave.spec.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { computed, effectScope, ref } from 'vue'
+import { ApiError, FILE_VERSION, PlacementFormula, type QuizFile } from '@qzr/shared'
+import { useMeetSession } from '../useMeetSession'
+import { useServerAutoSave } from '../useServerAutoSave'
+
+vi.mock('../../api', () => ({
+  postSave: vi.fn(),
+}))
+
+import { postSave } from '../../api'
+
+function makeQuizFile(overrides: Partial<QuizFile['quiz']> = {}): QuizFile {
+  return {
+    version: FILE_VERSION,
+    quiz: {
+      division: '1',
+      quizNumber: '1',
+      overtime: false,
+      placementFormula: PlacementFormula.Rules,
+      questionTypes: [],
+      ...overrides,
+    },
+    teams: [],
+    answers: [],
+    noJumps: [],
+  }
+}
+
+function activateSession({
+  serverSaveEnabled = true,
+  scheduledQuizId = 777 as number | null,
+  roomId = 9 as number | null,
+} = {}) {
+  const session = useMeetSession()
+  session.restoreSession({
+    meetId: 42,
+    meetName: 'Finals',
+    slots: [undefined, undefined, undefined],
+    teamList: [],
+    meetDivisions: [],
+    quizId: scheduledQuizId,
+    roomId,
+    roomName: 'Sanctuary',
+    serverSaveEnabled,
+    submittedAt: null,
+  })
+  return session
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  localStorage.clear()
+  vi.mocked(postSave).mockReset()
+  vi.mocked(postSave).mockResolvedValue({ id: 1, savedAt: '2026-05-23T20:00:00.000Z' })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  useMeetSession().clearSession()
+})
+
+describe('useServerAutoSave — debouncing', () => {
+  it('coalesces a burst of edits into one POST after the debounce window', async () => {
+    activateSession()
+    const scope = effectScope()
+    scope.run(() => {
+      const qf = ref<QuizFile>(makeQuizFile())
+      useServerAutoSave({ quizFile: qf })
+      qf.value = makeQuizFile({ division: '2' })
+      qf.value = makeQuizFile({ division: '3' })
+      qf.value = makeQuizFile({ division: '4' })
+    })
+    expect(postSave).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(postSave).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(postSave).mock.calls[0]![1].quizFile.quiz.division).toBe('4')
+    scope.stop()
+  })
+
+  it('does not post when serverSaveEnabled is false', async () => {
+    activateSession({ serverSaveEnabled: false })
+    const scope = effectScope()
+    scope.run(() => {
+      const qf = ref<QuizFile>(makeQuizFile())
+      useServerAutoSave({ quizFile: qf })
+      qf.value = makeQuizFile({ division: '2' })
+    })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(postSave).not.toHaveBeenCalled()
+    scope.stop()
+  })
+
+  it('does not post when isSubmitted is true', async () => {
+    const session = activateSession()
+    session.markSubmitted()
+    const scope = effectScope()
+    scope.run(() => {
+      const qf = ref<QuizFile>(makeQuizFile())
+      useServerAutoSave({ quizFile: qf })
+      qf.value = makeQuizFile({ division: '2' })
+    })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(postSave).not.toHaveBeenCalled()
+    scope.stop()
+  })
+
+  it('flipping serverSaveEnabled on schedules an immediate autosave', async () => {
+    const session = activateSession({ serverSaveEnabled: false })
+    const scope = effectScope()
+    scope.run(() => {
+      const qf = ref<QuizFile>(makeQuizFile())
+      useServerAutoSave({ quizFile: qf })
+      session.setServerSaveEnabled(true)
+    })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(postSave).toHaveBeenCalledTimes(1)
+    scope.stop()
+  })
+
+  it('flipping serverSaveEnabled off cancels a pending autosave', async () => {
+    const session = activateSession()
+    const scope = effectScope()
+    scope.run(() => {
+      const qf = ref<QuizFile>(makeQuizFile())
+      useServerAutoSave({ quizFile: qf })
+      qf.value = makeQuizFile({ division: '2' })
+      session.setServerSaveEnabled(false)
+    })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(postSave).not.toHaveBeenCalled()
+    scope.stop()
+  })
+})
+
+describe('useServerAutoSave — payload', () => {
+  it('posts the current QuizFile with scheduledQuizId + roomId from the session', async () => {
+    activateSession({ scheduledQuizId: 777, roomId: 9 })
+    const scope = effectScope()
+    scope.run(() => {
+      const qf = ref<QuizFile>(makeQuizFile())
+      useServerAutoSave({ quizFile: qf })
+      qf.value = makeQuizFile({ quizNumber: '7' })
+    })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(postSave).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({
+        kind: 'autosave',
+        scheduledQuizId: 777,
+        roomId: 9,
+      }),
+    )
+    scope.stop()
+  })
+
+  it('skips a duplicate autosave when content is unchanged since the last POST', async () => {
+    activateSession()
+    const scope = effectScope()
+    scope.run(() => {
+      const qf = ref<QuizFile>(makeQuizFile({ division: '5' }))
+      useServerAutoSave({ quizFile: qf })
+      // First edit -> POST
+      qf.value = makeQuizFile({ division: '5' })
+    })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(postSave).toHaveBeenCalledTimes(1)
+
+    // Touch the ref to the same content — dedupe should skip the POST.
+    const session = useMeetSession()
+    session.setServerSaveEnabled(false)
+    session.setServerSaveEnabled(true)
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(postSave).toHaveBeenCalledTimes(1)
+    scope.stop()
+  })
+})
+
+describe('useServerAutoSave — saveCheckpoint', () => {
+  it('forces an immediate POST with kind=checkpoint and the supplied label', async () => {
+    activateSession()
+    const scope = effectScope()
+    const result = await scope.run(async () => {
+      const qf = ref<QuizFile>(makeQuizFile())
+      const { saveCheckpoint } = useServerAutoSave({ quizFile: qf })
+      return saveCheckpoint('end of Q15')
+    })
+    expect(result).toBe(true)
+    expect(postSave).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(postSave).mock.calls[0]![1]).toMatchObject({
+      kind: 'checkpoint',
+      label: 'end of Q15',
+    })
+    scope.stop()
+  })
+
+  it('saveCheckpoint returns false when not authorised / disabled', async () => {
+    activateSession({ serverSaveEnabled: false })
+    const scope = effectScope()
+    const result = await scope.run(async () => {
+      const qf = ref<QuizFile>(makeQuizFile())
+      const { saveCheckpoint } = useServerAutoSave({ quizFile: qf })
+      return saveCheckpoint('try anyway')
+    })
+    expect(result).toBe(false)
+    expect(postSave).not.toHaveBeenCalled()
+    scope.stop()
+  })
+
+  it('saveCheckpoint cancels a pending autosave and resets dedupe', async () => {
+    activateSession()
+    const scope = effectScope()
+    scope.run(async () => {
+      const qf = ref<QuizFile>(makeQuizFile())
+      const { saveCheckpoint } = useServerAutoSave({ quizFile: qf })
+      qf.value = makeQuizFile({ division: '2' })
+      await saveCheckpoint('mid-quiz')
+    })
+    await vi.advanceTimersByTimeAsync(10_000)
+    // Only the explicit checkpoint posted; the autosave it cancelled
+    // would have been a same-content duplicate and skipped anyway —
+    // but the dedupe reset means a future identical autosave still
+    // skips, which we verify by not triggering another edit.
+    expect(postSave).toHaveBeenCalledTimes(1)
+    scope.stop()
+  })
+})
+
+describe('useServerAutoSave — errors', () => {
+  it('surfaces the error message on failure but keeps the watcher live', async () => {
+    activateSession()
+    vi.mocked(postSave).mockRejectedValueOnce(new ApiError(500, 'boom'))
+    const scope = effectScope()
+    const handle = scope.run(() => {
+      const qf = ref<QuizFile>(makeQuizFile())
+      const h = useServerAutoSave({ quizFile: qf })
+      qf.value = makeQuizFile({ division: '2' })
+      return { qf, h }
+    })!
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(handle.h.lastError.value).toBe('boom')
+
+    // Recovery: next successful POST clears the error.
+    vi.mocked(postSave).mockResolvedValueOnce({ id: 2, savedAt: '2026-05-23T20:01:00.000Z' })
+    handle.qf.value = makeQuizFile({ division: '3' })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(handle.h.lastError.value).toBeNull()
+    expect(handle.h.lastSavedAt.value).toBe('2026-05-23T20:01:00.000Z')
+    scope.stop()
+  })
+})
+
+describe('useServerAutoSave — scope cleanup', () => {
+  it('cancels pending autosaves on scope dispose', async () => {
+    activateSession()
+    const scope = effectScope()
+    scope.run(() => {
+      const qf = ref<QuizFile>(makeQuizFile())
+      useServerAutoSave({ quizFile: qf })
+      qf.value = makeQuizFile({ division: '2' })
+    })
+    scope.stop()
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(postSave).not.toHaveBeenCalled()
+  })
+})
+
+describe('useServerAutoSave — computed quizFile source', () => {
+  it('also accepts a computed ref', async () => {
+    activateSession()
+    const scope = effectScope()
+    const trigger = ref(0)
+    scope.run(() => {
+      const qf = computed<QuizFile>(() => makeQuizFile({ quizNumber: `${trigger.value}` }))
+      useServerAutoSave({ quizFile: qf })
+      trigger.value = 5
+    })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(postSave).toHaveBeenCalledTimes(1)
+    scope.stop()
+  })
+})

--- a/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
+++ b/apps/scoresheet/src/composables/__tests__/useTutorial.spec.ts
@@ -201,6 +201,10 @@ describe('useTutorial — meet link', () => {
       teamList: [],
       meetDivisions: ['1'],
       quizId: null,
+      roomId: null,
+      roomName: null,
+      serverSaveEnabled: false,
+      submittedAt: null,
     })
     expect(meet.isActive.value).toBe(true)
 
@@ -235,6 +239,10 @@ describe('useTutorial — meet link', () => {
       teamList: [],
       meetDivisions: [],
       quizId: null,
+      roomId: null,
+      roomName: null,
+      serverSaveEnabled: false,
+      submittedAt: null,
     })
 
     const s = useScoresheet()

--- a/apps/scoresheet/src/composables/useMeetSession.ts
+++ b/apps/scoresheet/src/composables/useMeetSession.ts
@@ -29,9 +29,23 @@ export interface MeetSessionData {
   /** The meet's canonical division list, e.g. ["1", "2", "3"] */
   meetDivisions: string[]
   /** Set when this session was loaded from a specific scheduled quiz
-   *  (via loadFromQuiz). Stamped onto submitted results in the future
-   *  Submit flow (#7) so they back-link to the schedule entry. */
+   *  (via loadFromQuiz). Stamped onto server saves + submitted results
+   *  so they back-link to the schedule entry. */
   quizId: number | null
+  /** Room context captured at scheduled-quiz load time. Mirrored to
+   *  the save / result payloads. Null on standalone sessions. */
+  roomId: number | null
+  roomName: string | null
+  /** Whether to stream the QuizFile to the server on every change.
+   *  Auto-true when loaded from a scheduled quiz; manual opt-in
+   *  otherwise via setServerSaveEnabled(). Off-by-default for
+   *  standalone meet bindings. */
+  serverSaveEnabled: boolean
+  /** ISO timestamp set after a successful POST /results. Locks the
+   *  scoresheet UI; saves keep flowing on the server side (audit
+   *  trail) but the local UI presents as final. Cleared whenever the
+   *  session is replaced (New, Open, different scheduled load, Unlink). */
+  submittedAt: string | null
 }
 
 const session = ref<MeetSessionData | null>(loadFromStorage())
@@ -42,6 +56,11 @@ export function useMeetSession() {
   const meetName = computed(() => session.value?.meetName ?? null)
   const teamList = computed(() => session.value?.teamList ?? [])
   const quizId = computed(() => session.value?.quizId ?? null)
+  const roomId = computed(() => session.value?.roomId ?? null)
+  const roomName = computed(() => session.value?.roomName ?? null)
+  const serverSaveEnabled = computed(() => session.value?.serverSaveEnabled ?? false)
+  const submittedAt = computed(() => session.value?.submittedAt ?? null)
+  const isSubmitted = computed(() => session.value?.submittedAt != null)
 
   /** Division options for the scoresheet dropdown — the meet's canonical division list. */
   const divisionOptions = computed((): string[] => session.value?.meetDivisions ?? [])
@@ -76,6 +95,11 @@ export function useMeetSession() {
       teamList: teams,
       meetDivisions,
       quizId: null,
+      roomId: null,
+      roomName: null,
+      // Standalone meet binding: opt-in to server save via the UI.
+      serverSaveEnabled: false,
+      submittedAt: null,
     }
     persist()
   }
@@ -114,13 +138,44 @@ export function useMeetSession() {
   }
 
   /**
-   * Atomically commit a quiz load: replace the 3 slot assignments
-   * and stamp `quizId`. One reactivity tick, one `localStorage`
-   * write — vs. one per slot if callers used per-slot setters.
+   * Atomically commit a quiz load: replace the 3 slot assignments,
+   * stamp `quizId` and room context, auto-enable server save (the
+   * scoresheet was opened from the schedule — the official is on
+   * record). Clears any prior submittedAt because this is a fresh
+   * binding.
    */
-  function applyLoadedQuiz(slots: (SlotSession | undefined)[], quizId: number): void {
+  function applyLoadedQuiz(
+    slots: (SlotSession | undefined)[],
+    quizId: number,
+    room: { roomId: number; roomName: string } | null = null,
+  ): void {
     if (!session.value) return
-    session.value = { ...session.value, slots, quizId }
+    session.value = {
+      ...session.value,
+      slots,
+      quizId,
+      roomId: room?.roomId ?? null,
+      roomName: room?.roomName ?? null,
+      serverSaveEnabled: true,
+      submittedAt: null,
+    }
+    persist()
+  }
+
+  /** Flip the server-save opt-in for a standalone meet binding. */
+  function setServerSaveEnabled(enabled: boolean): void {
+    if (!session.value) return
+    if (session.value.serverSaveEnabled === enabled) return
+    session.value = { ...session.value, serverSaveEnabled: enabled }
+    persist()
+  }
+
+  /** Mark the current scoresheet as submitted. Locks the local UI until
+   *  the session is replaced. Idempotent — overwriting the timestamp
+   *  has no other effect. */
+  function markSubmitted(at: Date = new Date()): void {
+    if (!session.value) return
+    session.value = { ...session.value, submittedAt: at.toISOString() }
     persist()
   }
 
@@ -236,10 +291,17 @@ export function useMeetSession() {
     teamsForDivision,
     teamLabel,
     teamLabelFull,
+    roomId,
+    roomName,
+    serverSaveEnabled,
+    submittedAt,
+    isSubmitted,
     loadMeet,
     loadFromQuiz,
     buildSlotFromSeat,
     applyLoadedQuiz,
+    setServerSaveEnabled,
+    markSubmitted,
     assignTeam,
     clearSlot,
     getSlot,
@@ -356,6 +418,10 @@ function loadFromStorage(): MeetSessionData | null {
     // Migrate fields added after old sessions were persisted.
     if (!data.meetDivisions) data.meetDivisions = []
     if (data.quizId === undefined) data.quizId = null
+    if (data.roomId === undefined) data.roomId = null
+    if (data.roomName === undefined) data.roomName = null
+    if (data.serverSaveEnabled === undefined) data.serverSaveEnabled = false
+    if (data.submittedAt === undefined) data.submittedAt = null
     return data
   } catch {
     return null

--- a/apps/scoresheet/src/composables/useResultSubmission.ts
+++ b/apps/scoresheet/src/composables/useResultSubmission.ts
@@ -1,0 +1,71 @@
+import { ref, computed, type ComputedRef, type Ref } from 'vue'
+import { ApiError, type QuizFile } from '@qzr/shared'
+import { postResult } from '../api'
+import { useMeetSession } from './useMeetSession'
+
+export interface ScoresheetSubmitDeps {
+  hasAnyErrors: Ref<boolean> | ComputedRef<boolean>
+  allQuestionsComplete: Ref<boolean> | ComputedRef<boolean>
+  quiz: { value: { division: string; quizNumber: string } }
+  buildQuizFile: () => QuizFile
+}
+
+export type SubmitOutcome = { ok: true } | { ok: false; duplicate?: boolean; error?: string }
+
+/**
+ * Submit = freeze the current QuizFile as the official record. Distinct
+ * from server autosave (history of in-progress saves) — Submit is the
+ * room-level "we're done with this quiz" status flip. After success the
+ * meet session is markedSubmitted; the local UI locks; the server's
+ * /saves history keeps accepting rows (audit) but quiz_results stays
+ * frozen.
+ */
+export function useResultSubmission(deps: ScoresheetSubmitDeps, session = useMeetSession()) {
+  const submitting = ref(false)
+  const submitError = ref<string | null>(null)
+
+  const canSubmit = computed(
+    () =>
+      session.isActive.value &&
+      !session.isSubmitted.value &&
+      !deps.hasAnyErrors.value &&
+      deps.allQuestionsComplete.value &&
+      deps.quiz.value.division.trim() !== '' &&
+      deps.quiz.value.quizNumber.trim() !== '',
+  )
+
+  async function submit(): Promise<SubmitOutcome> {
+    if (!canSubmit.value) return { ok: false }
+    const meetId = session.meetId.value
+    if (meetId == null) return { ok: false }
+
+    submitting.value = true
+    submitError.value = null
+    try {
+      await postResult(meetId, {
+        quizFile: deps.buildQuizFile(),
+        quizId: session.quizId.value,
+        roomId: session.roomId.value,
+      })
+      session.markSubmitted()
+      return { ok: true }
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 409) {
+        return { ok: false, duplicate: true }
+      }
+      const msg = e instanceof Error ? e.message : String(e)
+      submitError.value = msg
+      return { ok: false, error: msg }
+    } finally {
+      submitting.value = false
+    }
+  }
+
+  return {
+    submitting,
+    submitError,
+    canSubmit,
+    submit,
+    isSubmitted: session.isSubmitted,
+  }
+}

--- a/apps/scoresheet/src/composables/useServerAutoSave.ts
+++ b/apps/scoresheet/src/composables/useServerAutoSave.ts
@@ -1,0 +1,151 @@
+import { ref, watch, onScopeDispose, type Ref, type ComputedRef } from 'vue'
+import { ApiError, type QuizFile } from '@qzr/shared'
+import { postSave } from '../api'
+import { useMeetSession } from './useMeetSession'
+
+/** Default debounce — long enough that a burst of cell edits coalesces
+ *  into one POST, short enough that a tablet crash loses ≤ this much. */
+const DEFAULT_DEBOUNCE_MS = 10_000
+
+export interface ServerAutoSaveDeps {
+  /** Reactive QuizFile (or factory). Each new identity triggers a
+   *  debounced POST. */
+  quizFile: Ref<QuizFile> | ComputedRef<QuizFile>
+}
+
+/**
+ * Streams the scoresheet's current QuizFile to the server while the
+ * meet session has `serverSaveEnabled === true`. Debounced — a flurry
+ * of edits collapses into one POST. Silent on errors (the localStorage
+ * autosave is still the durable copy).
+ *
+ * Cancelled inflight when the session opts out, when the meet is
+ * unlinked, or when the consumer scope unmounts. Does NOT fire after
+ * `markSubmitted` — that's the lock signal; further edits still flow
+ * to localStorage but not to the server until a fresh binding.
+ *
+ * Skipping the server doesn't disable local autosave — see
+ * persistence/autoSave.ts for the local path that always runs.
+ */
+export function useServerAutoSave(
+  deps: ServerAutoSaveDeps,
+  session = useMeetSession(),
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+) {
+  const lastSavedAt = ref<string | null>(null)
+  const lastError = ref<string | null>(null)
+  const inflight = ref(false)
+
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let lastPostedSerialised: string | null = null
+
+  function shouldSave(): boolean {
+    return (
+      session.isActive.value &&
+      session.serverSaveEnabled.value &&
+      !session.isSubmitted.value &&
+      session.meetId.value != null
+    )
+  }
+
+  async function postNow(kind: 'autosave' | 'checkpoint', label?: string): Promise<boolean> {
+    const meetId = session.meetId.value
+    if (meetId == null) return false
+    if (kind === 'autosave' && !shouldSave()) return false
+
+    const payload = deps.quizFile.value
+    const serialised = JSON.stringify(payload)
+    // Skip duplicate autosaves — same content as the last POST.
+    if (kind === 'autosave' && serialised === lastPostedSerialised) return false
+
+    inflight.value = true
+    lastError.value = null
+    try {
+      const res = await postSave(meetId, {
+        quizFile: payload,
+        kind,
+        scheduledQuizId: session.quizId.value,
+        roomId: session.roomId.value,
+        label: label ?? null,
+      })
+      lastSavedAt.value = res.savedAt
+      lastPostedSerialised = serialised
+      return true
+    } catch (e) {
+      lastError.value =
+        e instanceof ApiError ? e.message : e instanceof Error ? e.message : String(e)
+      return false
+    } finally {
+      inflight.value = false
+    }
+  }
+
+  function cancelPendingAutosave() {
+    if (timer != null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  function scheduleAutosave() {
+    cancelPendingAutosave()
+    if (!shouldSave()) return
+    timer = setTimeout(() => {
+      timer = null
+      void postNow('autosave')
+    }, debounceMs)
+  }
+
+  /** Force a checkpoint save (manual "Save to server" button). Bypasses
+   *  the debounce + the same-content skip; respects opt-in + submitted
+   *  guards. Returns true on success. */
+  function saveCheckpoint(label?: string): Promise<boolean> {
+    if (!shouldSave()) return Promise.resolve(false)
+    cancelPendingAutosave()
+    // Reset the dedupe sentinel so the next autosave still posts even
+    // if the user makes zero edits after the checkpoint.
+    lastPostedSerialised = null
+    return postNow('checkpoint', label)
+  }
+
+  // Watch the QuizFile identity (deep) — re-arms the debounce on every
+  // edit. The serialise + compare in postNow handles same-content
+  // no-ops (resetStore producing an identical JSON, etc.).
+  watch(
+    () => deps.quizFile.value,
+    () => scheduleAutosave(),
+    { deep: true },
+  )
+  // Also react to opt-in flips so turning the toggle on triggers an
+  // immediate autosave of the current state.
+  watch(
+    () => session.serverSaveEnabled.value,
+    (enabled) => {
+      if (enabled) scheduleAutosave()
+      else cancelPendingAutosave()
+    },
+  )
+  // If the meet binding changes (new quiz loaded, unlinked, etc.),
+  // reset the dedupe sentinel — the next save is conceptually new.
+  watch(
+    () => `${session.meetId.value ?? 'none'}:${session.quizId.value ?? 'none'}`,
+    () => {
+      lastPostedSerialised = null
+    },
+  )
+
+  onScopeDispose(() => {
+    cancelPendingAutosave()
+  })
+
+  return {
+    /** ISO timestamp returned by the server for the most recent successful save. */
+    lastSavedAt,
+    /** Last error message, or null after a successful save. */
+    lastError,
+    /** True while a POST is in flight. */
+    inflight,
+    /** Manual checkpoint — returns true on success. */
+    saveCheckpoint,
+  }
+}

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -17,6 +17,40 @@ wire/state compatibility signal — see CLAUDE.md "Contract package versioning".
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-05-23
+
+### Added
+
+* **`quiz_saves` table** — append-only history of in-progress scoresheet state. Both autosaves
+  (debounced bursts from the scoresheet) and manual checkpoints land here; admins scrub the history
+  for audit and recovery. No uniqueness; every save is a new row.
+* **`quiz_results` table** — frozen "Submit" snapshot. Distinct from `quiz_saves` — Submit is a
+  status flip, not a data event. Stats read from `quiz_results`. UNIQUE(meetId, quizId) returns 409
+  on a second submit of the same scheduled quiz; orphan results (quizId NULL) coexist because SQLite
+  treats NULL as distinct.
+* **`quiz_disputes` table** — multi-per-result flag-and-resolve loop. Officials raise; admins
+  resolve. Resolver attribution is symmetric — clears on reopen.
+* **`POST /api/meets/:id/saves`** — first mutation route that admits guest officials (via the new
+  `isOfficialOf` helper). Append-only, takes `kind: 'autosave' | 'checkpoint'` + optional label,
+  validates the QuizFile against the shared TypeBox schema.
+* **`GET /api/meets/:id/saves`** — admin/superuser list. Metadata only (the quizFile blob lives
+  behind the detail endpoint). Filters: `?scheduledQuizId`, `?division`, `?round`. Newest first.
+* **`GET /api/meets/:id/saves/:saveId`** — admin detail with the QuizFile parsed back out.
+* **`POST /api/meets/:id/results`** — Submit. Same auth as `/saves`. Snapshots the current QuizFile
+  into `quiz_results`. Subsequent `/saves` rows still flow so admins see any post-submit edits.
+* **`GET /api/meets/:id/results`** — admin list with an `openDisputes` count per row.
+* **`GET /api/meets/:id/results/:resultId`** — admin detail with QuizFile.
+* **`POST /api/meets/:id/results/:resultId/disputes`** + **`PATCH /api/meets/:id/disputes/:id`** —
+  flag-and-resolve.
+* **`isOfficialOf(c, db, meetId)` permission helper** — superuser, meet admin, meet official (any
+  room), or guest JWT with `role=Official` scoped to the meet. First mutation gate that admits
+  guests.
+* **`@sinclair/typebox` direct dependency** — for `Value.Check` of the shared QuizFile schema.
+
+### Bundled contract
+
+* `@qzr/shared@0.9.2` — unchanged (the new endpoints consume the existing `QuizFileSchema`).
+
 ## [0.10.0] — 2026-05-21
 
 First per-package API release. Covers everything shipped on master since unified tag `v0.9.1`.

--- a/packages/api/migrations/0004_flimsy_slipstream.sql
+++ b/packages/api/migrations/0004_flimsy_slipstream.sql
@@ -1,0 +1,51 @@
+CREATE TABLE `quiz_disputes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`result_id` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	`created_by_account_id` text,
+	`created_by_guest_label` text,
+	`reason` text NOT NULL,
+	`resolved` integer DEFAULT false NOT NULL,
+	`resolved_at` integer,
+	`resolved_by_account_id` text,
+	FOREIGN KEY (`result_id`) REFERENCES `quiz_results`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by_account_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`resolved_by_account_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `quiz_results` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`meet_id` integer NOT NULL,
+	`quiz_id` integer,
+	`room_id` integer,
+	`division` text NOT NULL,
+	`round` text NOT NULL,
+	`submitted_at` integer NOT NULL,
+	`submitted_by_account_id` text,
+	`submitted_by_guest_label` text,
+	`quiz_file` text NOT NULL,
+	FOREIGN KEY (`meet_id`) REFERENCES `quiz_meets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`quiz_id`) REFERENCES `scheduled_quizzes`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`room_id`) REFERENCES `meet_rooms`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`submitted_by_account_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `quiz_results_meet_id_quiz_id_unique` ON `quiz_results` (`meet_id`,`quiz_id`);--> statement-breakpoint
+CREATE TABLE `quiz_saves` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`meet_id` integer NOT NULL,
+	`scheduled_quiz_id` integer,
+	`room_id` integer,
+	`division` text NOT NULL,
+	`round` text NOT NULL,
+	`saved_at` integer NOT NULL,
+	`kind` text NOT NULL,
+	`label` text,
+	`saved_by_account_id` text,
+	`saved_by_guest_label` text,
+	`quiz_file` text NOT NULL,
+	FOREIGN KEY (`meet_id`) REFERENCES `quiz_meets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`scheduled_quiz_id`) REFERENCES `scheduled_quizzes`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`room_id`) REFERENCES `meet_rooms`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`saved_by_account_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);

--- a/packages/api/migrations/meta/0004_snapshot.json
+++ b/packages/api/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1911 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "93cf348d-9a74-44cd-a946-3b711b7ba4c5",
+  "prevId": "f4e4c02f-ae46-4439-9858-44c54a76095c",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "admin_memberships": {
+      "name": "admin_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "admin_memberships_account_id_meet_id_unique": {
+          "name": "admin_memberships_account_id_meet_id_unique",
+          "columns": [
+            "account_id",
+            "meet_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "admin_memberships_account_id_user_id_fk": {
+          "name": "admin_memberships_account_id_user_id_fk",
+          "tableFrom": "admin_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "admin_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "admin_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "churches": {
+      "name": "churches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coach_code_hash": {
+          "name": "coach_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "churches_meet_id_quiz_meets_id_fk": {
+          "name": "churches_meet_id_quiz_meets_id_fk",
+          "tableFrom": "churches",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coach_memberships": {
+      "name": "coach_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "church_id": {
+          "name": "church_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "coach_memberships_account_id_church_id_unique": {
+          "name": "coach_memberships_account_id_church_id_unique",
+          "columns": [
+            "account_id",
+            "church_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "coach_memberships_account_id_user_id_fk": {
+          "name": "coach_memberships_account_id_user_id_fk",
+          "tableFrom": "coach_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_memberships_church_id_churches_id_fk": {
+          "name": "coach_memberships_church_id_churches_id_fk",
+          "tableFrom": "coach_memberships",
+          "tableTo": "churches",
+          "columnsFrom": [
+            "church_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coach_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "coach_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "coach_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "division_states": {
+      "name": "division_states",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'prelim_running'"
+        },
+        "transitioned_at": {
+          "name": "transitioned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "division_states_meet_id_division_unique": {
+          "name": "division_states_meet_id_division_unique",
+          "columns": [
+            "meet_id",
+            "division"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "division_states_meet_id_quiz_meets_id_fk": {
+          "name": "division_states_meet_id_quiz_meets_id_fk",
+          "tableFrom": "division_states",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meet_rooms": {
+      "name": "meet_rooms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meet_rooms_meet_id_quiz_meets_id_fk": {
+          "name": "meet_rooms_meet_id_quiz_meets_id_fk",
+          "tableFrom": "meet_rooms",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meet_slots": {
+      "name": "meet_slots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_label": {
+          "name": "event_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meet_slots_meet_id_quiz_meets_id_fk": {
+          "name": "meet_slots_meet_id_quiz_meets_id_fk",
+          "tableFrom": "meet_slots",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "official_memberships": {
+      "name": "official_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "official_memberships_account_id_meet_id_room_id_unique": {
+          "name": "official_memberships_account_id_meet_id_room_id_unique",
+          "columns": [
+            "account_id",
+            "meet_id",
+            "room_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "official_memberships_account_id_user_id_fk": {
+          "name": "official_memberships_account_id_user_id_fk",
+          "tableFrom": "official_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "official_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "official_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "official_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "official_memberships_room_id_meet_rooms_id_fk": {
+          "name": "official_memberships_room_id_meet_rooms_id_fk",
+          "tableFrom": "official_memberships",
+          "tableTo": "meet_rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prelim_assignments": {
+      "name": "prelim_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "letter": {
+          "name": "letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prelim_assignments_meet_id_division_letter_unique": {
+          "name": "prelim_assignments_meet_id_division_letter_unique",
+          "columns": [
+            "meet_id",
+            "division",
+            "letter"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "prelim_assignments_meet_id_quiz_meets_id_fk": {
+          "name": "prelim_assignments_meet_id_quiz_meets_id_fk",
+          "tableFrom": "prelim_assignments",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prelim_assignments_team_id_teams_id_fk": {
+          "name": "prelim_assignments_team_id_teams_id_fk",
+          "tableFrom": "prelim_assignments",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_disputes": {
+      "name": "quiz_disputes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_account_id": {
+          "name": "created_by_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_guest_label": {
+          "name": "created_by_guest_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by_account_id": {
+          "name": "resolved_by_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_disputes_result_id_quiz_results_id_fk": {
+          "name": "quiz_disputes_result_id_quiz_results_id_fk",
+          "tableFrom": "quiz_disputes",
+          "tableTo": "quiz_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_disputes_created_by_account_id_user_id_fk": {
+          "name": "quiz_disputes_created_by_account_id_user_id_fk",
+          "tableFrom": "quiz_disputes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "quiz_disputes_resolved_by_account_id_user_id_fk": {
+          "name": "quiz_disputes_resolved_by_account_id_user_id_fk",
+          "tableFrom": "quiz_disputes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "resolved_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_meets": {
+      "name": "quiz_meets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_from": {
+          "name": "date_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_to": {
+          "name": "date_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_code_hash": {
+          "name": "admin_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "viewer_code": {
+          "name": "viewer_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "divisions": {
+          "name": "divisions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'registration'"
+        },
+        "registration_closes_at": {
+          "name": "registration_closes_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meet_starts_at": {
+          "name": "meet_starts_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_results": {
+      "name": "quiz_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "submitted_by_account_id": {
+          "name": "submitted_by_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted_by_guest_label": {
+          "name": "submitted_by_guest_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quiz_file": {
+          "name": "quiz_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quiz_results_meet_id_quiz_id_unique": {
+          "name": "quiz_results_meet_id_quiz_id_unique",
+          "columns": [
+            "meet_id",
+            "quiz_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "quiz_results_meet_id_quiz_meets_id_fk": {
+          "name": "quiz_results_meet_id_quiz_meets_id_fk",
+          "tableFrom": "quiz_results",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_results_quiz_id_scheduled_quizzes_id_fk": {
+          "name": "quiz_results_quiz_id_scheduled_quizzes_id_fk",
+          "tableFrom": "quiz_results",
+          "tableTo": "scheduled_quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "quiz_results_room_id_meet_rooms_id_fk": {
+          "name": "quiz_results_room_id_meet_rooms_id_fk",
+          "tableFrom": "quiz_results",
+          "tableTo": "meet_rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "quiz_results_submitted_by_account_id_user_id_fk": {
+          "name": "quiz_results_submitted_by_account_id_user_id_fk",
+          "tableFrom": "quiz_results",
+          "tableTo": "user",
+          "columnsFrom": [
+            "submitted_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_saves": {
+      "name": "quiz_saves",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_quiz_id": {
+          "name": "scheduled_quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round": {
+          "name": "round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saved_by_account_id": {
+          "name": "saved_by_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saved_by_guest_label": {
+          "name": "saved_by_guest_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quiz_file": {
+          "name": "quiz_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_saves_meet_id_quiz_meets_id_fk": {
+          "name": "quiz_saves_meet_id_quiz_meets_id_fk",
+          "tableFrom": "quiz_saves",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_saves_scheduled_quiz_id_scheduled_quizzes_id_fk": {
+          "name": "quiz_saves_scheduled_quiz_id_scheduled_quizzes_id_fk",
+          "tableFrom": "quiz_saves",
+          "tableTo": "scheduled_quizzes",
+          "columnsFrom": [
+            "scheduled_quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "quiz_saves_room_id_meet_rooms_id_fk": {
+          "name": "quiz_saves_room_id_meet_rooms_id_fk",
+          "tableFrom": "quiz_saves",
+          "tableTo": "meet_rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "quiz_saves_saved_by_account_id_user_id_fk": {
+          "name": "quiz_saves_saved_by_account_id_user_id_fk",
+          "tableFrom": "quiz_saves",
+          "tableTo": "user",
+          "columnsFrom": [
+            "saved_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quizzer_identities": {
+      "name": "quizzer_identities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_quiz_seats": {
+      "name": "scheduled_quiz_seats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seat_number": {
+          "name": "seat_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "letter": {
+          "name": "letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seed_ref": {
+          "name": "seed_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_quiz_seats_quiz_id_scheduled_quizzes_id_fk": {
+          "name": "scheduled_quiz_seats_quiz_id_scheduled_quizzes_id_fk",
+          "tableFrom": "scheduled_quiz_seats",
+          "tableTo": "scheduled_quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_quizzes": {
+      "name": "scheduled_quizzes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lane": {
+          "name": "lane",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bracket_label": {
+          "name": "bracket_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_quizzes_meet_id_quiz_meets_id_fk": {
+          "name": "scheduled_quizzes_meet_id_quiz_meets_id_fk",
+          "tableFrom": "scheduled_quizzes",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_quizzes_slot_id_meet_slots_id_fk": {
+          "name": "scheduled_quizzes_slot_id_meet_slots_id_fk",
+          "tableFrom": "scheduled_quizzes",
+          "tableTo": "meet_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_quizzes_room_id_meet_rooms_id_fk": {
+          "name": "scheduled_quizzes_room_id_meet_rooms_id_fk",
+          "tableFrom": "scheduled_quizzes",
+          "tableTo": "meet_rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "seed_resolutions": {
+      "name": "seed_resolutions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed_ref": {
+          "name": "seed_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "seed_resolutions_meet_id_seed_ref_unique": {
+          "name": "seed_resolutions_meet_id_seed_ref_unique",
+          "columns": [
+            "meet_id",
+            "seed_ref"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "seed_resolutions_meet_id_quiz_meets_id_fk": {
+          "name": "seed_resolutions_meet_id_quiz_meets_id_fk",
+          "tableFrom": "seed_resolutions",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "seed_resolutions_team_id_teams_id_fk": {
+          "name": "seed_resolutions_team_id_teams_id_fk",
+          "tableFrom": "seed_resolutions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_rosters": {
+      "name": "team_rosters",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quizzer_id": {
+          "name": "quizzer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_rosters_team_id_quizzer_id_unique": {
+          "name": "team_rosters_team_id_quizzer_id_unique",
+          "columns": [
+            "team_id",
+            "quizzer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_rosters_team_id_teams_id_fk": {
+          "name": "team_rosters_team_id_teams_id_fk",
+          "tableFrom": "team_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_rosters_quizzer_id_quizzer_identities_id_fk": {
+          "name": "team_rosters_quizzer_id_quizzer_identities_id_fk",
+          "tableFrom": "team_rosters",
+          "tableTo": "quizzer_identities",
+          "columnsFrom": [
+            "quizzer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "church_id": {
+          "name": "church_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consolation": {
+          "name": "consolation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "lateness": {
+          "name": "lateness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_meet_id_quiz_meets_id_fk": {
+          "name": "teams_meet_id_quiz_meets_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_church_id_churches_id_fk": {
+          "name": "teams_church_id_churches_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "churches",
+          "columnsFrom": [
+            "church_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "viewer_memberships": {
+      "name": "viewer_memberships",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meet_id": {
+          "name": "meet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "viewer_memberships_account_id_meet_id_unique": {
+          "name": "viewer_memberships_account_id_meet_id_unique",
+          "columns": [
+            "account_id",
+            "meet_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "viewer_memberships_account_id_user_id_fk": {
+          "name": "viewer_memberships_account_id_user_id_fk",
+          "tableFrom": "viewer_memberships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "viewer_memberships_meet_id_quiz_meets_id_fk": {
+          "name": "viewer_memberships_meet_id_quiz_meets_id_fk",
+          "tableFrom": "viewer_memberships",
+          "tableTo": "quiz_meets",
+          "columnsFrom": [
+            "meet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1778793724215,
       "tag": "0003_dear_venus",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1779574198422,
+      "tag": "0004_flimsy_slipstream",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qzr/api",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@qzr/shared": "workspace:*",
+    "@sinclair/typebox": "^0.34.0",
     "better-auth": "^1.2.7",
     "drizzle-orm": "^0.44.0",
     "hono": "^4.7.0",

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -295,6 +295,96 @@ export const seedResolutions = sqliteTable(
   (t) => [unique().on(t.meetId, t.seedRef)],
 )
 
+// ---- Saves + results ----
+
+// Append-only history of an official's in-progress QuizFile state. The
+// scoresheet debounces edits and POSTs autosaves; a manual "Save to
+// server" creates a `checkpoint` row. Admins scrub through this for
+// audit / recovery; stats never read it directly (stats read from
+// quiz_results, which is the frozen submit snapshot).
+//
+// Grouping for "the history of one quiz" is by
+// (meetId, submittedBy*, scheduledQuizId | (division+round)). No
+// uniqueness — every save is a new row.
+export const quizSaves = sqliteTable('quiz_saves', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  meetId: integer('meet_id')
+    .notNull()
+    .references(() => quizMeets.id, { onDelete: 'cascade' }),
+  // Nullable when the scoresheet wasn't loaded from the schedule.
+  scheduledQuizId: integer('scheduled_quiz_id').references(() => scheduledQuizzes.id, {
+    onDelete: 'set null',
+  }),
+  roomId: integer('room_id').references(() => meetRooms.id, { onDelete: 'set null' }),
+  division: text('division').notNull(),
+  round: text('round').notNull(),
+  savedAt: integer('saved_at', { mode: 'timestamp' }).notNull(),
+  kind: text('kind', { enum: ['autosave', 'checkpoint'] }).notNull(),
+  // Optional checkpoint label ("end of Q15", "before re-check") — null for autosaves.
+  label: text('label'),
+  // Exactly one of these is set; null for the other.
+  savedByAccountId: text('saved_by_account_id').references(() => user.id, {
+    onDelete: 'set null',
+  }),
+  savedByGuestLabel: text('saved_by_guest_label'),
+  quizFile: text('quiz_file').notNull(),
+})
+
+// Immutable submit snapshot. Created when an official marks the quiz
+// "done" via the Submit button — the server snapshots the current
+// QuizFile and stores it here. Stats read from this table.
+//
+// quizId is nullable for orphaned submissions (scoresheet wasn't
+// loaded from the schedule). SQLite treats NULL as distinct in
+// unique indexes, so orphans coexist freely; the (meetId, quizId)
+// constraint only fires when quizId is set.
+//
+// Post-submit, the underlying quiz_saves history keeps growing —
+// quiz_results stays frozen at submit-time. Admin can compare the
+// snapshot against later saves to spot post-submit edits.
+export const quizResults = sqliteTable(
+  'quiz_results',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    meetId: integer('meet_id')
+      .notNull()
+      .references(() => quizMeets.id, { onDelete: 'cascade' }),
+    quizId: integer('quiz_id').references(() => scheduledQuizzes.id, {
+      onDelete: 'set null',
+    }),
+    roomId: integer('room_id').references(() => meetRooms.id, { onDelete: 'set null' }),
+    division: text('division').notNull(),
+    round: text('round').notNull(),
+    submittedAt: integer('submitted_at', { mode: 'timestamp' }).notNull(),
+    submittedByAccountId: text('submitted_by_account_id').references(() => user.id, {
+      onDelete: 'set null',
+    }),
+    submittedByGuestLabel: text('submitted_by_guest_label'),
+    quizFile: text('quiz_file').notNull(),
+  },
+  (t) => [unique().on(t.meetId, t.quizId)],
+)
+
+// Flag a submitted result for admin review. Multiple disputes per
+// result allowed. Officials raise; admins resolve.
+export const quizDisputes = sqliteTable('quiz_disputes', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  resultId: integer('result_id')
+    .notNull()
+    .references(() => quizResults.id, { onDelete: 'cascade' }),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  createdByAccountId: text('created_by_account_id').references(() => user.id, {
+    onDelete: 'set null',
+  }),
+  createdByGuestLabel: text('created_by_guest_label'),
+  reason: text('reason').notNull(),
+  resolved: integer('resolved', { mode: 'boolean' }).notNull().default(false),
+  resolvedAt: integer('resolved_at', { mode: 'timestamp' }),
+  resolvedByAccountId: text('resolved_by_account_id').references(() => user.id, {
+    onDelete: 'set null',
+  }),
+})
+
 // ---- Inferred types ----
 
 export type User = typeof user.$inferSelect
@@ -315,3 +405,6 @@ export type ScheduledQuiz = typeof scheduledQuizzes.$inferSelect
 export type ScheduledQuizSeat = typeof scheduledQuizSeats.$inferSelect
 export type PrelimAssignment = typeof prelimAssignments.$inferSelect
 export type SeedResolution = typeof seedResolutions.$inferSelect
+export type QuizSave = typeof quizSaves.$inferSelect
+export type QuizResult = typeof quizResults.$inferSelect
+export type QuizDispute = typeof quizDisputes.$inferSelect

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -12,6 +12,7 @@ import { memberships } from './routes/memberships'
 import { churches } from './routes/churches'
 import { phase } from './routes/phase'
 import { schedule } from './routes/schedule'
+import { results } from './routes/results'
 import { createAuth } from './lib/auth'
 import { createDb } from './lib/db'
 import { autoAdvancePhases } from './scheduler'
@@ -58,6 +59,7 @@ app.route('/api/my-meets', memberships)
 app.route('/api', churches)
 app.route('/api/meets', phase)
 app.route('/api/meets', schedule)
+app.route('/api/meets', results)
 
 export { app }
 

--- a/packages/api/src/lib/permissions.ts
+++ b/packages/api/src/lib/permissions.ts
@@ -1,6 +1,6 @@
 import { eq, and, sql } from 'drizzle-orm'
 import type { Context } from 'hono'
-import { AccountRole } from '@qzr/shared'
+import { AccountRole, MeetRole } from '@qzr/shared'
 import * as schema from '../db/schema'
 import type { Db } from './db'
 import type { SessionVariables } from '../middleware/session'
@@ -61,6 +61,38 @@ export async function isViewerOf<E extends { Variables: SessionVariables }>(
       SELECT 1 FROM ${schema.viewerMemberships}
         WHERE ${schema.viewerMemberships.accountId} = ${user.id}
           AND ${schema.viewerMemberships.meetId} = ${meetId}
+    ) AS found`,
+  )
+  return Boolean(result?.found)
+}
+
+/**
+ * True if the requester is authorised to write results for this meet —
+ * superuser, meet admin, meet official (any room), or a guest JWT
+ * carrying role=Official for this meetId. First mutation gate that
+ * admits guests; readers should stay on isViewerOf.
+ */
+export async function isOfficialOf<E extends { Variables: SessionVariables }>(
+  c: Context<E>,
+  db: Db,
+  meetId: number,
+): Promise<boolean> {
+  const guest = c.get('guest')
+  if (guest && guest.meetId === meetId && guest.role === MeetRole.Official) return true
+
+  const user = c.get('user')
+  if (!user) return false
+  if (user.role === AccountRole.Superuser) return true
+
+  const result = await db.get<{ found: number }>(
+    sql`SELECT EXISTS (
+      SELECT 1 FROM ${schema.adminMemberships}
+        WHERE ${schema.adminMemberships.accountId} = ${user.id}
+          AND ${schema.adminMemberships.meetId} = ${meetId}
+      UNION ALL
+      SELECT 1 FROM ${schema.officialMemberships}
+        WHERE ${schema.officialMemberships.accountId} = ${user.id}
+          AND ${schema.officialMemberships.meetId} = ${meetId}
     ) AS found`,
   )
   return Boolean(result?.found)

--- a/packages/api/src/routes/__tests__/results.spec.ts
+++ b/packages/api/src/routes/__tests__/results.spec.ts
@@ -454,3 +454,132 @@ describe('GET /api/meets/:id/saves/:saveId — admin detail', () => {
     expect(body.save.quizFile).toEqual(qf)
   })
 })
+
+describe('POST /api/meets/:id/results — submit', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('401 with neither user nor guest', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, null)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('403 for guest with role=Viewer', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, { meetId: meet.id, role: MeetRole.Viewer })
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('400 when QuizFile is invalid', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: { version: 2 } }),
+      env,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('400 when quizId belongs to a different meet', async () => {
+    const meetA = await seedMeet(db, 'A')
+    const meetB = await seedMeet(db, 'B')
+    const quiz = await seedScheduledQuiz(db, meetB.id)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meetA.id}/results`,
+      postJson({ quizFile: makeQuizFile(), quizId: quiz.id }),
+      env,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('201 for guest official, stores label and parses division/round from QuizFile', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, {
+      meetId: meet.id,
+      role: MeetRole.Official,
+      label: 'Room 1',
+    })
+    const qf = makeQuizFile({ division: '2', quizNumber: 'A' })
+    const res = await app.request(`/api/meets/${meet.id}/results`, postJson({ quizFile: qf }), env)
+    expect(res.status).toBe(201)
+    const [row] = await db.select().from(schema.quizResults)
+    expect(row?.division).toBe('2')
+    expect(row?.round).toBe('A')
+    expect(row?.submittedByAccountId).toBeNull()
+    expect(row?.submittedByGuestLabel).toBe('Room 1')
+    expect(JSON.parse(row!.quizFile)).toEqual(qf)
+  })
+
+  it('409 when submitting the same scheduled quiz twice', async () => {
+    const meet = await seedMeet(db)
+    const quiz = await seedScheduledQuiz(db, meet.id)
+    const app = createApp(testSuperuser, db)
+    const first = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile(), quizId: quiz.id }),
+      env,
+    )
+    expect(first.status).toBe(201)
+    const second = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile(), quizId: quiz.id }),
+      env,
+    )
+    expect(second.status).toBe(409)
+  })
+
+  it('allows two orphan submissions in the same meet (NULL ≠ NULL)', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const a = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    const b = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    expect(a.status).toBe(201)
+    expect(b.status).toBe(201)
+    const rows = await db.select().from(schema.quizResults)
+    expect(rows).toHaveLength(2)
+  })
+
+  it('saves can still be appended after submit (history keeps growing)', async () => {
+    const meet = await seedMeet(db)
+    const quiz = await seedScheduledQuiz(db, meet.id)
+    const app = createApp(testSuperuser, db)
+    await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile(), quizId: quiz.id }),
+      env,
+    )
+    const save = await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave', scheduledQuizId: quiz.id }),
+      env,
+    )
+    expect(save.status).toBe(201)
+    const saves = await db.select().from(schema.quizSaves)
+    expect(saves).toHaveLength(1)
+    const results = await db.select().from(schema.quizResults)
+    expect(results).toHaveLength(1)
+  })
+})

--- a/packages/api/src/routes/__tests__/results.spec.ts
+++ b/packages/api/src/routes/__tests__/results.spec.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { FILE_VERSION, MeetRole, PlacementFormula, type QuizFile } from '@qzr/shared'
+import type { Bindings } from '../../bindings'
+import type { SessionVariables } from '../../middleware/session'
+import { results } from '../results'
+import * as schema from '../../db/schema'
+import {
+  mockSession,
+  mockDb,
+  testSuperuser,
+  testUser,
+  jsonOf,
+  jsonRequest,
+  seedMeet,
+} from '../../test-utils'
+import { createTestDb } from '../../test-db'
+import type { Db } from '../../lib/db'
+import type { GuestPayload } from '../../lib/jwt'
+import type { SessionUser } from '../../middleware/session'
+
+const env = { ENVIRONMENT: 'test' } as unknown as Bindings
+
+function createApp(user: SessionUser | null, db: Db, guest: GuestPayload | null = null) {
+  const app = new Hono<{ Bindings: Bindings; Variables: SessionVariables & { db: Db } }>()
+  app.use('*', mockSession(user, guest))
+  app.use('*', mockDb(db))
+  app.route('/api/meets', results)
+  return app
+}
+
+function makeQuizFile(overrides: Partial<QuizFile['quiz']> = {}): QuizFile {
+  return {
+    version: FILE_VERSION,
+    quiz: {
+      division: '1',
+      quizNumber: '1',
+      overtime: false,
+      placementFormula: PlacementFormula.Rules,
+      questionTypes: [],
+      ...overrides,
+    },
+    teams: [],
+    answers: [],
+    noJumps: [],
+  }
+}
+
+async function seedRoom(db: Db, meetId: number, name = 'Room A') {
+  const [room] = await db
+    .insert(schema.meetRooms)
+    .values({ meetId, name, sortOrder: 0 })
+    .returning()
+  return room!
+}
+
+async function seedSlot(db: Db, meetId: number) {
+  const [slot] = await db
+    .insert(schema.meetSlots)
+    .values({
+      meetId,
+      startAt: new Date('2026-01-01T20:00:00Z'),
+      durationMinutes: 25,
+      kind: 'quiz',
+      sortOrder: 0,
+    })
+    .returning()
+  return slot!
+}
+
+async function seedScheduledQuiz(db: Db, meetId: number) {
+  const room = await seedRoom(db, meetId, `Room ${Math.random().toString(36).slice(2, 6)}`)
+  const slot = await seedSlot(db, meetId)
+  const [quiz] = await db
+    .insert(schema.scheduledQuizzes)
+    .values({
+      meetId,
+      slotId: slot.id,
+      roomId: room.id,
+      division: '1',
+      phase: 'prelim',
+      label: 'D1-Q1',
+    })
+    .returning()
+  return quiz!
+}
+
+async function seedOfficial(db: Db, meetId: number, accountId: string, roomId: number) {
+  await db.insert(schema.officialMemberships).values({ accountId, meetId, roomId })
+}
+
+async function seedAdmin(db: Db, meetId: number, accountId: string) {
+  await db.insert(schema.adminMemberships).values({ accountId, meetId })
+}
+
+const postJson = (body: Record<string, unknown>) => jsonRequest('POST', body)
+
+describe('POST /api/meets/:id/saves — auth matrix', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('401 with neither user nor guest', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, null)
+    const res = await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave' }),
+      env,
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('404 when meet does not exist', async () => {
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/999/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave' }),
+      env,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('403 for signed-in non-member', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testUser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave' }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('403 for guest with role=Viewer', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, { meetId: meet.id, role: MeetRole.Viewer })
+    const res = await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave' }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('201 for superuser', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave' }),
+      env,
+    )
+    expect(res.status).toBe(201)
+  })
+
+  it('201 for meet admin', async () => {
+    const meet = await seedMeet(db)
+    await seedAdmin(db, meet.id, testUser.id)
+    const app = createApp(testUser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave' }),
+      env,
+    )
+    expect(res.status).toBe(201)
+  })
+
+  it('201 for meet official', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id)
+    await seedOfficial(db, meet.id, testUser.id, room.id)
+    const app = createApp(testUser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave' }),
+      env,
+    )
+    expect(res.status).toBe(201)
+  })
+
+  it('201 for guest with role=Official scoped to meet', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, {
+      meetId: meet.id,
+      role: MeetRole.Official,
+      label: 'Room 2',
+    })
+    const res = await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave' }),
+      env,
+    )
+    expect(res.status).toBe(201)
+  })
+})
+
+describe('POST /api/meets/:id/saves — payload validation', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('400 when kind is missing or invalid', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'mystery' }),
+      env,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('400 when QuizFile is malformed', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: { version: 2 }, kind: 'autosave' }),
+      env,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('400 when scheduledQuizId is from a different meet', async () => {
+    const meetA = await seedMeet(db, 'A')
+    const meetB = await seedMeet(db, 'B')
+    const quiz = await seedScheduledQuiz(db, meetB.id)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meetA.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave', scheduledQuizId: quiz.id }),
+      env,
+    )
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('POST /api/meets/:id/saves — storage shape', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('stores division + round from QuizFile, kind, label, scheduledQuizId, submitter', async () => {
+    const meet = await seedMeet(db)
+    const quiz = await seedScheduledQuiz(db, meet.id)
+    const app = createApp(testSuperuser, db)
+    const qf = makeQuizFile({ division: '2', quizNumber: 'B' })
+
+    await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({
+        quizFile: qf,
+        kind: 'checkpoint',
+        scheduledQuizId: quiz.id,
+        roomId: quiz.roomId,
+        label: 'after Q15',
+      }),
+      env,
+    )
+
+    const [row] = await db.select().from(schema.quizSaves)
+    expect(row?.meetId).toBe(meet.id)
+    expect(row?.scheduledQuizId).toBe(quiz.id)
+    expect(row?.roomId).toBe(quiz.roomId)
+    expect(row?.division).toBe('2')
+    expect(row?.round).toBe('B')
+    expect(row?.kind).toBe('checkpoint')
+    expect(row?.label).toBe('after Q15')
+    expect(row?.savedByAccountId).toBe(testSuperuser.id)
+    expect(row?.savedByGuestLabel).toBeNull()
+    expect(JSON.parse(row!.quizFile)).toEqual(qf)
+  })
+
+  it('records guest label when posted via guest JWT', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, {
+      meetId: meet.id,
+      role: MeetRole.Official,
+      label: 'Room 3 official',
+    })
+    await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave' }),
+      env,
+    )
+    const [row] = await db.select().from(schema.quizSaves)
+    expect(row?.savedByAccountId).toBeNull()
+    expect(row?.savedByGuestLabel).toBe('Room 3 official')
+  })
+
+  it('appends rows; two saves for the same quiz coexist', async () => {
+    const meet = await seedMeet(db)
+    const quiz = await seedScheduledQuiz(db, meet.id)
+    const app = createApp(testSuperuser, db)
+    for (let i = 0; i < 3; i++) {
+      const res = await app.request(
+        `/api/meets/${meet.id}/saves`,
+        postJson({ quizFile: makeQuizFile(), kind: 'autosave', scheduledQuizId: quiz.id }),
+        env,
+      )
+      expect(res.status).toBe(201)
+    }
+    const rows = await db.select().from(schema.quizSaves)
+    expect(rows).toHaveLength(3)
+  })
+
+  it('blank label is normalised to null', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave', label: '   ' }),
+      env,
+    )
+    const [row] = await db.select().from(schema.quizSaves)
+    expect(row?.label).toBeNull()
+  })
+})

--- a/packages/api/src/routes/__tests__/results.spec.ts
+++ b/packages/api/src/routes/__tests__/results.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { Hono } from 'hono'
+import { eq } from 'drizzle-orm'
 import { FILE_VERSION, MeetRole, PlacementFormula, type QuizFile } from '@qzr/shared'
 import type { Bindings } from '../../bindings'
 import type { SessionVariables } from '../../middleware/session'
@@ -318,5 +319,138 @@ describe('POST /api/meets/:id/saves — storage shape', () => {
     )
     const [row] = await db.select().from(schema.quizSaves)
     expect(row?.label).toBeNull()
+  })
+})
+
+describe('GET /api/meets/:id/saves — admin list', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('401 when no signed-in user', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(null, db, { meetId: meet.id, role: MeetRole.Official })
+    const res = await app.request(`/api/meets/${meet.id}/saves`, {}, env)
+    expect(res.status).toBe(401)
+  })
+
+  it('403 for signed-in non-admin', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id)
+    await seedOfficial(db, meet.id, testUser.id, room.id)
+    const app = createApp(testUser, db)
+    const res = await app.request(`/api/meets/${meet.id}/saves`, {}, env)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns newest first; supports scheduledQuizId + division + round filters', async () => {
+    const meet = await seedMeet(db)
+    const quizA = await seedScheduledQuiz(db, meet.id)
+    const quizB = await seedScheduledQuiz(db, meet.id)
+    const app = createApp(testSuperuser, db)
+
+    async function post(scheduledQuizId: number, quizNumber: string) {
+      const r = await app.request(
+        `/api/meets/${meet.id}/saves`,
+        postJson({
+          quizFile: makeQuizFile({ quizNumber }),
+          kind: 'autosave',
+          scheduledQuizId,
+        }),
+        env,
+      )
+      return (await jsonOf<{ id: number }>(r)).id
+    }
+    const a1 = await post(quizA.id, '1')
+    const a2 = await post(quizA.id, '1')
+    await post(quizB.id, '2')
+
+    // Force a1 to look older than a2 for the ordering check.
+    await db
+      .update(schema.quizSaves)
+      .set({ savedAt: new Date(Date.now() - 60_000) })
+      .where(eq(schema.quizSaves.id, a1))
+
+    const all = await app.request(`/api/meets/${meet.id}/saves`, {}, env)
+    expect(all.status).toBe(200)
+    const allBody = await jsonOf<{ saves: { id: number }[] }>(all)
+    expect(allBody.saves).toHaveLength(3)
+    // a2 saved most recently, then quizB save, then a1.
+    expect(allBody.saves[allBody.saves.length - 1]!.id).toBe(a1)
+
+    const filtered = await app.request(
+      `/api/meets/${meet.id}/saves?scheduledQuizId=${quizA.id}`,
+      {},
+      env,
+    )
+    const filteredBody = await jsonOf<{ saves: { id: number }[] }>(filtered)
+    expect(filteredBody.saves).toHaveLength(2)
+
+    const byRound = await app.request(`/api/meets/${meet.id}/saves?round=2`, {}, env)
+    const byRoundBody = await jsonOf<{ saves: { id: number }[] }>(byRound)
+    expect(byRoundBody.saves).toHaveLength(1)
+  })
+
+  it('omits the quizFile blob from list rows', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave' }),
+      env,
+    )
+    const res = await app.request(`/api/meets/${meet.id}/saves`, {}, env)
+    const body = await jsonOf<{ saves: Record<string, unknown>[] }>(res)
+    expect(body.saves[0]).not.toHaveProperty('quizFile')
+  })
+})
+
+describe('GET /api/meets/:id/saves/:saveId — admin detail', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('403 for non-admin', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testUser, db)
+    const res = await app.request(`/api/meets/${meet.id}/saves/1`, {}, env)
+    expect(res.status).toBe(403)
+  })
+
+  it('404 when the save belongs to a different meet', async () => {
+    const meetA = await seedMeet(db, 'A')
+    const meetB = await seedMeet(db, 'B')
+    const app = createApp(testSuperuser, db)
+    const post = await app.request(
+      `/api/meets/${meetA.id}/saves`,
+      postJson({ quizFile: makeQuizFile(), kind: 'autosave' }),
+      env,
+    )
+    const { id } = await jsonOf<{ id: number }>(post)
+    const res = await app.request(`/api/meets/${meetB.id}/saves/${id}`, {}, env)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns the row with the QuizFile parsed', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const qf = makeQuizFile({ division: '3' })
+    const post = await app.request(
+      `/api/meets/${meet.id}/saves`,
+      postJson({ quizFile: qf, kind: 'checkpoint', label: 'mid-quiz' }),
+      env,
+    )
+    const { id } = await jsonOf<{ id: number }>(post)
+    const res = await app.request(`/api/meets/${meet.id}/saves/${id}`, {}, env)
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{
+      save: { id: number; division: string; label: string; quizFile: QuizFile }
+    }>(res)
+    expect(body.save.id).toBe(id)
+    expect(body.save.division).toBe('3')
+    expect(body.save.label).toBe('mid-quiz')
+    expect(body.save.quizFile).toEqual(qf)
   })
 })

--- a/packages/api/src/routes/__tests__/results.spec.ts
+++ b/packages/api/src/routes/__tests__/results.spec.ts
@@ -583,3 +583,188 @@ describe('POST /api/meets/:id/results — submit', () => {
     expect(results).toHaveLength(1)
   })
 })
+
+describe('GET /api/meets/:id/results — admin list + detail', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  it('403 for signed-in non-admin', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testUser, db)
+    const res = await app.request(`/api/meets/${meet.id}/results`, {}, env)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns rows newest first with openDisputes count', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const earlyRes = await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile({ quizNumber: 'early' }) }),
+      env,
+    )
+    const { id: earlyId } = await jsonOf<{ id: number }>(earlyRes)
+    await db
+      .update(schema.quizResults)
+      .set({ submittedAt: new Date(Date.now() - 60_000) })
+      .where(eq(schema.quizResults.id, earlyId))
+    await app.request(
+      `/api/meets/${meet.id}/results`,
+      postJson({ quizFile: makeQuizFile({ quizNumber: 'late' }) }),
+      env,
+    )
+    await db.insert(schema.quizDisputes).values([
+      { resultId: earlyId, createdAt: new Date(), reason: 'wrong', resolved: false },
+      { resultId: earlyId, createdAt: new Date(), reason: 'done', resolved: true },
+    ])
+
+    const res = await app.request(`/api/meets/${meet.id}/results`, {}, env)
+    const body = await jsonOf<{
+      results: { id: number; round: string; openDisputes: number }[]
+    }>(res)
+    expect(body.results.map((r) => r.round)).toEqual(['late', 'early'])
+    expect(body.results.find((r) => r.id === earlyId)?.openDisputes).toBe(1)
+  })
+
+  it('detail returns the QuizFile parsed', async () => {
+    const meet = await seedMeet(db)
+    const app = createApp(testSuperuser, db)
+    const qf = makeQuizFile({ division: '3' })
+    const post = await app.request(`/api/meets/${meet.id}/results`, postJson({ quizFile: qf }), env)
+    const { id } = await jsonOf<{ id: number }>(post)
+    const res = await app.request(`/api/meets/${meet.id}/results/${id}`, {}, env)
+    expect(res.status).toBe(200)
+    const body = await jsonOf<{ result: { quizFile: QuizFile } }>(res)
+    expect(body.result.quizFile).toEqual(qf)
+  })
+})
+
+describe('POST /api/meets/:id/results/:resultId/disputes', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  async function seedResult(meetId: number): Promise<number> {
+    const app = createApp(testSuperuser, db)
+    const post = await app.request(
+      `/api/meets/${meetId}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    return (await jsonOf<{ id: number }>(post)).id
+  }
+
+  it('403 for signed-in non-member', async () => {
+    const meet = await seedMeet(db)
+    const resultId = await seedResult(meet.id)
+    const app = createApp(testUser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results/${resultId}/disputes`,
+      postJson({ reason: 'wrong' }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('400 when reason is blank', async () => {
+    const meet = await seedMeet(db)
+    const resultId = await seedResult(meet.id)
+    const app = createApp(testSuperuser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/results/${resultId}/disputes`,
+      postJson({ reason: '   ' }),
+      env,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('201 for guest official with stored label and reason', async () => {
+    const meet = await seedMeet(db)
+    const resultId = await seedResult(meet.id)
+    const app = createApp(null, db, {
+      meetId: meet.id,
+      role: MeetRole.Official,
+      label: 'Room 2',
+    })
+    const res = await app.request(
+      `/api/meets/${meet.id}/results/${resultId}/disputes`,
+      postJson({ reason: 'score off' }),
+      env,
+    )
+    expect(res.status).toBe(201)
+    const [row] = await db.select().from(schema.quizDisputes)
+    expect(row?.createdByGuestLabel).toBe('Room 2')
+    expect(row?.reason).toBe('score off')
+  })
+})
+
+describe('PATCH /api/meets/:id/disputes/:disputeId', () => {
+  let db: Db
+  beforeEach(async () => {
+    db = await createTestDb()
+  })
+
+  async function seedResultAndDispute(meetId: number): Promise<number> {
+    const app = createApp(testSuperuser, db)
+    const post = await app.request(
+      `/api/meets/${meetId}/results`,
+      postJson({ quizFile: makeQuizFile() }),
+      env,
+    )
+    const { id: resultId } = await jsonOf<{ id: number }>(post)
+    const flag = await app.request(
+      `/api/meets/${meetId}/results/${resultId}/disputes`,
+      postJson({ reason: 'flag me' }),
+      env,
+    )
+    return (await jsonOf<{ id: number }>(flag)).id
+  }
+
+  it('403 for non-admin', async () => {
+    const meet = await seedMeet(db)
+    const room = await seedRoom(db, meet.id)
+    await seedOfficial(db, meet.id, testUser.id, room.id)
+    const disputeId = await seedResultAndDispute(meet.id)
+    const app = createApp(testUser, db)
+    const res = await app.request(
+      `/api/meets/${meet.id}/disputes/${disputeId}`,
+      jsonRequest('PATCH', { resolved: true }),
+      env,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('toggles resolved and stamps resolver attribution', async () => {
+    const meet = await seedMeet(db)
+    const disputeId = await seedResultAndDispute(meet.id)
+    const app = createApp(testSuperuser, db)
+
+    await app.request(
+      `/api/meets/${meet.id}/disputes/${disputeId}`,
+      jsonRequest('PATCH', { resolved: true }),
+      env,
+    )
+    let [row] = await db
+      .select()
+      .from(schema.quizDisputes)
+      .where(eq(schema.quizDisputes.id, disputeId))
+    expect(row?.resolved).toBe(true)
+    expect(row?.resolvedByAccountId).toBe(testSuperuser.id)
+
+    await app.request(
+      `/api/meets/${meet.id}/disputes/${disputeId}`,
+      jsonRequest('PATCH', { resolved: false }),
+      env,
+    )
+    ;[row] = await db
+      .select()
+      .from(schema.quizDisputes)
+      .where(eq(schema.quizDisputes.id, disputeId))
+    expect(row?.resolved).toBe(false)
+    expect(row?.resolvedAt).toBeNull()
+    expect(row?.resolvedByAccountId).toBeNull()
+  })
+})

--- a/packages/api/src/routes/results.ts
+++ b/packages/api/src/routes/results.ts
@@ -1,12 +1,12 @@
-import { Hono } from 'hono'
-import { eq, and } from 'drizzle-orm'
+import { Hono, type Context } from 'hono'
+import { eq, and, desc } from 'drizzle-orm'
 import { Value } from '@sinclair/typebox/value'
 import { QuizFileSchema, type QuizFile } from '@qzr/shared'
 import type { Bindings } from '../bindings'
 import type { SessionVariables } from '../middleware/session'
 import { requireAuthOrGuest } from '../middleware/session'
 import { createDb, type Db } from '../lib/db'
-import { isOfficialOf } from '../lib/permissions'
+import { isAdminOrSuperuser, isOfficialOf } from '../lib/permissions'
 import * as schema from '../db/schema'
 
 interface ResultsVariables extends SessionVariables {
@@ -30,6 +30,16 @@ results.use('*', async (c, next) => {
 
 function getDb(c: { get(key: 'db'): Db }): Db {
   return c.get('db')
+}
+
+async function requireAdmin(c: Context<Env>, meetId: number) {
+  const user = c.get('user')
+  if (!user) return c.json({ error: 'Sign-in required' }, 401)
+  const db = getDb(c)
+  if (!(await isAdminOrSuperuser(db, user.id, user.role, meetId))) {
+    return c.json({ error: 'Admin or superuser access required' }, 403)
+  }
+  return null
 }
 
 /**
@@ -120,4 +130,74 @@ results.post('/:id/saves', async (c) => {
     .returning({ id: schema.quizSaves.id, savedAt: schema.quizSaves.savedAt })
 
   return c.json({ id: inserted!.id, savedAt: inserted!.savedAt }, 201)
+})
+
+/**
+ * GET /api/meets/:id/saves
+ *
+ * Admin/superuser list. Returns metadata only (no quizFile blob) so
+ * scrubbing the history doesn't blow up the response. Optional query
+ * filters: ?scheduledQuizId=N, ?division=1, ?round=A. Newest first.
+ */
+results.get('/:id/saves', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const filters = [eq(schema.quizSaves.meetId, meetId)]
+  const qid = c.req.query('scheduledQuizId')
+  if (qid && !Number.isNaN(Number(qid))) {
+    filters.push(eq(schema.quizSaves.scheduledQuizId, Number(qid)))
+  }
+  const div = c.req.query('division')
+  if (div) filters.push(eq(schema.quizSaves.division, div))
+  const round = c.req.query('round')
+  if (round) filters.push(eq(schema.quizSaves.round, round))
+
+  const db = getDb(c)
+  const rows = await db
+    .select({
+      id: schema.quizSaves.id,
+      scheduledQuizId: schema.quizSaves.scheduledQuizId,
+      roomId: schema.quizSaves.roomId,
+      division: schema.quizSaves.division,
+      round: schema.quizSaves.round,
+      savedAt: schema.quizSaves.savedAt,
+      kind: schema.quizSaves.kind,
+      label: schema.quizSaves.label,
+      savedByAccountId: schema.quizSaves.savedByAccountId,
+      savedByGuestLabel: schema.quizSaves.savedByGuestLabel,
+    })
+    .from(schema.quizSaves)
+    .where(and(...filters))
+    .orderBy(desc(schema.quizSaves.savedAt), desc(schema.quizSaves.id))
+
+  return c.json({ saves: rows })
+})
+
+/**
+ * GET /api/meets/:id/saves/:saveId
+ *
+ * Admin detail with the QuizFile blob parsed back into the response.
+ */
+results.get('/:id/saves/:saveId', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const saveId = Number(c.req.param('saveId'))
+  if (Number.isNaN(meetId) || Number.isNaN(saveId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const db = getDb(c)
+  const [row] = await db
+    .select()
+    .from(schema.quizSaves)
+    .where(and(eq(schema.quizSaves.id, saveId), eq(schema.quizSaves.meetId, meetId)))
+  if (!row) return c.json({ error: 'Save not found' }, 404)
+
+  return c.json({ save: { ...row, quizFile: JSON.parse(row.quizFile) as QuizFile } })
 })

--- a/packages/api/src/routes/results.ts
+++ b/packages/api/src/routes/results.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from 'hono'
-import { eq, and, desc } from 'drizzle-orm'
+import { eq, and, desc, inArray, sql } from 'drizzle-orm'
 import { Value } from '@sinclair/typebox/value'
 import { QuizFileSchema, type QuizFile } from '@qzr/shared'
 import type { Bindings } from '../bindings'
@@ -289,4 +289,171 @@ results.post('/:id/results', async (c) => {
     }
     throw e
   }
+})
+
+/**
+ * GET /api/meets/:id/results
+ *
+ * Admin/superuser list of submitted results. Each row carries an
+ * openDisputes count so a future review UI can flag rows without a
+ * second round-trip.
+ */
+results.get('/:id/results', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const db = getDb(c)
+  const rows = await db
+    .select({
+      id: schema.quizResults.id,
+      meetId: schema.quizResults.meetId,
+      quizId: schema.quizResults.quizId,
+      roomId: schema.quizResults.roomId,
+      division: schema.quizResults.division,
+      round: schema.quizResults.round,
+      submittedAt: schema.quizResults.submittedAt,
+      submittedByAccountId: schema.quizResults.submittedByAccountId,
+      submittedByGuestLabel: schema.quizResults.submittedByGuestLabel,
+    })
+    .from(schema.quizResults)
+    .where(eq(schema.quizResults.meetId, meetId))
+    .orderBy(desc(schema.quizResults.submittedAt), desc(schema.quizResults.id))
+
+  const resultIds = rows.map((r) => r.id)
+  const disputeRows =
+    resultIds.length === 0
+      ? []
+      : await db
+          .select({
+            resultId: schema.quizDisputes.resultId,
+            open: sql<number>`SUM(CASE WHEN ${schema.quizDisputes.resolved} = 0 THEN 1 ELSE 0 END)`,
+          })
+          .from(schema.quizDisputes)
+          .where(inArray(schema.quizDisputes.resultId, resultIds))
+          .groupBy(schema.quizDisputes.resultId)
+  const openByResult = new Map(disputeRows.map((d) => [d.resultId, Number(d.open)]))
+
+  return c.json({
+    results: rows.map((r) => ({ ...r, openDisputes: openByResult.get(r.id) ?? 0 })),
+  })
+})
+
+/**
+ * GET /api/meets/:id/results/:resultId
+ *
+ * Admin detail with the QuizFile parsed back out of storage.
+ */
+results.get('/:id/results/:resultId', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const resultId = Number(c.req.param('resultId'))
+  if (Number.isNaN(meetId) || Number.isNaN(resultId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const db = getDb(c)
+  const [row] = await db
+    .select()
+    .from(schema.quizResults)
+    .where(and(eq(schema.quizResults.id, resultId), eq(schema.quizResults.meetId, meetId)))
+  if (!row) return c.json({ error: 'Result not found' }, 404)
+
+  return c.json({ result: { ...row, quizFile: JSON.parse(row.quizFile) as QuizFile } })
+})
+
+/**
+ * POST /api/meets/:id/results/:resultId/disputes
+ *
+ * Flag a submitted result for review. Officials raise; admins resolve.
+ */
+results.post('/:id/results/:resultId/disputes', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const resultId = Number(c.req.param('resultId'))
+  if (Number.isNaN(meetId) || Number.isNaN(resultId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const db = getDb(c)
+  const [result] = await db
+    .select({ id: schema.quizResults.id })
+    .from(schema.quizResults)
+    .where(and(eq(schema.quizResults.id, resultId), eq(schema.quizResults.meetId, meetId)))
+  if (!result) return c.json({ error: 'Result not found' }, 404)
+
+  if (!(await isOfficialOf(c, db, meetId))) {
+    return c.json({ error: 'Official access required' }, 403)
+  }
+
+  const body = await c.req.json<{ reason?: string }>()
+  const reason = body.reason?.trim() ?? ''
+  if (!reason) return c.json({ error: 'reason is required' }, 400)
+
+  const user = c.get('user')
+  const guest = c.get('guest')
+
+  const [inserted] = await db
+    .insert(schema.quizDisputes)
+    .values({
+      resultId,
+      createdAt: new Date(),
+      createdByAccountId: user?.id ?? null,
+      createdByGuestLabel: !user && guest ? (guest.label ?? null) : null,
+      reason,
+      resolved: false,
+    })
+    .returning({ id: schema.quizDisputes.id, createdAt: schema.quizDisputes.createdAt })
+  return c.json({ id: inserted!.id, createdAt: inserted!.createdAt }, 201)
+})
+
+/**
+ * PATCH /api/meets/:id/disputes/:disputeId
+ *
+ * Admin-only resolve/unresolve toggle. Stamps resolvedAt + resolver on
+ * true; clears both on false so reopening returns the row to its
+ * original state.
+ */
+results.patch('/:id/disputes/:disputeId', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  const disputeId = Number(c.req.param('disputeId'))
+  if (Number.isNaN(meetId) || Number.isNaN(disputeId)) {
+    return c.json({ error: 'Invalid ID' }, 400)
+  }
+
+  const denied = await requireAdmin(c, meetId)
+  if (denied) return denied
+
+  const db = getDb(c)
+  const [dispute] = await db
+    .select({
+      id: schema.quizDisputes.id,
+      resultMeetId: schema.quizResults.meetId,
+    })
+    .from(schema.quizDisputes)
+    .innerJoin(schema.quizResults, eq(schema.quizResults.id, schema.quizDisputes.resultId))
+    .where(eq(schema.quizDisputes.id, disputeId))
+  if (!dispute || dispute.resultMeetId !== meetId) {
+    return c.json({ error: 'Dispute not found' }, 404)
+  }
+
+  const body = await c.req.json<{ resolved?: boolean }>()
+  if (typeof body.resolved !== 'boolean') {
+    return c.json({ error: 'resolved (boolean) is required' }, 400)
+  }
+
+  const user = c.get('user')!
+  const [updated] = await db
+    .update(schema.quizDisputes)
+    .set({
+      resolved: body.resolved,
+      resolvedAt: body.resolved ? new Date() : null,
+      resolvedByAccountId: body.resolved ? user.id : null,
+    })
+    .where(eq(schema.quizDisputes.id, disputeId))
+    .returning()
+  return c.json({ dispute: updated })
 })

--- a/packages/api/src/routes/results.ts
+++ b/packages/api/src/routes/results.ts
@@ -1,0 +1,123 @@
+import { Hono } from 'hono'
+import { eq, and } from 'drizzle-orm'
+import { Value } from '@sinclair/typebox/value'
+import { QuizFileSchema, type QuizFile } from '@qzr/shared'
+import type { Bindings } from '../bindings'
+import type { SessionVariables } from '../middleware/session'
+import { requireAuthOrGuest } from '../middleware/session'
+import { createDb, type Db } from '../lib/db'
+import { isOfficialOf } from '../lib/permissions'
+import * as schema from '../db/schema'
+
+interface ResultsVariables extends SessionVariables {
+  db: Db
+}
+
+type Env = { Bindings: Bindings; Variables: ResultsVariables }
+
+export const results = new Hono<Env>()
+
+// Mutation routes here admit guests with role=Official — gated via
+// isOfficialOf inside the handler. Reads layer requireAuth() on top
+// because admin lists do not yet expose to guests.
+results.use('*', requireAuthOrGuest())
+results.use('*', async (c, next) => {
+  if (!c.get('db')) {
+    c.set('db', createDb(c.env.DB) as unknown as Db)
+  }
+  await next()
+})
+
+function getDb(c: { get(key: 'db'): Db }): Db {
+  return c.get('db')
+}
+
+/**
+ * POST /api/meets/:id/saves
+ *
+ * Append a row to the in-progress save history. Both autosaves and
+ * manual checkpoints flow through here; the `kind` discriminator and
+ * optional `label` let admins filter the audit view.
+ *
+ * Body:
+ *   {
+ *     quizFile, kind: 'autosave' | 'checkpoint',
+ *     scheduledQuizId?, roomId?, label?
+ *   }
+ *
+ * Append-only: no UNIQUE constraint, every POST is a new row.
+ * Submission/freeze lives at POST /results, not here.
+ */
+results.post('/:id/saves', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const db = getDb(c)
+  const [meet] = await db
+    .select({ id: schema.quizMeets.id })
+    .from(schema.quizMeets)
+    .where(eq(schema.quizMeets.id, meetId))
+  if (!meet) return c.json({ error: 'Meet not found' }, 404)
+
+  if (!(await isOfficialOf(c, db, meetId))) {
+    return c.json({ error: 'Official access required' }, 403)
+  }
+
+  const body = await c.req.json<{
+    quizFile: unknown
+    kind: 'autosave' | 'checkpoint'
+    scheduledQuizId?: number | null
+    roomId?: number | null
+    label?: string | null
+  }>()
+
+  if (body.kind !== 'autosave' && body.kind !== 'checkpoint') {
+    return c.json({ error: "kind must be 'autosave' or 'checkpoint'" }, 400)
+  }
+  if (!Value.Check(QuizFileSchema, body.quizFile)) {
+    return c.json({ error: 'Invalid QuizFile' }, 400)
+  }
+  const quizFile = body.quizFile as QuizFile
+
+  if (body.scheduledQuizId != null) {
+    const [q] = await db
+      .select({ id: schema.scheduledQuizzes.id })
+      .from(schema.scheduledQuizzes)
+      .where(
+        and(
+          eq(schema.scheduledQuizzes.id, body.scheduledQuizId),
+          eq(schema.scheduledQuizzes.meetId, meetId),
+        ),
+      )
+    if (!q) return c.json({ error: 'Quiz does not belong to this meet' }, 400)
+  }
+  if (body.roomId != null) {
+    const [r] = await db
+      .select({ id: schema.meetRooms.id })
+      .from(schema.meetRooms)
+      .where(and(eq(schema.meetRooms.id, body.roomId), eq(schema.meetRooms.meetId, meetId)))
+    if (!r) return c.json({ error: 'Room does not belong to this meet' }, 400)
+  }
+
+  const user = c.get('user')
+  const guest = c.get('guest')
+
+  const [inserted] = await db
+    .insert(schema.quizSaves)
+    .values({
+      meetId,
+      scheduledQuizId: body.scheduledQuizId ?? null,
+      roomId: body.roomId ?? null,
+      division: quizFile.quiz.division,
+      round: quizFile.quiz.quizNumber,
+      savedAt: new Date(),
+      kind: body.kind,
+      label: body.label?.trim() ? body.label.trim() : null,
+      savedByAccountId: user?.id ?? null,
+      savedByGuestLabel: !user && guest ? (guest.label ?? null) : null,
+      quizFile: JSON.stringify(quizFile),
+    })
+    .returning({ id: schema.quizSaves.id, savedAt: schema.quizSaves.savedAt })
+
+  return c.json({ id: inserted!.id, savedAt: inserted!.savedAt }, 201)
+})

--- a/packages/api/src/routes/results.ts
+++ b/packages/api/src/routes/results.ts
@@ -201,3 +201,92 @@ results.get('/:id/saves/:saveId', async (c) => {
 
   return c.json({ save: { ...row, quizFile: JSON.parse(row.quizFile) as QuizFile } })
 })
+
+/**
+ * POST /api/meets/:id/results
+ *
+ * Mark this room's quiz "done" by freezing the current QuizFile as the
+ * official record. Distinct from /saves — Submit is a status flip, not
+ * a data event. Subsequent /saves rows still flow (audit), but
+ * quiz_results stays frozen at submit-time.
+ *
+ * Body: { quizFile, quizId?, roomId? }
+ *
+ * UNIQUE(meetId, quizId) — SQLite NULL≠NULL lets orphans coexist; a
+ * second submit of the same scheduled quiz returns 409.
+ */
+results.post('/:id/results', async (c) => {
+  const meetId = Number(c.req.param('id'))
+  if (Number.isNaN(meetId)) return c.json({ error: 'Invalid meet ID' }, 400)
+
+  const db = getDb(c)
+  const [meet] = await db
+    .select({ id: schema.quizMeets.id })
+    .from(schema.quizMeets)
+    .where(eq(schema.quizMeets.id, meetId))
+  if (!meet) return c.json({ error: 'Meet not found' }, 404)
+
+  if (!(await isOfficialOf(c, db, meetId))) {
+    return c.json({ error: 'Official access required' }, 403)
+  }
+
+  const body = await c.req.json<{
+    quizFile: unknown
+    quizId?: number | null
+    roomId?: number | null
+  }>()
+
+  if (!Value.Check(QuizFileSchema, body.quizFile)) {
+    return c.json({ error: 'Invalid QuizFile' }, 400)
+  }
+  const quizFile = body.quizFile as QuizFile
+
+  if (body.quizId != null) {
+    const [q] = await db
+      .select({ id: schema.scheduledQuizzes.id })
+      .from(schema.scheduledQuizzes)
+      .where(
+        and(
+          eq(schema.scheduledQuizzes.id, body.quizId),
+          eq(schema.scheduledQuizzes.meetId, meetId),
+        ),
+      )
+    if (!q) return c.json({ error: 'Quiz does not belong to this meet' }, 400)
+  }
+  if (body.roomId != null) {
+    const [r] = await db
+      .select({ id: schema.meetRooms.id })
+      .from(schema.meetRooms)
+      .where(and(eq(schema.meetRooms.id, body.roomId), eq(schema.meetRooms.meetId, meetId)))
+    if (!r) return c.json({ error: 'Room does not belong to this meet' }, 400)
+  }
+
+  const user = c.get('user')
+  const guest = c.get('guest')
+
+  try {
+    const [inserted] = await db
+      .insert(schema.quizResults)
+      .values({
+        meetId,
+        quizId: body.quizId ?? null,
+        roomId: body.roomId ?? null,
+        division: quizFile.quiz.division,
+        round: quizFile.quiz.quizNumber,
+        submittedAt: new Date(),
+        submittedByAccountId: user?.id ?? null,
+        submittedByGuestLabel: !user && guest ? (guest.label ?? null) : null,
+        quizFile: JSON.stringify(quizFile),
+      })
+      .returning({
+        id: schema.quizResults.id,
+        submittedAt: schema.quizResults.submittedAt,
+      })
+    return c.json({ id: inserted!.id, submittedAt: inserted!.submittedAt }, 201)
+  } catch (e) {
+    if (e instanceof Error && /UNIQUE.*quiz_results/.test(e.message)) {
+      return c.json({ error: 'A result already exists for this scheduled quiz' }, 409)
+    }
+    throw e
+  }
+})

--- a/packages/api/src/test-db.ts
+++ b/packages/api/src/test-db.ts
@@ -198,6 +198,47 @@ export async function createTestDb(): Promise<Db> {
       resolved_at INTEGER NOT NULL,
       UNIQUE(meet_id, seed_ref)
     );
+
+    CREATE TABLE quiz_saves (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      meet_id INTEGER NOT NULL REFERENCES quiz_meets(id) ON DELETE CASCADE,
+      scheduled_quiz_id INTEGER REFERENCES scheduled_quizzes(id) ON DELETE SET NULL,
+      room_id INTEGER REFERENCES meet_rooms(id) ON DELETE SET NULL,
+      division TEXT NOT NULL,
+      round TEXT NOT NULL,
+      saved_at INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      label TEXT,
+      saved_by_account_id TEXT REFERENCES user(id) ON DELETE SET NULL,
+      saved_by_guest_label TEXT,
+      quiz_file TEXT NOT NULL
+    );
+
+    CREATE TABLE quiz_results (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      meet_id INTEGER NOT NULL REFERENCES quiz_meets(id) ON DELETE CASCADE,
+      quiz_id INTEGER REFERENCES scheduled_quizzes(id) ON DELETE SET NULL,
+      room_id INTEGER REFERENCES meet_rooms(id) ON DELETE SET NULL,
+      division TEXT NOT NULL,
+      round TEXT NOT NULL,
+      submitted_at INTEGER NOT NULL,
+      submitted_by_account_id TEXT REFERENCES user(id) ON DELETE SET NULL,
+      submitted_by_guest_label TEXT,
+      quiz_file TEXT NOT NULL,
+      UNIQUE(meet_id, quiz_id)
+    );
+
+    CREATE TABLE quiz_disputes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      result_id INTEGER NOT NULL REFERENCES quiz_results(id) ON DELETE CASCADE,
+      created_at INTEGER NOT NULL,
+      created_by_account_id TEXT REFERENCES user(id) ON DELETE SET NULL,
+      created_by_guest_label TEXT,
+      reason TEXT NOT NULL,
+      resolved INTEGER NOT NULL DEFAULT 0,
+      resolved_at INTEGER,
+      resolved_by_account_id TEXT REFERENCES user(id) ON DELETE SET NULL
+    );
   `)
 
   // Seed test users so FK constraints on membership tables are satisfied

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       '@qzr/shared':
         specifier: workspace:*
         version: link:../shared
+      '@sinclair/typebox':
+        specifier: ^0.34.0
+        version: 0.34.49
       better-auth:
         specifier: ^1.2.7
         version: 1.5.6(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.28.15)(sql.js@1.14.1))(vitest@3.2.4(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.28(typescript@5.9.3))


### PR DESCRIPTION
Closes #7. Supersedes #71.

## Model

Three concepts, distinct on purpose:

* **`quiz_saves`** — append-only history of in-progress scoresheet state. Autosaves and manual checkpoints both land here. Admins scrub for audit and recovery; stats never read it.
* **`quiz_results`** — frozen "Submit" snapshot. Distinct from saves — Submit is a status flip, not a data event. UNIQUE on `(meetId, quizId)` so a second submit of the same scheduled quiz returns 409; orphan results (no quizId) coexist freely because SQLite treats NULL as distinct. Stats read from here.
* **`quiz_disputes`** — multi-per-result flag-and-resolve loop.

Submit ≠ Save. After Submit, the server's `/saves` history keeps accepting rows so admins see any post-submit edits — `quiz_results` stays frozen.

## API endpoints (all under `/api/meets/:id`)

* `POST /saves` — autosave or checkpoint. First mutation in the codebase that admits guest officials, gated by the new `isOfficialOf` helper.
* `GET /saves` — admin list (metadata only) with `?scheduledQuizId`, `?division`, `?round` filters.
* `GET /saves/:saveId` — admin detail with the QuizFile parsed.
* `POST /results` — Submit (freeze snapshot). Same auth as `/saves`.
* `GET /results` + `GET /results/:resultId` — admin list (with `openDisputes` count) + detail.
* `POST /results/:resultId/disputes` + `PATCH /disputes/:disputeId` — flag + resolve.

## Scoresheet client

* **`useServerAutoSave`** — watches the reactive QuizFile, debounces 10 s, POSTs to `/saves` as `kind: 'autosave'` when the session has `serverSaveEnabled` and isn't submitted. Same-content dedupe. Exposes `saveCheckpoint(label?)` for the manual button.
* **Opt-in model** — server save auto-enables on scheduled-quiz load; for standalone meet-linked sessions, a "Server autosave" toggle in the New menu turns it on.
* **"☁ Save to server"** under the Save dropdown — labelled checkpoint, posted immediately.
* **"⇪ Submit"** primary button in the file-action bar when meet-linked + clean + complete. Confirms, freezes the snapshot, locks the UI (scoring surface dims, "✓ Submitted" badge replaces the button). 409 handled with a duplicate-specific alert.
* localStorage autosave continues unchanged — durable local copy, server is best-effort.

## Versions

* `@qzr/api` 0.10.0 → 0.11.0 (new tables + endpoints)
* `scoresheet` 0.9.2 → 0.10.0 (server autosave + submit feature)
* `@qzr/shared` unchanged

## Tests

* `pnpm test:unit` — **257 API tests** (38 new for `/saves` + `/results` + disputes auth matrix, payload validation, dedupe, 409, orphan coexistence, dispute lifecycle); **728 scoresheet tests** (13 new for `useServerAutoSave` covering debouncing, opt-in flips, dedupe, checkpoint forcing, scope cleanup; 10 new for `useResultSubmission` covering canSubmit gates, 409, errors; 5 new for the meet-session room/opt-in/submitted fields).
* `pnpm type-check` clean across all packages.
* Manual UI verification not yet done (dev servers can't be started from here per CLAUDE.md). See test plan.

## Test plan

- [ ] Sign in, load a scheduled quiz, edit cells → DB `quiz_saves` shows debounced rows.
- [ ] Click "☁ Save to server" with a label → another row, `kind='checkpoint'`, `label` set.
- [ ] Complete the scoresheet → "⇪ Submit" enables → confirm → success alert → UI locked, "✓ Submitted" badge visible.
- [ ] Continue editing (cells stay disabled) — verify lock holds across reload.
- [ ] DB `quiz_results` shows one frozen row; `quiz_saves` keeps growing post-submit if edits resume (admin route after un-lock).
- [ ] Second submit attempt of the same scheduled quiz → 409 alert.
- [ ] Standalone meet-linked scoresheet: New menu → "Server autosave" toggle → autosaves start; Submit creates an orphan `quiz_results` row.
- [ ] Guest official token: same flows work; rows record `saved_by_guest_label` / `submitted_by_guest_label` instead of account.
- [ ] Guest viewer token: 403 on `/saves` and `/results`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)